### PR TITLE
Added Api Specification for integration testing

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -260,7 +260,8 @@ We recommend providing different web app configurations for different endpoints'
 That's what we did in our case. We've set up our Shopping Carts API and injected external dependencies:
 
 - event store to store and retrieve events,
-- The `getUnitPrice` method represents a call to an external service to get the price of a product added to the shopping cart.
+- The `getUnitPrice` method represents a call to an external service to get the price of a product added to the shopping cart,
+- We're also passing the current date generator. Embracing this non-deterministic dependency will be helpful for integration testing later on.
 
 That clearly explains what dependencies this API needs, and by reading the file, you can understand what your application technology needs. That should cut the onboarding time for new people grasping our system setup.
 

--- a/docs/snippets/gettingStarted/businessLogic.unit.spec.ts
+++ b/docs/snippets/gettingStarted/businessLogic.unit.spec.ts
@@ -50,20 +50,18 @@ describe('ShoppingCart', () => {
         },
       })
         .when({
-          type: 'AddProductItemToShoppingCart',
+          type: 'ConfirmShoppingCart',
           data: {
             shoppingCartId,
-            productItem,
           },
           metadata: { now },
         })
         .then([
           {
-            type: 'ProductItemAddedToShoppingCart',
+            type: 'ShoppingCartConfirmed',
             data: {
               shoppingCartId,
-              productItem,
-              addedAt: now,
+              confirmedAt: now,
             },
           },
         ]);

