### PR TITLE
Added default handling of EventStoreDB test container ARM64 image

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@event-driven-io/core",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@event-driven-io/core",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "workspaces": [
         "packages/emmett",
         "packages/emmett-esdb",
@@ -8014,7 +8014,7 @@
     },
     "packages/emmett": {
       "name": "@event-driven-io/emmett",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "devDependencies": {},
       "peerDependencies": {
         "@types/node": "^20.11.30"
@@ -8022,12 +8022,12 @@
     },
     "packages/emmett-esdb": {
       "name": "@event-driven-io/emmett-esdb",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "devDependencies": {
         "@event-driven-io/emmett-testcontainers": "^0.5.0"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.7.1",
+        "@event-driven-io/emmett": "0.8.0",
         "@eventstore/db-client": "^6.1.0"
       }
     },
@@ -8049,10 +8049,10 @@
     },
     "packages/emmett-expressjs": {
       "name": "@event-driven-io/emmett-expressjs",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "devDependencies": {},
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.7.1",
+        "@event-driven-io/emmett": "0.8.0",
         "@types/express": "4.17.21",
         "@types/supertest": "6.0.2",
         "express": "4.19.2",
@@ -8063,10 +8063,10 @@
     },
     "packages/emmett-fastify": {
       "name": "@event-driven-io/emmett-fastify",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "devDependencies": {},
       "peerDependencies": {
-        "@event-driven-io/emmett": "^0.7.1",
+        "@event-driven-io/emmett": "^0.8.0",
         "@fastify/compress": "7.0.0",
         "@fastify/etag": "5.1.0",
         "@fastify/formbody": "7.4.0",
@@ -8076,9 +8076,9 @@
     },
     "packages/emmett-testcontainers": {
       "name": "@event-driven-io/emmett-testcontainers",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "dependencies": {
-        "@event-driven-io/emmett": "0.7.1",
+        "@event-driven-io/emmett": "0.8.0",
         "testcontainers": "^10.7.2"
       },
       "devDependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/core",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Emmett - Event Sourcing development made simple",
   "engines": {
     "node": ">=20.11.1"

--- a/src/packages/emmett-esdb/package.json
+++ b/src/packages/emmett-esdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-esdb",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Emmett - EventStoreDB - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -50,7 +50,7 @@
     "@event-driven-io/emmett-testcontainers": "^0.5.0"
   },
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.7.1",
+    "@event-driven-io/emmett": "0.8.0",
     "@eventstore/db-client": "^6.1.0"
   }
 }

--- a/src/packages/emmett-expressjs/package.json
+++ b/src/packages/emmett-expressjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-expressjs",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -48,7 +48,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.7.1",
+    "@event-driven-io/emmett": "0.8.0",
     "@types/express": "4.17.21",
     "@types/supertest": "6.0.2",
     "express": "4.19.2",

--- a/src/packages/emmett-fastify/package.json
+++ b/src/packages/emmett-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-fastify",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -52,7 +52,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "@event-driven-io/emmett": "^0.7.1",
+    "@event-driven-io/emmett": "^0.8.0",
     "fastify": "4.26.2",
     "@fastify/compress": "7.0.0",
     "@fastify/etag": "5.1.0",

--- a/src/packages/emmett-testcontainers/package.json
+++ b/src/packages/emmett-testcontainers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-testcontainers",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Emmett - TestContainers - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -46,7 +46,7 @@
     "dist"
   ],
   "dependencies": {
-    "@event-driven-io/emmett": "0.7.1",
+    "@event-driven-io/emmett": "0.8.0",
     "testcontainers": "^10.7.2"
   },
   "devDependencies": {

--- a/src/packages/emmett-testcontainers/src/eventStore/eventStoreDBContainer.ts
+++ b/src/packages/emmett-testcontainers/src/eventStore/eventStoreDBContainer.ts
@@ -6,36 +6,54 @@ import {
 } from 'testcontainers';
 import type { Environment } from 'testcontainers/build/types';
 
-const EVENTSTOREDB_PORT = 2113;
-const EVENTSTOREDB_TCP_PORT = 1113;
-const EVENTSTOREDB_TCP_PORTS = [EVENTSTOREDB_TCP_PORT, EVENTSTOREDB_PORT];
-const EVENTSTOREDB_IMAGE_NAME = 'eventstore/eventstore';
-const EVENTSTOREDB_IMAGE_TAG = '23.10.1-bookworm-slim';
+export const EVENTSTOREDB_PORT = 2113;
+export const EVENTSTOREDB_TCP_PORT = 1113;
+export const EVENTSTOREDB_TCP_PORTS = [
+  EVENTSTOREDB_TCP_PORT,
+  EVENTSTOREDB_PORT,
+];
+export const EVENTSTOREDB_IMAGE_NAME = 'eventstore/eventstore';
+export const EVENTSTOREDB_IMAGE_TAG = '23.10.1-bookworm-slim';
+export const EVENTSTOREDB_ARM64_IMAGE_TAG = '23.10.1-alpha-arm64v8';
+
+export const EVENTSTOREDB_DEFAULT_IMAGE = `${EVENTSTOREDB_IMAGE_NAME}:${process.arch !== 'arm64' ? EVENTSTOREDB_IMAGE_TAG : EVENTSTOREDB_ARM64_IMAGE_TAG}`;
+
+export type EventStoreDBContainerOptions = {
+  disableProjections?: boolean;
+  isSecure?: boolean;
+  useFileStorage?: boolean;
+  withoutReuse?: boolean;
+};
+
+export const defaultEventStoreDBContainerOptions: EventStoreDBContainerOptions =
+  {
+    disableProjections: false,
+    isSecure: false,
+    useFileStorage: false,
+    withoutReuse: false,
+  };
 
 export class EventStoreDBContainer extends GenericContainer {
   private readonly tcpPorts = EVENTSTOREDB_TCP_PORTS;
 
   constructor(
-    image = `${EVENTSTOREDB_IMAGE_NAME}:${EVENTSTOREDB_IMAGE_TAG}`,
-    runProjections = true,
-    isInsecure = true,
-    emptyDatabase = true,
-    withoutReuse = false,
+    image = EVENTSTOREDB_DEFAULT_IMAGE,
+    options: EventStoreDBContainerOptions = defaultEventStoreDBContainerOptions,
   ) {
     super(image);
 
     const environment: Environment = {
-      ...(runProjections
+      ...(!options.disableProjections
         ? {
             EVENTSTORE_RUN_PROJECTIONS: 'ALL',
           }
         : {}),
-      ...(isInsecure
+      ...(!options.isSecure
         ? {
             EVENTSTORE_INSECURE: 'true',
           }
         : {}),
-      ...(!emptyDatabase
+      ...(options.useFileStorage
         ? {
             EVENTSTORE_MEM_DB: 'false',
             EVENTSTORE_DB: '/data/integration-tests',
@@ -51,7 +69,7 @@ export class EventStoreDBContainer extends GenericContainer {
 
     this.withEnvironment(environment).withExposedPorts(...this.tcpPorts);
 
-    if (!withoutReuse) this.withReuse();
+    if (!options.withoutReuse) this.withReuse();
   }
 
   async start(): Promise<StartedEventStoreDBContainer> {

--- a/src/packages/emmett/package.json
+++ b/src/packages/emmett/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
That should make Mac M1 setup easier.

Also changed EventStoreDB test container options to be in the nested object and false by default. That should make them more straightforward.