### PR TITLE
Made conventional error matching in `problemDetailsMiddleware`  to be based on `errorCode` property

### DIFF
--- a/packages/emmett-expressjs/src/middlewares/problemDetailsMiddleware.ts
+++ b/packages/emmett-expressjs/src/middlewares/problemDetailsMiddleware.ts
@@ -1,4 +1,4 @@
-import { EmmettError } from '@event-driven-io/emmett';
+import { isNumber } from '@event-driven-io/emmett';
 import type { NextFunction, Request, Response } from 'express';
 import { ProblemDocument } from 'http-problem-details';
 import { sendProblem, type ErrorToProblemDetailsMapping } from '..';
@@ -26,7 +26,12 @@ export const defaulErrorToProblemDetailsMapping = (
 ): ProblemDocument => {
   let statusCode = 500;
 
-  if (error instanceof EmmettError) {
+  if (
+    'errorCode' in error &&
+    isNumber(error.errorCode) &&
+    error.errorCode >= 100 &&
+    error.errorCode < 600
+  ) {
     statusCode = error.errorCode;
   }
 


### PR DESCRIPTION
TypeScript class comparison with an `instance of` can misbehave depending on the TS settings (see more [here](https://stackoverflow.com/a/41102306)). 

To remove that risk and make generic handling easier, the matching in `problemDetailsMiddleware` was updated to use regular structural matching on the `errorCode` property.