### PR TITLE
Allow Custom `appendToStream` options when using `CommandHandler`

### DIFF
--- a/src/packages/emmett/src/commandHandling/handleCommand.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.ts
@@ -20,11 +20,11 @@ export const CommandHandler =
     getInitialState: () => State,
     mapToStreamId: (id: string) => string = (id) => id,
   ) =>
-  async (
-    eventStore: EventStore<StreamVersion>,
+  async <Store extends EventStore<StreamVersion>>(
+    eventStore: Store,
     id: string,
     handle: (state: State) => StreamEvent | StreamEvent[],
-    options?: {
+    options?: Parameters<Store['appendToStream']>[2] & {
       expectedStreamVersion?: ExpectedStreamVersion<StreamVersion>;
     },
   ): Promise<CommandHandlerResult<State, StreamVersion>> => {
@@ -68,6 +68,7 @@ export const CommandHandler =
       streamName,
       newEvents,
       {
+        ...options,
         expectedStreamVersion,
       },
     );


### PR DESCRIPTION
Updates the `CommandHandler` handle function to accept any custom options that are added to the `EventStore` implementation and pass them to the event store `appendToStream` function.

Example:

```typescript
// EventStore.ts
interface MyCustomOptions {
    project: (...) => ...
}

class CustomEventStore implements EventStore {
    // ...
    async appendToStream<EventType extends Event>(
        streamName: string,
        events: EventType[],
        options: AppendToStreamOptions<StreamVersion> & MyCustomOptions // options are a superset of defaults
    ) { ... }
}
```

Then when using `CommandHandler`:

```typescript
const handle = CommandHandler(...)

await handle(CustomEventStore, id, {
    expectedStreamVersion: ...,
    project: (...) => ... // and any other custom options in MyCustomOptions for `appendToStream`
}
```