### PR TITLE
Removed node packages usage in core Emmett package

### DIFF
--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -11,7 +11,7 @@
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "plugin:prettier/recommended"
   ],
-  "ignorePatterns": ["**/dist/", "**/lib/"],
+  "ignorePatterns": ["**/dist/", "**/lib/", "**/cache/"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2023,
@@ -25,8 +25,29 @@
       { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }
     ],
     "@typescript-eslint/no-misused-promises": ["off"],
-    "@typescript-eslint/prefer-namespace-keyword": "off"
+    "@typescript-eslint/prefer-namespace-keyword": "off",
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": ["**.spec.ts"],
+        "patterns": ["node:*"]
+      }
+    ]
   },
+  "overrides": [
+    {
+      "files": [
+        "**.spec.ts",
+        "packages/**/src/testing/**",
+        "docs/**",
+        "packages/emmett-esdb/**",
+        "packages/emmett-expressjs/**",
+        "packages/emmett-fastify/**",
+        "packages/emmett-testcontainers/**"
+      ],
+      "rules": { "no-restricted-imports": "off" }
+    }
+  ],
   "settings": {
     "import/resolver": {
       "typescript": {}

--- a/src/.prettierignore
+++ b/src/.prettierignore
@@ -1,2 +1,3 @@
 **/dist/
 **/lib/
+**/cache/

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@event-driven-io/core",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@event-driven-io/core",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "workspaces": [
         "packages/emmett",
         "packages/emmett-esdb",
@@ -16,8 +16,9 @@
       ],
       "devDependencies": {
         "@faker-js/faker": "8.4.1",
-        "@typescript-eslint/eslint-plugin": "7.4.0",
-        "@typescript-eslint/parser": "7.4.0",
+        "@types/uuid": "9.0.8",
+        "@typescript-eslint/eslint-plugin": "7.9.0",
+        "@typescript-eslint/parser": "7.9.0",
         "eslint": "8.57.0",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-prettier": "5.1.3",
@@ -29,6 +30,7 @@
         "tsup": "8.0.2",
         "tsx": "4.7.1",
         "typescript": "5.4.3",
+        "uuid": "9.0.1",
         "vitepress": "1.0.1"
       },
       "engines": {
@@ -789,6 +791,14 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.89.tgz",
       "integrity": "sha512-QlrE8QI5z62nfnkiUZysUsAaxWaTMoGqFVcB3PvK1WxJ0c699bacErV4Fabe9Hki6ZnaHalgzihLbTl2d34XfQ=="
     },
+    "node_modules/@eventstore/db-client/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@faker-js/faker": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz",
@@ -1512,12 +1522,6 @@
       "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
       "peer": true
     },
-    "node_modules/@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
-    },
     "node_modules/@types/linkify-it": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
@@ -1576,12 +1580,6 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "peer": true
-    },
-    "node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-      "dev": true
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
@@ -1649,6 +1647,11 @@
         "@types/superagent": "^8.1.0"
       }
     },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
