### PR TITLE
Add expected version to EventStore interface #10

### DIFF
--- a/packages/emmett/src/eventStore/eventStore.ts
+++ b/packages/emmett/src/eventStore/eventStore.ts
@@ -2,18 +2,26 @@ import type { Event } from '../typing';
 
 // #region event-store
 export interface EventStore {
-  aggregateStream<Entity, E extends Event>(
+  aggregateStream<Entity, E extends Event, NextExpectedVersion = bigint>(
     streamName: string,
     options: {
       evolve: (currentState: Entity, event: E) => Entity;
       getInitialState: () => Entity;
+      startingVersion?: NextExpectedVersion | undefined;
     },
-  ): Promise<Entity | null>;
+  ): Promise<{
+    entity: Entity | null;
+    nextExpectedVersion: NextExpectedVersion;
+  }>;
 
-  readStream<E extends Event>(streamName: string): Promise<E[]>;
+  readStream<E extends Event, NextExpectedVersion = bigint>(
+    streamName: string,
+    startingVersion?: NextExpectedVersion | undefined,
+  ): Promise<E[]>;
 
   appendToStream<E extends Event, NextExpectedVersion = bigint>(
     streamId: string,
+    expectedVersion?: NextExpectedVersion | undefined,
     ...events: E[]
   ): Promise<NextExpectedVersion>;
 }


### PR DESCRIPTION
This PR is merely to discuss issue #10 and I don't feel confident enough in the foundational API shapes to suggest otherwise.

Trying to adapt Emmett to some problems I found myself smuggling expected versions within event metadata rather than the API itself, while also having the next expected version returned through the API.