### PR TITLE
Extended thenThrows in DeciderSpecification to handle type checks

### DIFF
--- a/src/packages/emmett/src/errors/index.ts
+++ b/src/packages/emmett/src/errors/index.ts
@@ -1,5 +1,24 @@
 import { isNumber, isString } from '../validation';
 
+export type ErrorConstructor<ErrorType extends Error> = new (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ...args: any[]
+) => ErrorType;
+
+export const isErrorConstructor = <ErrorType extends Error>(
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  expect: Function,
+): expect is ErrorConstructor<ErrorType> => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return (
+    typeof expect === 'function' &&
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect.prototype &&
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect.prototype.constructor === expect
+  );
+};
+
 export class EmmettError extends Error {
   public errorCode: number;
 

--- a/src/packages/emmett/src/testing/deciderSpecification.unit.spec.ts
+++ b/src/packages/emmett/src/testing/deciderSpecification.unit.spec.ts
@@ -1,0 +1,159 @@
+import { describe, it } from 'node:test';
+
+import assert, { AssertionError } from 'node:assert';
+import { IllegalStateError, ValidationError } from '../errors';
+import { type Command, type Event } from '../typing';
+import { DeciderSpecification } from './deciderSpecification';
+
+type DoSomething = Command<'Do', { something: string }>;
+type SomethingHappened = Event<'Did', { something: string }>;
+type Entity = { something: string };
+
+const decide = (
+  { data: { something } }: DoSomething,
+  _entity: Entity,
+): SomethingHappened => {
+  if (something !== 'Yes!') throw new IllegalStateError('Nope!');
+
+  return { type: 'Did', data: { something } };
+};
+
+const getInitialState = (): Entity => ({ something: 'Meh' });
+
+const evolve = (_entity: Entity, _event: SomethingHappened): Entity => ({
+  something: 'Nothing',
+});
+
+const given = DeciderSpecification.for({
+  decide: decide,
+  evolve,
+  initialState: getInitialState,
+});
+
+void describe('DeciderSpecification', () => {
+  void describe('thenThrows', () => {
+    void it('check error was thrown', () => {
+      given([])
+        .when({
+          type: 'Do',
+          data: {
+            something: 'Nope!',
+          },
+        })
+        .thenThrows();
+    });
+
+    void it('checks error condition', () => {
+      given([])
+        .when({
+          type: 'Do',
+          data: {
+            something: 'Nope!',
+          },
+        })
+        .thenThrows((error) => error.message === 'Nope!');
+    });
+
+    void it('checks error type', () => {
+      given([])
+        .when({
+          type: 'Do',
+          data: {
+            something: 'Nope!',
+          },
+        })
+        .thenThrows(IllegalStateError);
+    });
+
+    void it('checks error type and condition', () => {
+      given([])
+        .when({
+          type: 'Do',
+          data: {
+            something: 'Nope!',
+          },
+        })
+        .thenThrows(IllegalStateError, (error) => error.message === 'Nope!');
+    });
+
+    void it('fails if no error was thrown', () => {
+      assert.throws(
+        () => {
+          given([])
+            .when({
+              type: 'Do',
+              data: {
+                something: 'Yes!',
+              },
+            })
+            .thenThrows();
+        },
+        (error) =>
+          error instanceof AssertionError &&
+          error.message === 'Handler did not fail as expected',
+      );
+    });
+
+    void it('fails if wrong error type', () => {
+      assert.throws(
+        () => {
+          given([])
+            .when({
+              type: 'Do',
+              data: {
+                something: 'Nope!',
+              },
+            })
+            .thenThrows(ValidationError);
+        },
+        (error) =>
+          error instanceof AssertionError &&
+          error.message.startsWith(
+            'Caught error is not an instance of the expected type:',
+          ),
+      );
+    });
+
+    void it('fails if wrong error type and correct condition', () => {
+      assert.throws(
+        () => {
+          given([])
+            .when({
+              type: 'Do',
+              data: {
+                something: 'Nope!',
+              },
+            })
+            .thenThrows(ValidationError, (error) => error.message === 'Nope!');
+        },
+        (error) =>
+          error instanceof AssertionError &&
+          error.message.startsWith(
+            'Caught error is not an instance of the expected type:',
+          ),
+      );
+    });
+
+    void it('fails if correct error type but wrong correct condition', () => {
+      assert.throws(
+        () => {
+          given([])
+            .when({
+              type: 'Do',
+              data: {
+                something: 'Nope!',
+              },
+            })
+            .thenThrows(
+              IllegalStateError,
+              (error) => error.message !== 'Nope!',
+            );
+        },
+        (error) =>
+          error instanceof AssertionError &&
+          error.message ==
+            `Error didn't match the error condition: Error: Nope!`,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Now it allows multiple options like:
- just checking if the error was thrown,
- if it is of the specified type,
- if matches condition,
- if it is of the specified type and matches the condition.