+    },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.20",
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
@@ -1656,22 +1659,20 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.4.0.tgz",
-      "integrity": "sha512-yHMQ/oFaM7HZdVrVm/M2WHaNPgyuJH4WelkSVEWSSsir34kxW2kDJCxlXRhhGWEsMN0WAW/vLpKfKVcm8k+MPw==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.9.0.tgz",
+      "integrity": "sha512-6e+X0X3sFe/G/54aC3jt0txuMTURqLyekmEHViqyA2VnxhLMpvA6nqmcjIy+Cr9tLDHPssA74BP5Mx9HQIxBEA==",
       "dev": true,
       "dependencies": {
-        "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "7.4.0",
-        "@typescript-eslint/type-utils": "7.4.0",
-        "@typescript-eslint/utils": "7.4.0",
-        "@typescript-eslint/visitor-keys": "7.4.0",
-        "debug": "^4.3.4",
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "7.9.0",
+        "@typescript-eslint/type-utils": "7.9.0",
+        "@typescript-eslint/utils": "7.9.0",
+        "@typescript-eslint/visitor-keys": "7.9.0",
         "graphemer": "^1.4.0",
-        "ignore": "^5.2.4",
+        "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -1691,15 +1692,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.4.0.tgz",
-      "integrity": "sha512-ZvKHxHLusweEUVwrGRXXUVzFgnWhigo4JurEj0dGF1tbcGh6buL+ejDdjxOQxv6ytcY1uhun1p2sm8iWStlgLQ==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.9.0.tgz",
+      "integrity": "sha512-qHMJfkL5qvgQB2aLvhUSXxbK7OLnDkwPzFalg458pxQgfxKDfT1ZDbHQM/I6mDIf/svlMkj21kzKuQ2ixJlatQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.4.0",
-        "@typescript-eslint/types": "7.4.0",
-        "@typescript-eslint/typescript-estree": "7.4.0",
-        "@typescript-eslint/visitor-keys": "7.4.0",
+        "@typescript-eslint/scope-manager": "7.9.0",
+        "@typescript-eslint/types": "7.9.0",
+        "@typescript-eslint/typescript-estree": "7.9.0",
+        "@typescript-eslint/visitor-keys": "7.9.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1719,13 +1720,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.4.0.tgz",
-      "integrity": "sha512-68VqENG5HK27ypafqLVs8qO+RkNc7TezCduYrx8YJpXq2QGZ30vmNZGJJJC48+MVn4G2dCV8m5ZTVnzRexTVtw==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.9.0.tgz",
+      "integrity": "sha512-ZwPK4DeCDxr3GJltRz5iZejPFAAr4Wk3+2WIBaj1L5PYK5RgxExu/Y68FFVclN0y6GGwH8q+KgKRCvaTmFBbgQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.4.0",
-        "@typescript-eslint/visitor-keys": "7.4.0"
+        "@typescript-eslint/types": "7.9.0",
+        "@typescript-eslint/visitor-keys": "7.9.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -1736,15 +1737,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.4.0.tgz",
-      "integrity": "sha512-247ETeHgr9WTRMqHbbQdzwzhuyaJ8dPTuyuUEMANqzMRB1rj/9qFIuIXK7l0FX9i9FXbHeBQl/4uz6mYuCE7Aw==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.9.0.tgz",
+      "integrity": "sha512-6Qy8dfut0PFrFRAZsGzuLoM4hre4gjzWJB6sUvdunCYZsYemTkzZNwF1rnGea326PHPT3zn5Lmg32M/xfJfByA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.4.0",
-        "@typescript-eslint/utils": "7.4.0",
+        "@typescript-eslint/typescript-estree": "7.9.0",
+        "@typescript-eslint/utils": "7.9.0",
         "debug": "^4.3.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -1763,9 +1764,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.4.0.tgz",
-      "integrity": "sha512-mjQopsbffzJskos5B4HmbsadSJQWaRK0UxqQ7GuNA9Ga4bEKeiO6b2DnB6cM6bpc8lemaPseh0H9B/wyg+J7rw==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.9.0.tgz",
+      "integrity": "sha512-oZQD9HEWQanl9UfsbGVcZ2cGaR0YT5476xfWE0oE5kQa2sNK2frxOlkeacLOTh9po4AlUT5rtkGyYM5kew0z5w==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -1776,19 +1777,19 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.4.0.tgz",
-      "integrity": "sha512-A99j5AYoME/UBQ1ucEbbMEmGkN7SE0BvZFreSnTd1luq7yulcHdyGamZKizU7canpGDWGJ+Q6ZA9SyQobipePg==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.9.0.tgz",
+      "integrity": "sha512-zBCMCkrb2YjpKV3LA0ZJubtKCDxLttxfdGmwZvTqqWevUPN0FZvSI26FalGFFUZU/9YQK/A4xcQF9o/VVaCKAg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.4.0",
-        "@typescript-eslint/visitor-keys": "7.4.0",
+        "@typescript-eslint/types": "7.9.0",
+        "@typescript-eslint/visitor-keys": "7.9.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -1804,18 +1805,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.4.0.tgz",
-      "integrity": "sha512-NQt9QLM4Tt8qrlBVY9lkMYzfYtNz8/6qwZg8pI3cMGlPnj6mOpRxxAm7BMJN9K0AiY+1BwJ5lVC650YJqYOuNg==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.9.0.tgz",
+      "integrity": "sha512-5KVRQCzZajmT4Ep+NEgjXCvjuypVvYHUW7RHlXzNPuak2oWpVoD1jf5xCP0dPAuNIchjC7uQyvbdaSTFaLqSdA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "7.4.0",
-        "@typescript-eslint/types": "7.4.0",
-        "@typescript-eslint/typescript-estree": "7.4.0",
-        "semver": "^7.5.4"
+        "@typescript-eslint/scope-manager": "7.9.0",
+        "@typescript-eslint/types": "7.9.0",
+        "@typescript-eslint/typescript-estree": "7.9.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -1829,13 +1827,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.4.0.tgz",
-      "integrity": "sha512-0zkC7YM0iX5Y41homUUeW1CHtZR01K3ybjM1l6QczoMuay0XKtrb93kv95AxUGwdjGr64nNqnOCwmEl616N8CA==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.9.0.tgz",
+      "integrity": "sha512-iESPx2TNLDNGQLyjKhUvIKprlP49XNEK+MvIf9nIO7ZZaZdbnfWKHnXAgufpxqfA0YryH8XToi4+CjBgVnFTSQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.4.0",
-        "eslint-visitor-keys": "^3.4.1"
+        "@typescript-eslint/types": "7.9.0",
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -5009,9 +5007,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -7157,9 +7155,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -8014,20 +8016,21 @@
     },
     "packages/emmett": {
       "name": "@event-driven-io/emmett",
-      "version": "0.8.0",
-      "devDependencies": {},
+      "version": "0.9.0",
       "peerDependencies": {
-        "@types/node": "^20.11.30"
+        "@types/node": "^20.11.30",
+        "@types/uuid": "9.0.8",
+        "uuid": "9.0.1"
       }
     },
     "packages/emmett-esdb": {
       "name": "@event-driven-io/emmett-esdb",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "devDependencies": {
         "@event-driven-io/emmett-testcontainers": "^0.5.0"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.8.0",
+        "@event-driven-io/emmett": "0.9.0",
         "@eventstore/db-client": "^6.1.0"
       }
     },
