### PR TITLE
Made event store features tests internal not to expose node packages in bundled Emmett code

### DIFF
--- a/src/docs/snippets/gettingStarted/businessLogic.unit.spec.ts
+++ b/src/docs/snippets/gettingStarted/businessLogic.unit.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
 import { describe, it } from 'node:test';
 import { decide } from './businessLogic';
 import { evolve, getInitialState } from './shoppingCart';
@@ -14,9 +13,9 @@ const given = DeciderSpecification.for({
   initialState: getInitialState,
 });
 
-describe('ShoppingCart', () => {
-  describe('When empty', () => {
-    it('should add product item', () => {
+void describe('ShoppingCart', () => {
+  void describe('When empty', () => {
+    void it('should add product item', () => {
       given([])
         .when({
           type: 'AddProductItemToShoppingCart',
@@ -39,8 +38,8 @@ describe('ShoppingCart', () => {
     });
   });
 
-  describe('When opened', () => {
-    it('should confirm', () => {
+  void describe('When opened', () => {
+    void it('should confirm', () => {
       given({
         type: 'ProductItemAddedToShoppingCart',
         data: {
@@ -68,8 +67,8 @@ describe('ShoppingCart', () => {
     });
   });
 
-  describe('When confirmed', () => {
-    it('should not add products', () => {
+  void describe('When confirmed', () => {
+    void it('should not add products', () => {
       given([
         {
           type: 'ProductItemAddedToShoppingCart',

--- a/src/docs/snippets/gettingStarted/webApi/apiBDD.e2e.spec.ts
+++ b/src/docs/snippets/gettingStarted/webApi/apiBDD.e2e.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
 import { after, before, beforeEach, describe, it } from 'node:test';
 import type { PricedProductItem } from '../events';
 import { ShoppingCartStatus } from './shoppingCart';
@@ -18,7 +17,7 @@ import {
 } from '@event-driven-io/emmett-testcontainers';
 import { randomUUID } from 'node:crypto';
 
-describe('ShoppingCart E2E', () => {
+void describe('ShoppingCart E2E', () => {
   const unitPrice = 100;
   let clientId: string;
   let shoppingCartId: string;
@@ -52,8 +51,8 @@ describe('ShoppingCart E2E', () => {
     return esdbContainer.stop();
   });
 
-  describe('When opened with product item', () => {
-    it('should confirm', () => {
+  void describe('When opened with product item', () => {
+    void it('should confirm', () => {
       return given((request) =>
         request
           .post(`/clients/${clientId}/shopping-carts/current/product-items`)
@@ -65,7 +64,7 @@ describe('ShoppingCart E2E', () => {
         .then([expectResponse(204)]);
     });
 
-    it('should return details', () => {
+    void it('should return details', () => {
       return given((request) =>
         request
           .post(`/clients/${clientId}/shopping-carts/current/product-items`)

--- a/src/docs/snippets/gettingStarted/webApi/apiBDD.int.spec.ts
+++ b/src/docs/snippets/gettingStarted/webApi/apiBDD.int.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
 import { beforeEach, describe, it } from 'node:test';
 import type { PricedProductItem, ShoppingCartEvent } from '../events';
 import { shoppingCartApi } from './simpleApi';
@@ -17,7 +16,7 @@ import {
 } from '@event-driven-io/emmett-expressjs';
 import { randomUUID } from 'node:crypto';
 
-describe('ShoppingCart', () => {
+void describe('ShoppingCart', () => {
   let clientId: string;
   let shoppingCartId: string;
 
@@ -26,8 +25,8 @@ describe('ShoppingCart', () => {
     shoppingCartId = `shopping_cart:${clientId}:current`;
   });
 
-  describe('When empty', () => {
-    it('should add product item', () => {
+  void describe('When empty', () => {
+    void it('should add product item', () => {
       return given()
         .when((request) =>
           request
@@ -49,8 +48,8 @@ describe('ShoppingCart', () => {
     });
   });
 
-  describe('When opened with product item', () => {
-    it('should confirm', () => {
+  void describe('When opened with product item', () => {
+    void it('should confirm', () => {
       return given(
         existingStream(shoppingCartId, [
           {
@@ -81,8 +80,8 @@ describe('ShoppingCart', () => {
     });
   });
 
-  describe('When confirmed', () => {
-    it('should not add products', () => {
+  void describe('When confirmed', () => {
+    void it('should not add products', () => {
       return given(
         existingStream(shoppingCartId, [
           {

--- a/src/docs/snippets/gettingStarted/webApi/apiBDDE2EGiven.ts
+++ b/src/docs/snippets/gettingStarted/webApi/apiBDDE2EGiven.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { after, before, describe } from 'node:test';
 import { shoppingCartApi } from './simpleApi';
@@ -13,7 +12,7 @@ import {
 } from '@event-driven-io/emmett-testcontainers';
 
 let esdbContainer: StartedEventStoreDBContainer;
-describe('ShoppingCart E2E', () => {
+void describe('ShoppingCart E2E', () => {
   // Set up a container before all tests
   before(async () => {
     esdbContainer = await new EventStoreDBContainer().start();

--- a/src/docs/snippets/gettingStarted/webApi/apiBDDE2ETest.ts
+++ b/src/docs/snippets/gettingStarted/webApi/apiBDDE2ETest.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
 import { type EventStore } from '@event-driven-io/emmett';
 import {
   ApiE2ESpecification,
@@ -43,8 +42,8 @@ import { getEventStoreDBEventStore } from '@event-driven-io/emmett-esdb';
 import { expectResponse } from '@event-driven-io/emmett-expressjs';
 import type { StartedEventStoreDBContainer } from '@event-driven-io/emmett-testcontainers';
 
-describe('When opened with product item', () => {
-  it('should confirm', () => {
+void describe('When opened with product item', () => {
+  void it('should confirm', () => {
     return given((request) =>
       request
         .post(`/clients/${clientId}/shopping-carts/current/product-items`)

--- a/src/docs/snippets/gettingStarted/webApi/apiBDDIntTest.ts
+++ b/src/docs/snippets/gettingStarted/webApi/apiBDDIntTest.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
 import {
   getInMemoryEventStore,
   type EventStore,
@@ -49,8 +48,8 @@ import {
   expectResponse,
 } from '@event-driven-io/emmett-expressjs';
 
-describe('When opened with product item', () => {
-  it('should confirm', () => {
+void describe('When opened with product item', () => {
+  void it('should confirm', () => {
     return given(
       existingStream(shoppingCartId, [
         {

--- a/src/docs/snippets/gettingStarted/webApi/simpleApi.int.spec.ts
+++ b/src/docs/snippets/gettingStarted/webApi/simpleApi.int.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
 import {
   assertMatches,
   getInMemoryEventStore,
@@ -18,7 +17,7 @@ const getUnitPrice = (_productId: string) => {
   return Promise.resolve(100);
 };
 
-describe('Simple Api from getting started', () => {
+void describe('Simple Api from getting started', () => {
   let app: Application;
   let eventStore: EventStore;
 
@@ -29,7 +28,7 @@ describe('Simple Api from getting started', () => {
     });
   });
 
-  it('Should handle requests correctly', async () => {
+  void it('Should handle requests correctly', async () => {
     const clientId = randomUUID();
     ///////////////////////////////////////////////////
     // 1. Add Two Pair of Shoes

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@event-driven-io/core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@event-driven-io/core",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "workspaces": [
         "packages/emmett",
         "packages/emmett-esdb",
@@ -16,7 +16,6 @@
       ],
       "devDependencies": {
         "@faker-js/faker": "8.4.1",
-        "@types/node": "20.11.30",
         "@typescript-eslint/eslint-plugin": "7.4.0",
         "@typescript-eslint/parser": "7.4.0",
         "eslint": "8.57.0",
@@ -37,6 +36,7 @@
       },
       "peerDependencies": {
         "@types/express": "4.17.21",
+        "@types/node": "20.11.30",
         "@types/supertest": "6.0.2",
         "supertest": "6.3.4"
       }
@@ -8014,17 +8014,20 @@
     },
     "packages/emmett": {
       "name": "@event-driven-io/emmett",
-      "version": "0.7.0",
-      "devDependencies": {}
+      "version": "0.7.1",
+      "devDependencies": {},
+      "peerDependencies": {
+        "@types/node": "^20.11.30"
+      }
     },
     "packages/emmett-esdb": {
       "name": "@event-driven-io/emmett-esdb",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "devDependencies": {
         "@event-driven-io/emmett-testcontainers": "^0.5.0"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.7.0",
+        "@event-driven-io/emmett": "0.7.1",
         "@eventstore/db-client": "^6.1.0"
       }
     },
@@ -8046,10 +8049,10 @@
     },
     "packages/emmett-expressjs": {
       "name": "@event-driven-io/emmett-expressjs",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "devDependencies": {},
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.7.0",
+        "@event-driven-io/emmett": "0.7.1",
         "@types/express": "4.17.21",
         "@types/supertest": "6.0.2",
         "express": "4.19.2",
@@ -8060,10 +8063,10 @@
     },
     "packages/emmett-fastify": {
       "name": "@event-driven-io/emmett-fastify",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "devDependencies": {},
       "peerDependencies": {
-        "@event-driven-io/emmett": "^0.7.0",
+        "@event-driven-io/emmett": "^0.7.1",
         "@fastify/compress": "7.0.0",
         "@fastify/etag": "5.1.0",
         "@fastify/formbody": "7.4.0",
@@ -8073,9 +8076,9 @@
     },
     "packages/emmett-testcontainers": {
       "name": "@event-driven-io/emmett-testcontainers",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
-        "@event-driven-io/emmett": "0.7.0",
+        "@event-driven-io/emmett": "0.7.1",
         "testcontainers": "^10.7.2"
       },
       "devDependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Emmett - Event Sourcing development made simple",
   "engines": {
     "node": ">=20.11.1"
@@ -61,7 +61,6 @@
   ],
   "devDependencies": {
     "@faker-js/faker": "8.4.1",
-    "@types/node": "20.11.30",
     "@typescript-eslint/eslint-plugin": "7.4.0",
     "@typescript-eslint/parser": "7.4.0",
     "eslint": "8.57.0",
@@ -78,6 +77,7 @@
     "vitepress": "1.0.1"
   },
   "peerDependencies": {
+    "@types/node": "20.11.30",
     "@types/express": "4.17.21",
     "@types/supertest": "6.0.2",
     "supertest": "6.3.4"

--- a/src/packages/emmett-esdb/package.json
+++ b/src/packages/emmett-esdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-esdb",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Emmett - EventStoreDB - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -50,7 +50,7 @@
     "@event-driven-io/emmett-testcontainers": "^0.5.0"
   },
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.7.0",
+    "@event-driven-io/emmett": "0.7.1",
     "@eventstore/db-client": "^6.1.0"
   }
 }

--- a/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.e2e.spec.ts
+++ b/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.e2e.spec.ts
@@ -1,16 +1,15 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
-import {
-  testAggregateStream,
-  type EventStoreFactory,
-} from '@event-driven-io/emmett';
 import {
   EventStoreDBContainer,
   StartedEventStoreDBContainer,
 } from '@event-driven-io/emmett-testcontainers';
 import { describe } from 'node:test';
+import {
+  testAggregateStream,
+  type EventStoreFactory,
+} from '../../../emmett/src/testing/features';
 import { getEventStoreDBEventStore } from './eventstoreDBEventStore';
 
-describe('EventStoreDBEventStore', async () => {
+void describe('EventStoreDBEventStore', async () => {
   let esdbContainer: StartedEventStoreDBContainer;
 
   const eventStoreFactory: EventStoreFactory = async () => {

--- a/src/packages/emmett-esdb/tsup.config.ts
+++ b/src/packages/emmett-esdb/tsup.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   watch: env === 'development',
   target: 'esnext',
   outDir: 'dist', //env === 'production' ? 'dist' : 'lib',
-  entry: ['src/**/*.ts', '!src/**/*.spec.ts'], //include all files under src but not specs
+  entry: ['src/**/*.ts', '!src/**/*.spec.ts', '!src/**/*.internal.ts'], //include all files under src but not specs
   sourcemap: true,
   tsconfig: 'tsconfig.build.json', // workaround for https://github.com/egoist/tsup/issues/571#issuecomment-1760052931
 });

--- a/src/packages/emmett-expressjs/package.json
+++ b/src/packages/emmett-expressjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-expressjs",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -48,7 +48,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.7.0",
+    "@event-driven-io/emmett": "0.7.1",
     "@types/express": "4.17.21",
     "@types/supertest": "6.0.2",
     "express": "4.19.2",

--- a/src/packages/emmett-expressjs/src/e2e/decider/applicationLogicWithOC.int.spec.ts
+++ b/src/packages/emmett-expressjs/src/e2e/decider/applicationLogicWithOC.int.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
 import {
   assertMatches,
   getInMemoryEventStore,
@@ -6,6 +5,7 @@ import {
 } from '@event-driven-io/emmett';
 import { type Application } from 'express';
 import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
 import { beforeEach, describe, it } from 'node:test';
 import request from 'supertest';
 import { getApplication } from '../..';
@@ -19,9 +19,8 @@ import {
 import { shoppingCartApi } from './api';
 import { ShoppingCartErrors } from './businessLogic';
 import type { ShoppingCartEvent } from './shoppingCart';
-import { randomUUID } from 'node:crypto';
 
-describe('Application logic with optimistic concurrency', () => {
+void describe('Application logic with optimistic concurrency', () => {
   let app: Application;
   let eventStore: EventStore;
 
@@ -30,7 +29,7 @@ describe('Application logic with optimistic concurrency', () => {
     app = getApplication({ apis: [shoppingCartApi(eventStore)] });
   });
 
-  it('Should handle requests correctly', async () => {
+  void it('Should handle requests correctly', async () => {
     const clientId = randomUUID();
     ///////////////////////////////////////////////////
     // 1. Open Shopping Cart

--- a/src/packages/emmett-expressjs/tsup.config.ts
+++ b/src/packages/emmett-expressjs/tsup.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   watch: env === 'development',
   target: 'esnext',
   outDir: 'dist', //env === 'production' ? 'dist' : 'lib',
-  entry: ['src/**/*.ts', '!src/**/*.spec.ts'], //include all files under src but not specs
+  entry: ['src/**/*.ts', '!src/**/*.spec.ts', '!src/**/*.internal.ts'], //include all files under src but not specs
   sourcemap: true,
   tsconfig: 'tsconfig.build.json', // workaround for https://github.com/egoist/tsup/issues/571#issuecomment-1760052931
 });

--- a/src/packages/emmett-fastify/package.json
+++ b/src/packages/emmett-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-fastify",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -52,7 +52,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "@event-driven-io/emmett": "^0.7.0",
+    "@event-driven-io/emmett": "^0.7.1",
     "fastify": "4.26.2",
     "@fastify/compress": "7.0.0",
     "@fastify/etag": "5.1.0",

--- a/src/packages/emmett-fastify/src/e2e/decider/applicationLogicWithOC.int.spec.ts
+++ b/src/packages/emmett-fastify/src/e2e/decider/applicationLogicWithOC.int.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
 import {
   assertMatches,
   getInMemoryEventStore,
@@ -13,7 +12,7 @@ import { RegisterRoutes } from './api';
 import { ShoppingCartErrors } from './businessLogic';
 import type { ShoppingCartEvent } from './shoppingCart';
 
-describe('Application logic with optimistic concurrency using Fastify', () => {
+void describe('Application logic with optimistic concurrency using Fastify', () => {
   let app: FastifyInstance;
   let eventStore: EventStore;
   beforeEach(async () => {
@@ -22,7 +21,7 @@ describe('Application logic with optimistic concurrency using Fastify', () => {
     app = await getApplication({ registerRoutes });
   });
 
-  it('Should handle requests correctly', async () => {
+  void it('Should handle requests correctly', async () => {
     const clientId = randomUUID();
     ///////////////////////////////////////////////////
     // 1. Open Shopping Cart

--- a/src/packages/emmett-fastify/tsup.config.ts
+++ b/src/packages/emmett-fastify/tsup.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   watch: env === 'development',
   target: 'esnext',
   outDir: 'dist', //env === 'production' ? 'dist' : 'lib',
-  entry: ['src/**/*.ts', '!src/**/*.spec.ts'], //include all files under src but not specs
+  entry: ['src/**/*.ts', '!src/**/*.spec.ts', '!src/**/*.internal.ts'], //include all files under src but not specs
   sourcemap: true,
   tsconfig: 'tsconfig.build.json', // workaround for https://github.com/egoist/tsup/issues/571#issuecomment-1760052931
 });

--- a/src/packages/emmett-testcontainers/package.json
+++ b/src/packages/emmett-testcontainers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-testcontainers",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Emmett - TestContainers - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -46,7 +46,7 @@
     "dist"
   ],
   "dependencies": {
-    "@event-driven-io/emmett": "0.7.0",
+    "@event-driven-io/emmett": "0.7.1",
     "testcontainers": "^10.7.2"
   },
   "devDependencies": {

--- a/src/packages/emmett-testcontainers/src/eventStore/eventStoreDBContainer.e2e.spec.ts
+++ b/src/packages/emmett-testcontainers/src/eventStore/eventStoreDBContainer.e2e.spec.ts
@@ -1,21 +1,20 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
 import { jsonEvent } from '@eventstore/db-client';
 import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
 import { after, beforeEach, describe, it } from 'node:test';
 import {
   EventStoreDBContainer,
   StartedEventStoreDBContainer,
 } from './eventStoreDBContainer';
-import { randomUUID } from 'node:crypto';
 
-describe('EventStoreDBContainer', () => {
+void describe('EventStoreDBContainer', () => {
   let container: StartedEventStoreDBContainer;
 
   beforeEach(async () => {
     container = await new EventStoreDBContainer().start();
   });
 
-  it('should connect to EventStoreDB and append new event', async () => {
+  void it('should connect to EventStoreDB and append new event', async () => {
     const client = container.getClient();
 
     const result = await client.appendToStream(

--- a/src/packages/emmett-testcontainers/tsup.config.ts
+++ b/src/packages/emmett-testcontainers/tsup.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   watch: env === 'development',
   target: 'esnext',
   outDir: 'dist', //env === 'production' ? 'dist' : 'lib',
-  entry: ['src/**/*.ts', '!src/**/*.spec.ts'], //include all files under src but not specs
+  entry: ['src/**/*.ts', '!src/**/*.spec.ts', '!src/**/*.internal.ts'], //include all files under src but not specs
   sourcemap: true,
   tsconfig: 'tsconfig.build.json', // workaround for https://github.com/egoist/tsup/issues/571#issuecomment-1760052931
 });

--- a/src/packages/emmett/package.json
+++ b/src/packages/emmett/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -45,5 +45,8 @@
   "files": [
     "dist"
   ],
-  "devDependencies": {}
+  "devDependencies": {},
+  "peerDependencies": {
+    "@types/node": "^20.11.30"
+  }
 }

--- a/src/packages/emmett/src/commandHandling/handleCommand.unit.spec.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.unit.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
 import assert from 'node:assert';
 import { randomUUID } from 'node:crypto';
 import { describe, it } from 'node:test';
@@ -85,10 +84,10 @@ const handleCommand = CommandHandler<ShoppingCart, ShoppingCartEvent>(
   getInitialState,
 );
 
-describe('Command Handler', () => {
+void describe('Command Handler', () => {
   const eventStore = getInMemoryEventStore();
 
-  it('When called successfully returns new state for a single returned event', async () => {
+  void it('When called successfully returns new state for a single returned event', async () => {
     const productItem: PricedProductItem = {
       productId: '123',
       quantity: 10,
@@ -114,7 +113,7 @@ describe('Command Handler', () => {
     assert.equal(nextExpectedStreamVersion, 1);
   });
 
-  it('When called successfuly returns new state for multiple returned events', async () => {
+  void it('When called successfuly returns new state for multiple returned events', async () => {
     const productItem: PricedProductItem = {
       productId: '123',
       quantity: 10,

--- a/src/packages/emmett/src/eventStore/expectedVersion.unit.spec.ts
+++ b/src/packages/emmett/src/eventStore/expectedVersion.unit.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
@@ -8,8 +7,8 @@ import {
   matchesExpectedVersion,
 } from './expectedVersion';
 
-describe('matchesExpectedVersion', () => {
-  it('When NO_CONCURRENCY_CHECK provided returns `true` for any current version', () => {
+void describe('matchesExpectedVersion', () => {
+  void it('When NO_CONCURRENCY_CHECK provided returns `true` for any current version', () => {
     const allCurrentVersions = [undefined, 0, -1, 1, 100, 'random', ''];
 
     for (const currentStreamVersion of allCurrentVersions) {
@@ -19,11 +18,11 @@ describe('matchesExpectedVersion', () => {
     }
   });
 
-  it('When STREAM_DOES_NOT_EXIST provided returns `true` for current equals `undefined`', () => {
+  void it('When STREAM_DOES_NOT_EXIST provided returns `true` for current equals `undefined`', () => {
     assert.ok(matchesExpectedVersion(undefined, STREAM_DOES_NOT_EXIST));
   });
 
-  it('When STREAM_DOES_NOT_EXIST provided returns `false` for current different than `undefined`', () => {
+  void it('When STREAM_DOES_NOT_EXIST provided returns `false` for current different than `undefined`', () => {
     const definedStreamVersion = [0, -1, 1, 100, 'random', ''];
 
     for (const currentStreamVersion of definedStreamVersion) {
@@ -34,7 +33,7 @@ describe('matchesExpectedVersion', () => {
     }
   });
 
-  it('When STREAM_EXISTS provided returns `true` for current different than `undefined`', () => {
+  void it('When STREAM_EXISTS provided returns `true` for current different than `undefined`', () => {
     const definedStreamVersion = [0, -1, 1, 100, 'random', ''];
 
     for (const currentStreamVersion of definedStreamVersion) {
@@ -42,11 +41,11 @@ describe('matchesExpectedVersion', () => {
     }
   });
 
-  it('When STREAM_EXISTS provided returns `false` for current equals `undefined`', () => {
+  void it('When STREAM_EXISTS provided returns `false` for current equals `undefined`', () => {
     assert.equal(matchesExpectedVersion(undefined, STREAM_EXISTS), false);
   });
 
-  it('When value provided returns `true` for current matching expected value', () => {
+  void it('When value provided returns `true` for current matching expected value', () => {
     const definedStreamVersion = [0, -1, 1, 100, 'random', ''];
 
     for (const streamVersion of definedStreamVersion) {
@@ -54,7 +53,7 @@ describe('matchesExpectedVersion', () => {
     }
   });
 
-  it('When value provided returns `false` for current notmatching expected value', () => {
+  void it('When value provided returns `false` for current notmatching expected value', () => {
     const definedStreamVersion = [
       { current: 100, expected: 0 },
       { current: 0, expected: -1 },

--- a/src/packages/emmett/src/eventStore/inMemoryEventStore.unit.spec.ts
+++ b/src/packages/emmett/src/eventStore/inMemoryEventStore.unit.spec.ts
@@ -1,11 +1,10 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
 import { describe } from 'node:test';
 import { getInMemoryEventStore } from '../eventStore';
-import { testAggregateStream } from '../testing';
+import { testAggregateStream } from '../testing/features';
 
 // Events & Entity
 
-describe('InMemoryEventStore', () => {
+void describe('InMemoryEventStore', () => {
   const eventStore = getInMemoryEventStore();
-  testAggregateStream(() => Promise.resolve(eventStore));
+  void testAggregateStream(() => Promise.resolve(eventStore));
 });

--- a/src/packages/emmett/src/testing/features.ts
+++ b/src/packages/emmett/src/testing/features.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
 import assert from 'node:assert';
 import { randomUUID } from 'node:crypto';
 import { after, before, describe, it } from 'node:test';
@@ -35,7 +34,7 @@ export async function testAggregateStream(
       if (teardownHook) await teardownHook();
     });
 
-    it('When called with `to` allows time traveling', async () => {
+    void it('When called with `to` allows time traveling', async () => {
       // Given
       const productItem: PricedProductItem = {
         productId: '123',

--- a/src/packages/emmett/src/testing/index.ts
+++ b/src/packages/emmett/src/testing/index.ts
@@ -1,4 +1,3 @@
 export * from './assertions';
 export * from './deciderSpecification';
-export * from './features';
 export * from './shoppingCart.domain';

--- a/src/packages/emmett/src/validation/validation.spec.ts
+++ b/src/packages/emmett/src/validation/validation.spec.ts
@@ -1,11 +1,10 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
 import assert from 'node:assert/strict';
-import test, { describe } from 'node:test';
+import { describe, it } from 'node:test';
 import { assertNotEmptyString } from './index';
 
-describe('Validation', () => {
-  describe('assertNotEmptyString', () => {
-    test('should throw an error if the value is an empty string', () => {
+void describe('Validation', () => {
+  void describe('assertNotEmptyString', () => {
+    void it('should throw an error if the value is an empty string', () => {
       // Arrange
       const value = '';
 

--- a/src/packages/emmett/tsup.config.ts
+++ b/src/packages/emmett/tsup.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   watch: env === 'development',
   target: 'esnext',
   outDir: 'dist', //env === 'production' ? 'dist' : 'lib',
-  entry: ['src/**/*.ts', '!src/**/*.spec.ts'], //include all files under src but not specs
+  entry: ['src/**/*.ts', '!src/**/*.spec.ts', '!src/**/*.internal.ts'], //include all files under src but not specs
   sourcemap: true,
   tsconfig: 'tsconfig.build.json', // workaround for https://github.com/egoist/tsup/issues/571#issuecomment-1760052931
 });

--- a/src/tsup.config.ts
+++ b/src/tsup.config.ts
@@ -14,6 +14,6 @@ export default defineConfig({
   watch: env === 'development',
   target: 'esnext',
   outDir: 'dist', //env === 'production' ? 'dist' : 'lib',
-  entry: ['src/**/*.ts', '!src/**/*.spec.ts'], //include all files under src but not specs
+  entry: ['src/**/*.ts', '!src/**/*.spec.ts', '!src/**/*.internal.ts'], //include all files under src but not specs
   sourcemap: true,
 });


### PR DESCRIPTION
The issue is that `esbuild` (for `commonjs`) stripes the 'node:' prefix for targets different from the node (or using node earlier than 14) as they cannot handle packages with prefix like `node:test`. See more in:
https://github.com/evanw/esbuild/commit/6b4f97086c6247434ba95031c1e4335ef67d10b6

`Tsup` that I'm using for bundling also seems not to be handling that fully as it's built on top of `esbuild`: https://github.com/egoist/tsup/issues/1003

As there's no dependency to `test` package, then bundled code fails to load in commonjs environment. One solution is to add dependency to shim, as @alex-laycalvert suggested in #60. But I'm reluctant to do it, as I don't want to target older node environments than Node LTS version (currently >= 20.11.1). I also don't want to add dependency on the unmaintained shim package with potential vulnerabilities.

I could try to change tsconfig target from ESNext to Node, but at the moment I don't want to have this limitation, as I'd like to have the main Emmett package working both with backend and frontend.

The change removes the event store matrix tests, as they don't need to be exposed now. They're still available as js map files to make internal referencing work correctly.

This change should be seen more as a fix rather than solving the root cause. I need to think longer on alternative solutions like having internal project for testing event stores and not having this test at all.

Fixes #59, 
Closes #60

Besides that, following the boy scout rule I removed the `no-floating-promise` ingores as I found the way of handling them using `void` keyword before describes and it. And that Fixes #16 

@alex-laycalvert @thiagomini @mkubasz FYI