--- a/docs/snippets/gettingStarted/webApi/apiBDD.int.spec.ts
+++ b/docs/snippets/gettingStarted/webApi/apiBDD.int.spec.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import {
   getInMemoryEventStore,
@@ -10,6 +8,7 @@ import {
   existingStream,
   expectError,
   expectNewEvents,
+  expectResponse,
   getApplication,
 } from '@event-driven-io/emmett-expressjs';
 import { beforeEach, describe, it } from 'node:test';
@@ -22,10 +21,13 @@ const getUnitPrice = (_productId: string) => {
 };
 
 describe('ShoppingCart', () => {
+  let clientId: string;
+  let shoppingCartId: string;
   beforeEach(() => {
     clientId = uuid();
     shoppingCartId = `shopping_cart:${clientId}:current`;
   });
+
   describe('When empty', () => {
     it('should add product item', () => {
       return given()
@@ -67,6 +69,7 @@ describe('ShoppingCart', () => {
           request.post(`/clients/${clientId}/shopping-carts/current/confirm`),
         )
         .then([
+          expectResponse(204),
           expectNewEvents(shoppingCartId, [
             {
               type: 'ShoppingCartConfirmed',
@@ -114,20 +117,7 @@ describe('ShoppingCart', () => {
     });
   });
 
-  let clientId: string;
-  let shoppingCartId: string;
-
-  const getRandomProduct = (): PricedProductItem => {
-    return {
-      productId: uuid(),
-      unitPrice: 100,
-      quantity: Math.random() * 10,
-    };
-  };
   const oldTime = new Date();
-
-  const productItem = getRandomProduct();
-
   const now = new Date();
 
   const given = ApiSpecification.for<ShoppingCartEvent>(
@@ -137,4 +127,14 @@ describe('ShoppingCart', () => {
         apis: [shoppingCartApi(eventStore, getUnitPrice, () => now)],
       }),
   );
+
+  const getRandomProduct = (): PricedProductItem => {
+    return {
+      productId: uuid(),
+      unitPrice: 100,
+      quantity: Math.random() * 10,
+    };
+  };
+
+  const productItem = getRandomProduct();
 });

--- a/docs/snippets/gettingStarted/webApi/apiBDD.int.spec.ts
+++ b/docs/snippets/gettingStarted/webApi/apiBDD.int.spec.ts
@@ -7,7 +7,7 @@ import {
   ApiSpecification,
   getApplication,
 } from '@event-driven-io/emmett-expressjs';
-import { describe, it } from 'node:test';
+import { beforeEach, describe, it } from 'node:test';
 import { v4 as uuid } from 'uuid';
 import type { PricedProductItem, ShoppingCartEvent } from '../events';
 import { shoppingCartApi } from './simpleApi';
@@ -16,26 +16,24 @@ const getUnitPrice = (_productId: string) => {
   return Promise.resolve(100);
 };
 
-const given = ApiSpecification.for<ShoppingCartEvent>(
-  () => getInMemoryEventStore(),
-  (eventStore: EventStore) =>
-    getApplication({ apis: [shoppingCartApi(eventStore, getUnitPrice)] }),
-);
-
 describe('ShoppingCart', () => {
+  beforeEach(() => {
+    clientId = uuid();
+    shoppingCartId = `shopping_cart:${clientId}:current`;
+  });
   describe('When empty', () => {
     it('should add product item', () => {
-      const clientId = uuid();
       return given([])
         .when((request) =>
           request
             .post(`/clients/${clientId}/shopping-carts/current/product-items`)
-            .send(productItem),
+            .send(productItem)
+            .expect(204),
         )
         .then([
-          {
-            streamName: shoppingCartId,
-            events: [
+          [
+            shoppingCartId,
+            [
               {
                 type: 'ProductItemAddedToShoppingCart',
                 data: {
@@ -45,82 +43,103 @@ describe('ShoppingCart', () => {
                 },
               },
             ],
-          },
+          ],
         ]);
     });
   });
 
-  // describe('When opened', () => {
-  //   it('should confirm', () => {
-  //     given({
-  //       type: 'ProductItemAddedToShoppingCart',
-  //       data: {
-  //         shoppingCartId,
-  //         productItem,
-  //         addedAt: oldTime,
-  //       },
-  //     })
-  //       .when({
-  //         type: 'AddProductItemToShoppingCart',
-  //         data: {
-  //           shoppingCartId,
-  //           productItem,
-  //         },
-  //         metadata: { now },
-  //       })
-  //       .then([
-  //         {
-  //           type: 'ProductItemAddedToShoppingCart',
-  //           data: {
-  //             shoppingCartId,
-  //             productItem,
-  //             addedAt: now,
-  //           },
-  //         },
-  //       ]);
-  //   });
-  // });
+  describe('When opened', () => {
+    it('should confirm', () => {
+      return given([
+        [
+          shoppingCartId,
+          [
+            {
+              type: 'ProductItemAddedToShoppingCart',
+              data: {
+                shoppingCartId,
+                productItem,
+                addedAt: oldTime,
+              },
+            },
+          ],
+        ],
+      ])
+        .when((request) =>
+          request
+            .post(`/clients/${clientId}/shopping-carts/current/confirm`)
+            .send(productItem)
+            .expect(204),
+        )
+        .then([
+          [
+            shoppingCartId,
+            [
+              {
+                type: 'ShoppingCartConfirmed',
+                data: {
+                  shoppingCartId,
+                  confirmedAt: now,
+                },
+              },
+            ],
+          ],
+        ]);
+    });
+  });
 
-  // describe('When confirmed', () => {
-  //   it('should not add products', () => {
-  //     given([
-  //       {
-  //         type: 'ProductItemAddedToShoppingCart',
-  //         data: {
-  //           shoppingCartId,
-  //           productItem,
-  //           addedAt: oldTime,
-  //         },
-  //       },
-  //       {
-  //         type: 'ShoppingCartConfirmed',
-  //         data: { shoppingCartId, confirmedAt: oldTime },
-  //       },
-  //     ])
-  //       .when({
-  //         type: 'AddProductItemToShoppingCart',
-  //         data: {
-  //           shoppingCartId,
-  //           productItem,
-  //         },
-  //         metadata: { now },
-  //       })
-  //       .thenThrows(
-  //         (error: Error) => error.message === 'Shopping Cart already closed',
-  //       );
-  //   });
-  // });
+  describe('When confirmed', () => {
+    it('should not add products', () => {
+      return given([
+        [
+          shoppingCartId,
+          [
+            {
+              type: 'ProductItemAddedToShoppingCart',
+              data: {
+                shoppingCartId,
+                productItem,
+                addedAt: oldTime,
+              },
+            },
+            {
+              type: 'ShoppingCartConfirmed',
+              data: { shoppingCartId, confirmedAt: oldTime },
+            },
+          ],
+        ],
+      ])
+        .when((request) =>
+          request
+            .post(`/clients/${clientId}/shopping-carts/current/product-items`)
+            .send(productItem)
+            .expect(403),
+        )
+        .then([]);
+    });
+  });
+
+  let clientId: string;
+  let shoppingCartId: string;
 
   const getRandomProduct = (): PricedProductItem => {
     return {
       productId: uuid(),
-      unitPrice: Math.random() * 10,
+      unitPrice: 100,
       quantity: Math.random() * 10,
     };
   };
   const oldTime = new Date();
-  const now = new Date();
-  const shoppingCartId = uuid();
 
   const productItem = getRandomProduct();
+
+  const now = new Date();
+
+  const given = ApiSpecification.for<ShoppingCartEvent>(
+    (): EventStore => getInMemoryEventStore(),
+    (eventStore: EventStore) =>
+      getApplication({
+        apis: [shoppingCartApi(eventStore, getUnitPrice, () => now)],
+      }),
+  );
 });

--- a/docs/snippets/gettingStarted/webApi/apiBDD.int.spec.ts
+++ b/docs/snippets/gettingStarted/webApi/apiBDD.int.spec.ts
@@ -1,0 +1,126 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import {
+  getInMemoryEventStore,
+  type EventStore,
+} from '@event-driven-io/emmett';
+import {
+  ApiSpecification,
+  getApplication,
+} from '@event-driven-io/emmett-expressjs';
+import { describe, it } from 'node:test';
+import { v4 as uuid } from 'uuid';
+import type { PricedProductItem, ShoppingCartEvent } from '../events';
+import { shoppingCartApi } from './simpleApi';
+
+const getUnitPrice = (_productId: string) => {
+  return Promise.resolve(100);
+};
+
+const given = ApiSpecification.for<ShoppingCartEvent>(
+  () => getInMemoryEventStore(),
+  (eventStore: EventStore) =>
+    getApplication({ apis: [shoppingCartApi(eventStore, getUnitPrice)] }),
+);
+
+describe('ShoppingCart', () => {
+  describe('When empty', () => {
+    it('should add product item', () => {
+      const clientId = uuid();
+      return given([])
+        .when((request) =>
+          request
+            .post(`/clients/${clientId}/shopping-carts/current/product-items`)
+            .send(productItem),
+        )
+        .then([
+          {
+            streamName: shoppingCartId,
+            events: [
+              {
+                type: 'ProductItemAddedToShoppingCart',
+                data: {
+                  shoppingCartId,
+                  productItem,
+                  addedAt: now,
+                },
+              },
+            ],
+          },
+        ]);
+    });
+  });
+
+  // describe('When opened', () => {
+  //   it('should confirm', () => {
+  //     given({
+  //       type: 'ProductItemAddedToShoppingCart',
+  //       data: {
+  //         shoppingCartId,
+  //         productItem,
+  //         addedAt: oldTime,
+  //       },
+  //     })
+  //       .when({
+  //         type: 'AddProductItemToShoppingCart',
+  //         data: {
+  //           shoppingCartId,
+  //           productItem,
+  //         },
+  //         metadata: { now },
+  //       })
+  //       .then([
+  //         {
+  //           type: 'ProductItemAddedToShoppingCart',
+  //           data: {
+  //             shoppingCartId,
+  //             productItem,
+  //             addedAt: now,
+  //           },
+  //         },
+  //       ]);
+  //   });
+  // });
+
+  // describe('When confirmed', () => {
+  //   it('should not add products', () => {
+  //     given([
+  //       {
+  //         type: 'ProductItemAddedToShoppingCart',
+  //         data: {
+  //           shoppingCartId,
+  //           productItem,
+  //           addedAt: oldTime,
+  //         },
+  //       },
+  //       {
+  //         type: 'ShoppingCartConfirmed',
+  //         data: { shoppingCartId, confirmedAt: oldTime },
+  //       },
+  //     ])
+  //       .when({
+  //         type: 'AddProductItemToShoppingCart',
+  //         data: {
+  //           shoppingCartId,
+  //           productItem,
+  //         },
+  //         metadata: { now },
+  //       })
+  //       .thenThrows(
+  //         (error: Error) => error.message === 'Shopping Cart already closed',
+  //       );
+  //   });
+  // });
+
+  const getRandomProduct = (): PricedProductItem => {
+    return {
+      productId: uuid(),
+      unitPrice: Math.random() * 10,
+      quantity: Math.random() * 10,
+    };
+  };
+  const oldTime = new Date();
+  const now = new Date();
+  const shoppingCartId = uuid();
+
+  const productItem = getRandomProduct();
+});

--- a/docs/snippets/gettingStarted/webApi/apiBDD.int.spec.ts
+++ b/docs/snippets/gettingStarted/webApi/apiBDD.int.spec.ts
@@ -8,6 +8,7 @@ import {
 import {
   ApiSpecification,
   existingStream,
+  expectError,
   expectNewEvents,
   getApplication,
 } from '@event-driven-io/emmett-expressjs';
@@ -31,8 +32,7 @@ describe('ShoppingCart', () => {
         .when((request) =>
           request
             .post(`/clients/${clientId}/shopping-carts/current/product-items`)
-            .send(productItem)
-            .expect(204),
+            .send(productItem),
         )
         .then([
           expectNewEvents(shoppingCartId, [
@@ -64,9 +64,7 @@ describe('ShoppingCart', () => {
         ]),
       )
         .when((request) =>
-          request
-            .post(`/clients/${clientId}/shopping-carts/current/confirm`)
-            .expect(204),
+          request.post(`/clients/${clientId}/shopping-carts/current/confirm`),
         )
         .then([
           expectNewEvents(shoppingCartId, [
@@ -103,10 +101,16 @@ describe('ShoppingCart', () => {
         .when((request) =>
           request
             .post(`/clients/${clientId}/shopping-carts/current/product-items`)
-            .send(productItem)
-            .expect(403),
+            .send(productItem),
         )
-        .then([]);
+        .then(
+          expectError(403, {
+            detail: 'Shopping Cart already closed',
+            status: 403,
+            title: 'Forbidden',
+            type: 'about:blank',
+          }),
+        );
     });
   });
 

--- a/docs/snippets/gettingStarted/webApi/apiSetup.ts
+++ b/docs/snippets/gettingStarted/webApi/apiSetup.ts
@@ -11,5 +11,9 @@ import { getInMemoryEventStore } from '@event-driven-io/emmett';
 
 const eventStore = getInMemoryEventStore();
 
-const shoppingCarts = shoppingCartApi(eventStore, getUnitPrice);
+const shoppingCarts = shoppingCartApi(
+  eventStore,
+  getUnitPrice,
+  () => new Date(),
+);
 // #endregion getting-started-api-setup

--- a/docs/snippets/gettingStarted/webApi/simpleApi.int.spec.ts
+++ b/docs/snippets/gettingStarted/webApi/simpleApi.int.spec.ts
@@ -24,7 +24,9 @@ describe('Simple Api from getting started', () => {
 
   beforeEach(() => {
     eventStore = getInMemoryEventStore();
-    app = getApplication({ apis: [shoppingCartApi(eventStore, getUnitPrice)] });
+    app = getApplication({
+      apis: [shoppingCartApi(eventStore, getUnitPrice, () => new Date())],
+    });
   });
 
   it('Should handle requests correctly', async () => {

--- a/docs/snippets/gettingStarted/webApi/simpleApi.ts
+++ b/docs/snippets/gettingStarted/webApi/simpleApi.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import {
   assertNotEmptyString,
   assertPositiveNumber,
@@ -33,6 +36,7 @@ export const shoppingCartApi =
   (
     eventStore: EventStore,
     getUnitPrice: (_productId: string) => Promise<number>,
+    getCurrentTime: () => Date,
   ): WebApiSetup =>
   (router: Router) => {
     // #region complete-api
@@ -55,6 +59,7 @@ export const shoppingCartApi =
               unitPrice: await getUnitPrice(productId),
             },
           },
+          metadata: { now: getCurrentTime() },
         };
 
         await handle(eventStore, shoppingCartId, (state) =>
@@ -83,6 +88,7 @@ export const shoppingCartApi =
               unitPrice: assertPositiveNumber(Number(request.query.unitPrice)),
             },
           },
+          metadata: { now: getCurrentTime() },
         };
 
         await handle(eventStore, shoppingCartId, (state) =>
@@ -104,6 +110,7 @@ export const shoppingCartApi =
         const command: ConfirmShoppingCart = {
           type: 'ConfirmShoppingCart',
           data: { shoppingCartId },
+          metadata: { now: getCurrentTime() },
         };
 
         await handle(eventStore, shoppingCartId, (state) =>
@@ -125,6 +132,7 @@ export const shoppingCartApi =
         const command: CancelShoppingCart = {
           type: 'CancelShoppingCart',
           data: { shoppingCartId },
+          metadata: { now: getCurrentTime() },
         };
 
         await handle(eventStore, shoppingCartId, (state) =>

--- a/docs/snippets/gettingStarted/webApi/simpleApi.ts
+++ b/docs/snippets/gettingStarted/webApi/simpleApi.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-return */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import {
   assertNotEmptyString,
   assertPositiveNumber,

--- a/docs/snippets/gettingStarted/webApi/start.ts
+++ b/docs/snippets/gettingStarted/webApi/start.ts
@@ -13,7 +13,11 @@ import type { Server } from 'http';
 
 const eventStore = getInMemoryEventStore();
 
-const shoppingCarts = shoppingCartApi(eventStore, getUnitPrice);
+const shoppingCarts = shoppingCartApi(
+  eventStore,
+  getUnitPrice,
+  () => new Date(),
+);
 
 const application: Application = getApplication({
   apis: [shoppingCarts],

--- a/packages/emmett-expressjs/src/index.ts
+++ b/packages/emmett-expressjs/src/index.ts
@@ -12,6 +12,7 @@ import { problemDetailsMiddleware } from './middlewares/problemDetailsMiddleware
 
 export * from './etag';
 export * from './handler';
+export * from './testing';
 
 export type ErrorToProblemDetailsMapping = (
   error: Error,

--- a/packages/emmett-expressjs/src/testing/apiSpecification.ts
+++ b/packages/emmett-expressjs/src/testing/apiSpecification.ts
@@ -21,8 +21,22 @@ export type TestEventStream<EventType extends Event = Event> = [
   EventType[],
 ];
 
+export const existingStream = <EventType extends Event = Event>(
+  streamId: string,
+  events: EventType[],
+): TestEventStream<EventType> => {
+  return [streamId, events];
+};
+
+export const expectNewEvents = <EventType extends Event = Event>(
+  streamId: string,
+  events: EventType[],
+): TestEventStream<EventType> => {
+  return [streamId, events];
+};
+
 export type ApiSpecification<EventType extends Event = Event> = (
-  givenStreams: TestEventStream<EventType>[],
+  ...givenStreams: TestEventStream<EventType>[]
 ) => {
   when: (setupRequest: (request: TestAgent<supertest.Test>) => Test) => {
     then: (verify: ApiSpecificationAssert<EventType>) => Promise<void>;
@@ -46,7 +60,7 @@ export const ApiSpecification = {
     getApplication: (eventStore: EventStore<StreamVersion>) => Application,
   ): ApiSpecification<EventType> => {
     {
-      return (givenStreams: TestEventStream<EventType>[]) => {
+      return (...givenStreams: TestEventStream<EventType>[]) => {
         const eventStore = WrapEventStore(getEventStore());
         const application = getApplication(eventStore);
 

--- a/packages/emmett-expressjs/src/testing/apiSpecification.ts
+++ b/packages/emmett-expressjs/src/testing/apiSpecification.ts
@@ -1,14 +1,25 @@
-import type { Event, EventStore, Flavour } from '@event-driven-io/emmett';
+import {
+  assertMatches,
+  type AggregateStreamOptions,
+  type AggregateStreamResult,
+  type AppendToStreamOptions,
+  type AppendToStreamResult,
+  type DefaultStreamVersionType,
+  type Event,
+  type EventStore,
+  type ReadStreamOptions,
+  type ReadStreamResult,
+} from '@event-driven-io/emmett';
 import { type Application } from 'express';
 import assert from 'node:assert/strict';
 import type { Response, Test } from 'supertest';
 import supertest from 'supertest';
 import type TestAgent from 'supertest/lib/agent';
 
-export type TestEventStream<EventType extends Event = Event> = {
-  streamName: string;
-  events: EventType[];
-};
+export type TestEventStream<EventType extends Event = Event> = [
+  string,
+  EventType[],
+];
 
 export type ApiSpecification<EventType extends Event = Event> = (
   givenStreams: TestEventStream<EventType>[],
@@ -19,33 +30,33 @@ export type ApiSpecification<EventType extends Event = Event> = (
 };
 
 export type ApiSpecificationAssert<EventType extends Event = Event> =
-  | Flavour<TestEventStream<EventType>[], 'appendedEvents'>
-  | Flavour<(response: Response) => boolean, 'responseAssert'>
-  | Flavour<
-      {
-        events: TestEventStream<EventType>[];
-        responseMatches: (response: Response) => boolean;
-      },
-      'fullAssert'
-    >;
+  | TestEventStream<EventType>[]
+  | ((response: Response) => boolean)
+  | {
+      events: TestEventStream<EventType>[];
+      responseMatches: (response: Response) => boolean;
+    };
 
 export const ApiSpecification = {
-  for: <EventType extends Event = Event>(
-    getEventStore: () => EventStore,
-    getApplication: (eventStore: EventStore) => Application,
+  for: <
+    EventType extends Event = Event,
+    StreamVersion = DefaultStreamVersionType,
+  >(
+    getEventStore: () => EventStore<StreamVersion>,
+    getApplication: (eventStore: EventStore<StreamVersion>) => Application,
   ): ApiSpecification<EventType> => {
     {
       return (givenStreams: TestEventStream<EventType>[]) => {
+        const eventStore = WrapEventStore(getEventStore());
+        const application = getApplication(eventStore);
+
         return {
           when: (
             setupRequest: (request: TestAgent<supertest.Test>) => Test,
           ) => {
             const handle = async () => {
-              const eventStore = getEventStore();
-              const application = getApplication(eventStore);
-
-              for (const { streamName, events } of givenStreams) {
-                await eventStore.appendToStream(streamName, events);
+              for (const [streamName, events] of givenStreams) {
+                await eventStore.setup(streamName, events);
               }
 
               return setupRequest(supertest(application));
@@ -57,10 +68,20 @@ export const ApiSpecification = {
               ): Promise<void> => {
                 const response = await handle();
 
-                if (verify.__brand === 'responseAssert') {
+                if (typeof verify === 'function') {
                   assert.ok(verify(response));
-                } else if (verify.__brand === 'fullAssert') {
+                } else if (Array.isArray(verify)) {
+                  assertMatches(
+                    Array.from(eventStore.appendedEvents.values()),
+                    verify,
+                  );
+                } else {
                   assert.ok(verify.responseMatches(response));
+                  assertMatches(
+                    Array.from(eventStore.appendedEvents.values()),
+                    givenStreams,
+                  );
+                  return;
                 }
               },
             };
@@ -69,4 +90,62 @@ export const ApiSpecification = {
       };
     }
   },
+};
+
+const WrapEventStore = <StreamVersion = DefaultStreamVersionType>(
+  eventStore: EventStore<StreamVersion>,
+): EventStore<StreamVersion> & {
+  appendedEvents: Map<string, TestEventStream>;
+  setup<EventType extends Event>(
+    streamName: string,
+    events: EventType[],
+  ): Promise<AppendToStreamResult<StreamVersion>>;
+} => {
+  const appendedEvents = new Map<string, TestEventStream>();
+
+  return {
+    async aggregateStream<State, EventType extends Event>(
+      streamName: string,
+      options: AggregateStreamOptions<State, EventType, StreamVersion>,
+    ): Promise<AggregateStreamResult<State, StreamVersion> | null> {
+      return eventStore.aggregateStream(streamName, options);
+    },
+
+    readStream<EventType extends Event>(
+      streamName: string,
+      options?: ReadStreamOptions<StreamVersion>,
+    ): Promise<ReadStreamResult<EventType, StreamVersion>> {
+      return eventStore.readStream(streamName, options);
+    },
+
+    appendToStream: async <EventType extends Event>(
+      streamName: string,
+      events: EventType[],
+      options?: AppendToStreamOptions<StreamVersion>,
+    ): Promise<AppendToStreamResult<StreamVersion>> => {
+      const result = await eventStore.appendToStream(
+        streamName,
+        events,
+        options,
+      );
+
+      const currentStream = appendedEvents.get(streamName) ?? [streamName, []];
+
+      appendedEvents.set(streamName, [
+        streamName,
+        [...currentStream[1], ...events],
+      ]);
+
+      return result;
+    },
+
+    appendedEvents,
+
+    setup: async <EventType extends Event>(
+      streamName: string,
+      events: EventType[],
+    ): Promise<AppendToStreamResult<StreamVersion>> => {
+      return eventStore.appendToStream(streamName, events);
+    },
+  };
 };

--- a/packages/emmett-expressjs/src/testing/apiSpecification.ts
+++ b/packages/emmett-expressjs/src/testing/apiSpecification.ts
@@ -1,0 +1,72 @@
+import type { Event, EventStore, Flavour } from '@event-driven-io/emmett';
+import { type Application } from 'express';
+import assert from 'node:assert/strict';
+import type { Response, Test } from 'supertest';
+import supertest from 'supertest';
+import type TestAgent from 'supertest/lib/agent';
+
+export type TestEventStream<EventType extends Event = Event> = {
+  streamName: string;
+  events: EventType[];
+};
+
+export type ApiSpecification<EventType extends Event = Event> = (
+  givenStreams: TestEventStream<EventType>[],
+) => {
+  when: (setupRequest: (request: TestAgent<supertest.Test>) => Test) => {
+    then: (verify: ApiSpecificationAssert<EventType>) => Promise<void>;
+  };
+};
+
+export type ApiSpecificationAssert<EventType extends Event = Event> =
+  | Flavour<TestEventStream<EventType>[], 'appendedEvents'>
+  | Flavour<(response: Response) => boolean, 'responseAssert'>
+  | Flavour<
+      {
+        events: TestEventStream<EventType>[];
+        responseMatches: (response: Response) => boolean;
+      },
+      'fullAssert'
+    >;
+
+export const ApiSpecification = {
+  for: <EventType extends Event = Event>(
+    getEventStore: () => EventStore,
+    getApplication: (eventStore: EventStore) => Application,
+  ): ApiSpecification<EventType> => {
+    {
+      return (givenStreams: TestEventStream<EventType>[]) => {
+        return {
+          when: (
+            setupRequest: (request: TestAgent<supertest.Test>) => Test,
+          ) => {
+            const handle = async () => {
+              const eventStore = getEventStore();
+              const application = getApplication(eventStore);
+
+              for (const { streamName, events } of givenStreams) {
+                await eventStore.appendToStream(streamName, events);
+              }
+
+              return setupRequest(supertest(application));
+            };
+
+            return {
+              then: async (
+                verify: ApiSpecificationAssert<EventType>,
+              ): Promise<void> => {
+                const response = await handle();
+
+                if (verify.__brand === 'responseAssert') {
+                  assert.ok(verify(response));
+                } else if (verify.__brand === 'fullAssert') {
+                  assert.ok(verify.responseMatches(response));
+                }
+              },
+            };
+          },
+        };
+      };
+    }
+  },
+};

--- a/packages/emmett-expressjs/src/testing/index.ts
+++ b/packages/emmett-expressjs/src/testing/index.ts
@@ -1,0 +1,1 @@
+export * from './apiSpecification';

--- a/packages/emmett/src/eventStore/eventStore.ts
+++ b/packages/emmett/src/eventStore/eventStore.ts
@@ -14,7 +14,7 @@ export interface EventStore<StreamVersion = DefaultStreamVersionType> {
   ): Promise<ReadStreamResult<EventType, StreamVersion>>;
 
   appendToStream<EventType extends Event>(
-    streamId: string,
+    streamName: string,
     events: EventType[],
     options?: AppendToStreamOptions<StreamVersion>,
   ): Promise<AppendToStreamResult<StreamVersion>>;

--- a/packages/emmett/src/testing/assertions.ts
+++ b/packages/emmett/src/testing/assertions.ts
@@ -13,9 +13,9 @@ export const isSubset = (superObj: unknown, subObj: unknown): boolean => {
   });
 };
 
-export const assertMatches = (superObj: unknown, subObj: unknown) => {
-  if (!isSubset(superObj, subObj))
+export const assertMatches = (actual: unknown, expected: unknown) => {
+  if (!isSubset(actual, expected))
     throw Error(
-      `subObj:\n${JSON.stringify(subObj)}\nis not subset of\n${JSON.stringify(superObj)}`,
+      `subObj:\n${JSON.stringify(expected)}\nis not subset of\n${JSON.stringify(actual)}`,
     );
 };


### PR DESCRIPTION
In Emmett, you get lightweight abstractions like event store, command handlers, etc. Event Sourcing gives repeatable patterns for handling business logic:
1. Read events and build the state.
2. Take that state and a command and run business logic.
3. Store new event(s) as a result.

That's super easy to test, especially in the BDD style:
1. Given a set of events.
2. When the command is run.
3. Check the result events.

Now, I had a thought: why not apply the same for API tests? Such tests could even be written in the Hexagonal Architecture style by replacing the external dependencies with some in-memory implementation or just going fully end-to-end. 

The benefit of that is that you can test the whole pipeline (middleware, auth, etc.), even Open Telemetry traces (like [Martin Thwaites showed in his talks](https://www.youtube.com/watch?v=prLRI3VEVq4)).

This PR introduces the first version of such tests.