@@ -8049,10 +8052,10 @@
     },
     "packages/emmett-expressjs": {
       "name": "@event-driven-io/emmett-expressjs",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "devDependencies": {},
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.8.0",
+        "@event-driven-io/emmett": "0.9.0",
         "@types/express": "4.17.21",
         "@types/supertest": "6.0.2",
         "express": "4.19.2",
@@ -8063,10 +8066,10 @@
     },
     "packages/emmett-fastify": {
       "name": "@event-driven-io/emmett-fastify",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "devDependencies": {},
       "peerDependencies": {
-        "@event-driven-io/emmett": "^0.8.0",
+        "@event-driven-io/emmett": "^0.9.0",
         "@fastify/compress": "7.0.0",
         "@fastify/etag": "5.1.0",
         "@fastify/formbody": "7.4.0",
@@ -8076,9 +8079,9 @@
     },
     "packages/emmett-testcontainers": {
       "name": "@event-driven-io/emmett-testcontainers",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
-        "@event-driven-io/emmett": "0.8.0",
+        "@event-driven-io/emmett": "0.9.0",
         "testcontainers": "^10.7.2"
       },
       "devDependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/core",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Emmett - Event Sourcing development made simple",
   "engines": {
     "node": ">=20.11.1"
@@ -62,8 +62,9 @@
   ],
   "devDependencies": {
     "@faker-js/faker": "8.4.1",
-    "@typescript-eslint/eslint-plugin": "7.4.0",
-    "@typescript-eslint/parser": "7.4.0",
+    "@types/uuid": "9.0.8",
+    "@typescript-eslint/eslint-plugin": "7.9.0",
+    "@typescript-eslint/parser": "7.9.0",
     "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-prettier": "5.1.3",
@@ -75,11 +76,12 @@
     "tsup": "8.0.2",
     "tsx": "4.7.1",
     "typescript": "5.4.3",
+    "uuid": "9.0.1",
     "vitepress": "1.0.1"
   },
   "peerDependencies": {
-    "@types/node": "20.11.30",
     "@types/express": "4.17.21",
+    "@types/node": "20.11.30",
     "@types/supertest": "6.0.2",
     "supertest": "6.3.4"
   },

--- a/src/packages/emmett-esdb/package.json
+++ b/src/packages/emmett-esdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-esdb",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Emmett - EventStoreDB - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -50,7 +50,7 @@
     "@event-driven-io/emmett-testcontainers": "^0.5.0"
   },
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.8.0",
+    "@event-driven-io/emmett": "0.9.0",
     "@eventstore/db-client": "^6.1.0"
   }
 }

--- a/src/packages/emmett-expressjs/package.json
+++ b/src/packages/emmett-expressjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-expressjs",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -48,7 +48,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.8.0",
+    "@event-driven-io/emmett": "0.9.0",
     "@types/express": "4.17.21",
     "@types/supertest": "6.0.2",
     "express": "4.19.2",

--- a/src/packages/emmett-fastify/package.json
+++ b/src/packages/emmett-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-fastify",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -52,7 +52,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "@event-driven-io/emmett": "^0.8.0",
+    "@event-driven-io/emmett": "^0.9.0",
     "fastify": "4.26.2",
     "@fastify/compress": "7.0.0",
     "@fastify/etag": "5.1.0",

--- a/src/packages/emmett-testcontainers/package.json
+++ b/src/packages/emmett-testcontainers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-testcontainers",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Emmett - TestContainers - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -46,7 +46,7 @@
     "dist"
   ],
   "dependencies": {
-    "@event-driven-io/emmett": "0.8.0",
+    "@event-driven-io/emmett": "0.9.0",
     "testcontainers": "^10.7.2"
   },
   "devDependencies": {

--- a/src/packages/emmett/package.json
+++ b/src/packages/emmett/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -45,8 +45,9 @@
   "files": [
     "dist"
   ],
-  "devDependencies": {},
   "peerDependencies": {
-    "@types/node": "^20.11.30"
+    "@types/node": "^20.11.30",
+    "@types/uuid": "9.0.8",
+    "uuid": "9.0.1"
   }
 }

--- a/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
+++ b/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { v4 as randomUUID } from 'uuid';
 import type { Event } from '../typing';
 import {
   type AggregateStreamOptions,


### PR DESCRIPTION
Removed the accidental usage of `randomUUID` function from `node:crypto` package that was causing compatibility issues on frontend.

Added also the ESLint rule to prevent such things to happen in the future.

Bumped version to 0.9.0

Fixes #64