### PR TITLE
Feat/create testing abstraction

### DIFF
--- a/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.e2e.spec.ts
+++ b/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.e2e.spec.ts
@@ -1,94 +1,29 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import {
-  evolve,
-  getInitialState,
-  type EventStore,
-  type PricedProductItem,
-  type ShoppingCartEvent,
+  testAggregateStream,
+  type EventStoreFactory,
 } from '@event-driven-io/emmett';
 import {
   EventStoreDBContainer,
   StartedEventStoreDBContainer,
 } from '@event-driven-io/emmett-testcontainers';
-import assert from 'node:assert';
-import { randomUUID } from 'node:crypto';
-import { after, before, describe, it } from 'node:test';
+import { describe } from 'node:test';
 import { getEventStoreDBEventStore } from './eventstoreDBEventStore';
 
-describe('EventStoreDBEventStore', () => {
+describe('EventStoreDBEventStore', async () => {
   let esdbContainer: StartedEventStoreDBContainer;
-  let eventStore: EventStore;
 
-  before(async () => {
+  const eventStoreFactory: EventStoreFactory = async () => {
     esdbContainer = await new EventStoreDBContainer().start();
-    eventStore = getEventStoreDBEventStore(esdbContainer.getClient());
-  });
+    return getEventStoreDBEventStore(esdbContainer.getClient());
+  };
 
-  after(() => {
-    return esdbContainer.stop();
-  });
+  const teardownHook = async () => {
+    await esdbContainer.stop();
+  };
 
-  describe('aggregateStream', () => {
-    it('When called with `to` allows time traveling', async () => {
-      // Given
-      const productItem: PricedProductItem = {
-        productId: '123',
-        quantity: 10,
-        price: 3,
-      };
-      const discount = 10;
-      const shoppingCartId = randomUUID();
-
-      await eventStore.appendToStream<ShoppingCartEvent>(shoppingCartId, [
-        { type: 'ProductItemAdded', data: { productItem } },
-      ]);
-      await eventStore.appendToStream<ShoppingCartEvent>(shoppingCartId, [
-        { type: 'ProductItemAdded', data: { productItem } },
-      ]);
-      await eventStore.appendToStream<ShoppingCartEvent>(shoppingCartId, [
-        { type: 'DiscountApplied', data: { percent: discount } },
-      ]);
-
-      // when
-      const resultAt1 = await eventStore.aggregateStream(shoppingCartId, {
-        evolve,
-        getInitialState,
-        read: { to: 1n },
-      });
-      const resultAt2 = await eventStore.aggregateStream(shoppingCartId, {
-        evolve,
-        getInitialState,
-        read: { to: 2n },
-      });
-      const resultAt3 = await eventStore.aggregateStream(shoppingCartId, {
-        evolve,
-        getInitialState,
-        read: { to: 3n },
-      });
-
-      // then
-      assert.ok(resultAt1);
-      assert.ok(resultAt2);
-      assert.ok(resultAt3);
-
-      // Note that ESDB counts from 0
-      assert.equal(resultAt1.currentStreamVersion, 0);
-      assert.deepEqual(resultAt1.state, {
-        productItems: [productItem],
-        totalAmount: 30,
-      });
-
-      assert.equal(resultAt2.currentStreamVersion, 1);
-      assert.deepEqual(resultAt2.state, {
-        productItems: [productItem, productItem],
-        totalAmount: 60,
-      });
-
-      assert.equal(resultAt3.currentStreamVersion, 2);
-      assert.deepEqual(resultAt3.state, {
-        productItems: [productItem, productItem],
-        totalAmount: 54,
-      });
-    });
+  await testAggregateStream(eventStoreFactory, {
+    teardownHook,
+    getInitialIndex: () => 0n,
   });
 });

--- a/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.e2e.spec.ts
+++ b/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.e2e.spec.ts
@@ -1,5 +1,11 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import { type Event, type EventStore } from '@event-driven-io/emmett';
+import {
+  evolve,
+  getInitialState,
+  type EventStore,
+  type PricedProductItem,
+  type ShoppingCartEvent,
+} from '@event-driven-io/emmett';
 import {
   EventStoreDBContainer,
   StartedEventStoreDBContainer,
@@ -8,48 +14,6 @@ import assert from 'node:assert';
 import { randomUUID } from 'node:crypto';
 import { after, before, describe, it } from 'node:test';
 import { getEventStoreDBEventStore } from './eventstoreDBEventStore';
-
-// Events & Entity
-
-type PricedProductItem = { productId: string; quantity: number; price: number };
-
-type ShoppingCart = {
-  productItems: PricedProductItem[];
-  totalAmount: number;
-};
-
-type ProductItemAdded = Event<
-  'ProductItemAdded',
-  { productItem: PricedProductItem }
->;
-type DiscountApplied = Event<'DiscountApplied', { percent: number }>;
-
-type ShoppingCartEvent = ProductItemAdded | DiscountApplied;
-
-const evolve = (
-  state: ShoppingCart,
-  { type, data }: ShoppingCartEvent,
-): ShoppingCart => {
-  switch (type) {
-    case 'ProductItemAdded': {
-      const productItem = data.productItem;
-      return {
-        productItems: [...state.productItems, productItem],
-        totalAmount:
-          state.totalAmount + productItem.price * productItem.quantity,
-      };
-    }
-    case 'DiscountApplied':
-      return {
-        ...state,
-        totalAmount: state.totalAmount * (1 - data.percent / 100),
-      };
-  }
-};
-
-const getInitialState = (): ShoppingCart => {
-  return { productItems: [], totalAmount: 0 };
-};
 
 describe('EventStoreDBEventStore', () => {
   let esdbContainer: StartedEventStoreDBContainer;

--- a/src/packages/emmett/src/commandHandling/handleCommand.unit.spec.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.unit.spec.ts
@@ -88,7 +88,7 @@ const handleCommand = CommandHandler<ShoppingCart, ShoppingCartEvent>(
 describe('Command Handler', () => {
   const eventStore = getInMemoryEventStore();
 
-  it('When called successfuly returns new state for a single returned event', async () => {
+  it('When called successfully returns new state for a single returned event', async () => {
     const productItem: PricedProductItem = {
       productId: '123',
       quantity: 10,

--- a/src/packages/emmett/src/eventStore/inMemoryEventStore.unit.spec.ts
+++ b/src/packages/emmett/src/eventStore/inMemoryEventStore.unit.spec.ts
@@ -7,5 +7,5 @@ import { testAggregateStream } from '../testing';
 
 describe('InMemoryEventStore', () => {
   const eventStore = getInMemoryEventStore();
-  testAggregateStream(eventStore);
+  testAggregateStream(() => Promise.resolve(eventStore));
 });

--- a/src/packages/emmett/src/eventStore/inMemoryEventStore.unit.spec.ts
+++ b/src/packages/emmett/src/eventStore/inMemoryEventStore.unit.spec.ts
@@ -1,80 +1,11 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import assert from 'node:assert';
-import { randomUUID } from 'node:crypto';
-import { describe, it } from 'node:test';
+import { describe } from 'node:test';
 import { getInMemoryEventStore } from '../eventStore';
-import {
-  evolve,
-  getInitialState,
-  type PricedProductItem,
-  type ShoppingCartEvent,
-} from '../testing/shoppingCart.domain';
+import { testAggregateStream } from '../testing';
 
 // Events & Entity
 
 describe('InMemoryEventStore', () => {
   const eventStore = getInMemoryEventStore();
-
-  describe('aggregateStream', () => {
-    it('When called with `to` allows time traveling', async () => {
-      // Given
-      const productItem: PricedProductItem = {
-        productId: '123',
-        quantity: 10,
-        price: 3,
-      };
-      const discount = 10;
-      const shoppingCartId = randomUUID();
-
-      await eventStore.appendToStream<ShoppingCartEvent>(shoppingCartId, [
-        { type: 'ProductItemAdded', data: { productItem } },
-      ]);
-      await eventStore.appendToStream<ShoppingCartEvent>(shoppingCartId, [
-        { type: 'ProductItemAdded', data: { productItem } },
-      ]);
-      await eventStore.appendToStream<ShoppingCartEvent>(shoppingCartId, [
-        { type: 'DiscountApplied', data: { percent: discount } },
-      ]);
-
-      // when
-      const resultAt1 = await eventStore.aggregateStream(shoppingCartId, {
-        evolve,
-        getInitialState,
-        read: { to: 1n },
-      });
-      const resultAt2 = await eventStore.aggregateStream(shoppingCartId, {
-        evolve,
-        getInitialState,
-        read: { to: 2n },
-      });
-      const resultAt3 = await eventStore.aggregateStream(shoppingCartId, {
-        evolve,
-        getInitialState,
-        read: { to: 3n },
-      });
-
-      // then
-      assert.ok(resultAt1);
-      assert.ok(resultAt2);
-      assert.ok(resultAt3);
-
-      assert.equal(resultAt1.currentStreamVersion, 1);
-      assert.deepEqual(resultAt1.state, {
-        productItems: [productItem],
-        totalAmount: 30,
-      });
-
-      assert.equal(resultAt2.currentStreamVersion, 2);
-      assert.deepEqual(resultAt2.state, {
-        productItems: [productItem, productItem],
-        totalAmount: 60,
-      });
-
-      assert.equal(resultAt3.currentStreamVersion, 3);
-      assert.deepEqual(resultAt3.state, {
-        productItems: [productItem, productItem],
-        totalAmount: 54,
-      });
-    });
-  });
+  testAggregateStream(eventStore);
 });

--- a/src/packages/emmett/src/eventStore/inMemoryEventStore.unit.spec.ts
+++ b/src/packages/emmett/src/eventStore/inMemoryEventStore.unit.spec.ts
@@ -3,55 +3,20 @@ import assert from 'node:assert';
 import { randomUUID } from 'node:crypto';
 import { describe, it } from 'node:test';
 import { getInMemoryEventStore } from '../eventStore';
-import { type Event } from '../typing';
+import {
+  evolve,
+  getInitialState,
+  type PricedProductItem,
+  type ShoppingCartEvent,
+} from '../testing/shoppingCart.domain';
 
 // Events & Entity
-
-type PricedProductItem = { productId: string; quantity: number; price: number };
-
-type ShoppingCart = {
-  productItems: PricedProductItem[];
-  totalAmount: number;
-};
-
-type ProductItemAdded = Event<
-  'ProductItemAdded',
-  { productItem: PricedProductItem }
->;
-type DiscountApplied = Event<'DiscountApplied', { percent: number }>;
-
-type ShoppingCartEvent = ProductItemAdded | DiscountApplied;
-
-const evolve = (
-  state: ShoppingCart,
-  { type, data }: ShoppingCartEvent,
-): ShoppingCart => {
-  switch (type) {
-    case 'ProductItemAdded': {
-      const productItem = data.productItem;
-      return {
-        productItems: [...state.productItems, productItem],
-        totalAmount:
-          state.totalAmount + productItem.price * productItem.quantity,
-      };
-    }
-    case 'DiscountApplied':
-      return {
-        ...state,
-        totalAmount: state.totalAmount * (1 - data.percent / 100),
-      };
-  }
-};
-
-const getInitialState = (): ShoppingCart => {
-  return { productItems: [], totalAmount: 0 };
-};
 
 describe('InMemoryEventStore', () => {
   const eventStore = getInMemoryEventStore();
 
   describe('aggregateStream', () => {
-    it('When called with `to` allows time travelling', async () => {
+    it('When called with `to` allows time traveling', async () => {
       // Given
       const productItem: PricedProductItem = {
         productId: '123',

--- a/src/packages/emmett/src/testing/features.ts
+++ b/src/packages/emmett/src/testing/features.ts
@@ -59,17 +59,17 @@ export async function testAggregateStream(
       const resultAt1 = await eventStore.aggregateStream(shoppingCartId, {
         evolve,
         getInitialState,
-        read: { to: options.getInitialIndex() },
+        read: { to: 1n },
       });
       const resultAt2 = await eventStore.aggregateStream(shoppingCartId, {
         evolve,
         getInitialState,
-        read: { to: options.getInitialIndex() + 1n },
+        read: { to: 2n },
       });
       const resultAt3 = await eventStore.aggregateStream(shoppingCartId, {
         evolve,
         getInitialState,
-        read: { to: options.getInitialIndex() + 2n },
+        read: { to: 3n },
       });
 
       // then
@@ -77,19 +77,25 @@ export async function testAggregateStream(
       assert.ok(resultAt2);
       assert.ok(resultAt3);
 
-      assert.equal(resultAt1.currentStreamVersion, 1);
+      assert.equal(resultAt1.currentStreamVersion, options.getInitialIndex());
       assert.deepEqual(resultAt1.state, {
         productItems: [productItem],
         totalAmount: 30,
       });
 
-      assert.equal(resultAt2.currentStreamVersion, 2);
+      assert.equal(
+        resultAt2.currentStreamVersion,
+        options.getInitialIndex() + 1n,
+      );
       assert.deepEqual(resultAt2.state, {
         productItems: [productItem, productItem],
         totalAmount: 60,
       });
 
-      assert.equal(resultAt3.currentStreamVersion, 3);
+      assert.equal(
+        resultAt3.currentStreamVersion,
+        options.getInitialIndex() + 2n,
+      );
       assert.deepEqual(resultAt3.state, {
         productItems: [productItem, productItem],
         totalAmount: 54,

--- a/src/packages/emmett/src/testing/features.ts
+++ b/src/packages/emmett/src/testing/features.ts
@@ -1,0 +1,90 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import assert from 'node:assert';
+import { randomUUID } from 'node:crypto';
+import { describe, it } from 'node:test';
+import type { EventStore } from '../eventStore';
+import {
+  evolve,
+  getInitialState,
+  type PricedProductItem,
+  type ShoppingCartEvent,
+} from './shoppingCart.domain';
+
+type TestOptions = {
+  getInitialIndex: () => bigint;
+};
+
+export type EventStoreFactory = () => Promise<{
+  eventStore: EventStore<bigint>;
+  tearDown?: () => Promise<void>;
+}>;
+
+export async function testAggregateStream(
+  eventStore: EventStore,
+  options: TestOptions = {
+    getInitialIndex: () => 1n,
+  },
+) {
+  return describe('aggregateStream', () => {
+    it('When called with `to` allows time traveling', async () => {
+      // Given
+      const productItem: PricedProductItem = {
+        productId: '123',
+        quantity: 10,
+        price: 3,
+      };
+      const discount = 10;
+      const shoppingCartId = randomUUID();
+
+      await eventStore.appendToStream<ShoppingCartEvent>(shoppingCartId, [
+        { type: 'ProductItemAdded', data: { productItem } },
+      ]);
+      await eventStore.appendToStream<ShoppingCartEvent>(shoppingCartId, [
+        { type: 'ProductItemAdded', data: { productItem } },
+      ]);
+      await eventStore.appendToStream<ShoppingCartEvent>(shoppingCartId, [
+        { type: 'DiscountApplied', data: { percent: discount } },
+      ]);
+
+      // when
+      const resultAt1 = await eventStore.aggregateStream(shoppingCartId, {
+        evolve,
+        getInitialState,
+        read: { to: options.getInitialIndex() },
+      });
+      const resultAt2 = await eventStore.aggregateStream(shoppingCartId, {
+        evolve,
+        getInitialState,
+        read: { to: options.getInitialIndex() + 1n },
+      });
+      const resultAt3 = await eventStore.aggregateStream(shoppingCartId, {
+        evolve,
+        getInitialState,
+        read: { to: options.getInitialIndex() + 2n },
+      });
+
+      // then
+      assert.ok(resultAt1);
+      assert.ok(resultAt2);
+      assert.ok(resultAt3);
+
+      assert.equal(resultAt1.currentStreamVersion, 1);
+      assert.deepEqual(resultAt1.state, {
+        productItems: [productItem],
+        totalAmount: 30,
+      });
+
+      assert.equal(resultAt2.currentStreamVersion, 2);
+      assert.deepEqual(resultAt2.state, {
+        productItems: [productItem, productItem],
+        totalAmount: 60,
+      });
+
+      assert.equal(resultAt3.currentStreamVersion, 3);
+      assert.deepEqual(resultAt3.state, {
+        productItems: [productItem, productItem],
+        totalAmount: 54,
+      });
+    });
+  });
+}

--- a/src/packages/emmett/src/testing/index.ts
+++ b/src/packages/emmett/src/testing/index.ts
@@ -2,4 +2,3 @@ export * from './assertions';
 export * from './deciderSpecification';
 export * from './features';
 export * from './shoppingCart.domain';
-

--- a/src/packages/emmett/src/testing/index.ts
+++ b/src/packages/emmett/src/testing/index.ts
@@ -1,3 +1,5 @@
 export * from './assertions';
 export * from './deciderSpecification';
+export * from './features';
 export * from './shoppingCart.domain';
+

--- a/src/packages/emmett/src/testing/index.ts
+++ b/src/packages/emmett/src/testing/index.ts
@@ -1,2 +1,3 @@
 export * from './assertions';
 export * from './deciderSpecification';
+export * from './shoppingCart.domain';

--- a/src/packages/emmett/src/testing/shoppingCart.domain.ts
+++ b/src/packages/emmett/src/testing/shoppingCart.domain.ts
@@ -1,0 +1,45 @@
+import { type Event } from '../typing';
+
+export type PricedProductItem = {
+  productId: string;
+  quantity: number;
+  price: number;
+};
+
+export type ShoppingCart = {
+  productItems: PricedProductItem[];
+  totalAmount: number;
+};
+
+export type ProductItemAdded = Event<
+  'ProductItemAdded',
+  { productItem: PricedProductItem }
+>;
+export type DiscountApplied = Event<'DiscountApplied', { percent: number }>;
+
+export type ShoppingCartEvent = ProductItemAdded | DiscountApplied;
+
+export const evolve = (
+  state: ShoppingCart,
+  { type, data }: ShoppingCartEvent,
+): ShoppingCart => {
+  switch (type) {
+    case 'ProductItemAdded': {
+      const productItem = data.productItem;
+      return {
+        productItems: [...state.productItems, productItem],
+        totalAmount:
+          state.totalAmount + productItem.price * productItem.quantity,
+      };
+    }
+    case 'DiscountApplied':
+      return {
+        ...state,
+        totalAmount: state.totalAmount * (1 - data.percent / 100),
+      };
+  }
+};
+
+export const getInitialState = (): ShoppingCart => {
+  return { productItems: [], totalAmount: 0 };
+};

--- a/src/packages/emmett/src/testing/shoppingCart.feature
+++ b/src/packages/emmett/src/testing/shoppingCart.feature
@@ -1,0 +1,17 @@
+Feature: ShoppingCart
+  Scenario: Add a product to the shopping cart
+    Given I have a shopping cart
+    When I add a product to the shopping cart
+    Then the shopping cart should contain 1 product
+
+  Scenario: Add a product to the shopping cart changes the total price
+    Given I have an empty shopping cart
+    And there is a product item with id "Book-1" and price 3
+    When I add a 10 units to the shopping cart
+    Then the total price of the shopping cart should be 30
+
+  Scenario: Apply a discount to the shopping cart
+    Given there is a product item with id "Book-1" and price 3
+    And I have a shopping cart with 10 units of product "Book-1"
+    When I apply a 10% discount to the shopping cart
+    Then the total price of the shopping cart should be 27

--- a/src/packages/emmett/src/testing/timeTravel.feature
+++ b/src/packages/emmett/src/testing/timeTravel.feature
@@ -1,0 +1,48 @@
+Feature: Time-Travel
+
+  Scenario: Travels to the first version of an event stream
+    Given an event store with the following events:
+      | EventID | EventType          | EventData                                             |
+      | 1       | ProductItemAdded   | { "productId": "Book-1", "quantity": 10, "price": 3 } |
+      | 2       | ProductItemAdded   | { "productId": "Book-1", "quantity": 10, "price": 3 } |
+      | 3       | DiscountApplied    | { "percent": 10 }                                     |
+    When I travel to the **first** version of the event stream
+    Then the ShoppingCart should have the following state:
+      {
+        "totalAmount": 30,
+        "productItems": [
+          { "productId": "Book-1", "quantity": 10, "price": 3 }
+        ],
+      }
+
+  Scenario: Travels to the second version of an event stream
+    Given an event store with the following events:
+      | EventID | EventType          | EventData                                             |
+      | 1       | ProductItemAdded   | { "productId": "Book-1", "quantity": 10, "price": 3 } |
+      | 2       | ProductItemAdded   | { "productId": "Book-1", "quantity": 10, "price": 3 } |
+      | 3       | DiscountApplied    | { "percent": 10 }                                     |
+    When I travel to the **second** version of the event stream
+    Then the ShoppingCart should have the following state:
+      {
+        "totalAmount": 60,
+        "productItems": [
+          { "productId": "Book-1", "quantity": 10, "price": 3 },
+          { "productId": "Book-1", "quantity": 10, "price": 3 },
+        ],
+      }
+
+  Scenario: Travels to the third version of an event stream
+    Given an event store with the following events:
+      | EventID | EventType          | EventData                                             |
+      | 1       | ProductItemAdded   | { "productId": "Book-1", "quantity": 10, "price": 3 } |
+      | 2       | ProductItemAdded   | { "productId": "Book-1", "quantity": 10, "price": 3 } |
+      | 3       | DiscountApplied    | { "percent": 10 }                                     |
+    When I travel to the **third** version of the event stream
+    Then the ShoppingCart should have the following state:
+      {
+        "totalAmount": 54,
+        "productItems": [
+          { "productId": "Book-1", "quantity": 10, "price": 3 },
+          { "productId": "Book-1", "quantity": 10, "price": 3 },
+        ],
+      }


### PR DESCRIPTION
This should close #34 once ready for merge.

The idea here is to create some utility function that we can use to create similar tests between different Event Store implementations. Currently, we've done two major changes:

1. Extracted the common business rule code to the `shoppingCart.domain` file
2. Created an example utility function under `emmet/src/testing/features.ts` file.

Alright, this should already be working for existing tests, @oskardudycz . Now, a few things to discuss:

1. Where should we put the common business logic used by all tests? Currently it's in `src/packages/emmett/src/testing/shoppingCart.domain.ts`
2. Should we consider creating a separate package like `emmet-testing` where the common test utility resides? For instance, we could put both this "domain" logic and the function utilities to test new features (which currently are in `src/packages/emmett/src/testing/features.ts`
3. Should we make these test utilities more abstract? As you can see, I've created the `testAggregateStream()` function which is specifically for testing aggregate stream features. However, we certainly will need to test more features in the future, and we should consider how much duplication we want.