### PR TITLE
feat(docs,emmet-expressjs): add e2e api specification

### DIFF
--- a/docs/snippets/gettingStarted/webApi/apiBDD.e2e.spec.ts
+++ b/docs/snippets/gettingStarted/webApi/apiBDD.e2e.spec.ts
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import {
+  getInMemoryEventStore,
+  type EventStore,
+} from '@event-driven-io/emmett';
+import {
+  ApiE2ESpecification,
+  expectResponse,
+  getApplication,
+} from '@event-driven-io/emmett-expressjs';
+import { randomUUID } from 'node:crypto';
+import { beforeEach, describe, it } from 'node:test';
+import type { PricedProductItem } from '../events';
+import { ShoppingCartStatus } from './shoppingCart';
+import { shoppingCartApi } from './simpleApi';
+
+const getUnitPrice = () => {
+  return Promise.resolve(100);
+};
+
+describe('ShoppingCart E2E', () => {
+  let clientId: string;
+  let shoppingCartId: string;
+
+  beforeEach(() => {
+    clientId = randomUUID();
+    shoppingCartId = `shopping_cart:${clientId}:current`;
+  });
+
+  describe('When empty', () => {
+    it('should add product item', () => {
+      return given((request) =>
+        request
+          .post(`/clients/${clientId}/shopping-carts/current/product-items`)
+          .send(productItem),
+      )
+        .when((request) =>
+          request.get(`/clients/${clientId}/shopping-carts/current`).send(),
+        )
+        .then([
+          expectResponse(200, {
+            body: {
+              clientId,
+              id: shoppingCartId,
+              productItems: [
+                {
+                  quantity: productItem.quantity,
+                  productId: productItem.productId,
+                },
+              ],
+              status: ShoppingCartStatus.Opened,
+            },
+          }),
+        ]);
+    });
+  });
+
+  const now = new Date();
+
+  const given = ApiE2ESpecification.for(
+    (): EventStore => getInMemoryEventStore(),
+    (eventStore: EventStore) =>
+      getApplication({
+        apis: [shoppingCartApi(eventStore, getUnitPrice, () => now)],
+      }),
+  );
+
+  const getRandomProduct = (): PricedProductItem => {
+    return {
+      productId: randomUUID(),
+      unitPrice: 100,
+      quantity: Math.random() * 10,
+    };
+  };
+
+  const productItem = getRandomProduct();
+});

--- a/docs/snippets/gettingStarted/webApi/shoppingCart.ts
+++ b/docs/snippets/gettingStarted/webApi/shoppingCart.ts
@@ -52,6 +52,7 @@ export enum ShoppingCartStatus {
   Pending = 'Pending',
   Confirmed = 'Confirmed',
   Canceled = 'Canceled',
+  Opened = 'Opened',
 }
 
 export type Empty = { status: ShoppingCartStatus.Empty };

--- a/docs/snippets/gettingStarted/webApi/simpleApi.ts
+++ b/docs/snippets/gettingStarted/webApi/simpleApi.ts
@@ -6,6 +6,7 @@ import {
 } from '@event-driven-io/emmett';
 import {
   NoContent,
+  OK,
   on,
   type WebApiSetup,
 } from '@event-driven-io/emmett-expressjs';
@@ -22,7 +23,8 @@ import type {
   ConfirmShoppingCart,
   RemoveProductItemFromShoppingCart,
 } from '../commands';
-import { evolve, getInitialState } from '../shoppingCart';
+import type { ProductItem, ShoppingCartEvent } from '../events';
+import { evolve, getInitialState, type ShoppingCart } from '../shoppingCart';
 
 export const handle = CommandHandler(evolve, getInitialState);
 
@@ -139,6 +141,40 @@ export const shoppingCartApi =
         return NoContent();
       }),
     );
+
+    // Get Shopping Cart
+    router.get(
+      '/clients/:clientId/shopping-carts/current',
+      on(async (request: GetShoppingCartRequest) => {
+        const shoppingCartId = getShoppingCartId(
+          assertNotEmptyString(request.params.clientId),
+        );
+
+        const result = await eventStore.aggregateStream<
+          ShoppingCart,
+          ShoppingCartEvent
+        >(shoppingCartId, {
+          evolve,
+          getInitialState,
+        });
+
+        const productItems: ProductItem[] = Array.from(
+          result.state.productItems,
+        ).map(([productId, quantity]) => ({
+          productId,
+          quantity,
+        }));
+
+        return OK({
+          body: {
+            clientId: assertNotEmptyString(request.params.clientId),
+            id: shoppingCartId,
+            productItems,
+            status: result?.state.status,
+          },
+        });
+      }),
+    );
     // #endregion complete-api
   };
 
@@ -147,4 +183,10 @@ type AddProductItemRequest = Request<
   Partial<{ clientId: string; shoppingCartId: string }>,
   unknown,
   Partial<{ productId: number; quantity: number }>
+>;
+
+type GetShoppingCartRequest = Request<
+  Partial<{ clientId: string }>,
+  unknown,
+  unknown
 >;

--- a/packages/emmett-expressjs/src/e2e/decider/applicationLogicWithOC.int.spec.ts
+++ b/packages/emmett-expressjs/src/e2e/decider/applicationLogicWithOC.int.spec.ts
@@ -44,7 +44,6 @@ describe('Application logic with optimistic concurrency', () => {
 
     if (!current.id) {
       assert.fail();
-      return;
     }
     assert.ok(current.id);
 


### PR DESCRIPTION
Closes #26

Hey @oskardudycz , I haven't added the ES db yet because I'm unsure how to replace the `inMemoryStore()`. However, I believe this draft may suffice as an initial discussion for that issue. It took me some time to figure out how everything worked and glued together, but I feel I'm understanding the architecture better now 😅

One thing I'd like to ask / discuss is the [no-unsafe-assignement](https://typescript-eslint.io/rules/no-unsafe-assignment/) rule that we're using here and it's complaining all over the place - is this intended? Honestly, in many cases it doesn't make sense, look at this example:

![image](https://github.com/event-driven-io/emmett/assets/51245643/9f917c3e-72dc-4be1-99a0-b95c7049eeb5)

The `getInMemoryEventStore()` function has a defined return value, yet this rule is complaining 🤔 

Anyway, let me know what you think about this initial implementation!