### PR TITLE
Requiring only partial problem details in expectError helper for API and Integration tests

### DIFF
--- a/src/packages/emmett-expressjs/src/testing/apiSpecification.ts
+++ b/src/packages/emmett-expressjs/src/testing/apiSpecification.ts
@@ -62,7 +62,7 @@ export const expectResponse =
 
 export const expectError = (
   errorCode: number,
-  problemDetails?: ProblemDocument,
+  problemDetails?: Partial<ProblemDocument>,
 ) =>
   expectResponse(
     errorCode,


### PR DESCRIPTION
Most of the time, you just want to check the problem details message; no need to repeat the whole problem details body.