### PR TITLE
Aligned initial state naming

### DIFF
--- a/src/docs/api-docs.md
+++ b/src/docs/api-docs.md
@@ -83,7 +83,7 @@ const { state, expectedStreamVersion } = await eventStore.aggregateStream(
   streamName,
   {
     evolve,
-    getInitialState,
+    initialState,
   },
 );
 

--- a/src/docs/getting-started.md
+++ b/src/docs/getting-started.md
@@ -103,7 +103,7 @@ Each event recorded due to the business logic is appended to the event stream. A
 The state aggregation can be coded as:
 
 ```ts
-const currentState = events.reduce<State>(evolve, getInitialState());
+const currentState = events.reduce<State>(evolve, initialState());
 ```
 
 For our case initial state can look like:
@@ -171,7 +171,7 @@ const { state, expectedStreamVersion } = await eventStore.aggregateStream(
   streamName,
   {
     evolve,
-    getInitialState,
+    initialState,
   },
 );
 

--- a/src/docs/snippets/gettingStarted/businessLogic.ts
+++ b/src/docs/snippets/gettingStarted/businessLogic.ts
@@ -12,7 +12,7 @@ import type {
   ShoppingCartConfirmed,
   ShoppingCartEvent,
 } from './events';
-import { evolve, getInitialState, type ShoppingCart } from './shoppingCart';
+import { evolve, initialState, type ShoppingCart } from './shoppingCart';
 
 // #region getting-started-business-logic
 import { EmmettError, IllegalStateError, sum } from '@event-driven-io/emmett';
@@ -148,6 +148,6 @@ export const decider: Decider<
 > = {
   decide,
   evolve,
-  getInitialState,
+  initialState,
 };
 // #endregion getting-started-business-logic-decider

--- a/src/docs/snippets/gettingStarted/businessLogic.unit.spec.ts
+++ b/src/docs/snippets/gettingStarted/businessLogic.unit.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import { decide } from './businessLogic';
-import { evolve, getInitialState } from './shoppingCart';
+import { evolve, initialState } from './shoppingCart';
 
 // #region getting-started-unit-tests
 import { DeciderSpecification } from '@event-driven-io/emmett';
@@ -10,7 +10,7 @@ import type { PricedProductItem } from './events';
 const given = DeciderSpecification.for({
   decide,
   evolve,
-  initialState: getInitialState,
+  initialState: initialState,
 });
 
 void describe('ShoppingCart', () => {

--- a/src/docs/snippets/gettingStarted/commandHandler.ts
+++ b/src/docs/snippets/gettingStarted/commandHandler.ts
@@ -1,6 +1,6 @@
 // #region command-handler
 import { CommandHandler } from '@event-driven-io/emmett';
-import { evolve, getInitialState } from './shoppingCart';
+import { evolve, initialState } from './shoppingCart';
 
-export const handle = CommandHandler(evolve, getInitialState);
+export const handle = CommandHandler(evolve, initialState);
 // #endregion command-handler

--- a/src/docs/snippets/gettingStarted/shoppingCart.ts
+++ b/src/docs/snippets/gettingStarted/shoppingCart.ts
@@ -24,7 +24,7 @@ export type ProductItems = Map<string, number>;
 // #endregion getting-started-state
 
 // #region getting-started-state-default
-export const getInitialState = (): ShoppingCart => {
+export const initialState = (): ShoppingCart => {
   return {
     status: 'Empty',
   };

--- a/src/docs/snippets/gettingStarted/webApi/addProductVerticalSlice.ts
+++ b/src/docs/snippets/gettingStarted/webApi/addProductVerticalSlice.ts
@@ -15,12 +15,12 @@ import {
 import { Router, type Request } from 'express';
 import type { ProductItemAddedToShoppingCart } from '../events';
 import { type PricedProductItem } from '../events';
-import { evolve, getInitialState, type ShoppingCart } from '../shoppingCart';
+import { evolve, initialState, type ShoppingCart } from '../shoppingCart';
 import { getShoppingCartId } from './simpleApi';
 
 // #region vertical-slice
 
-const handle = CommandHandler(evolve, getInitialState);
+const handle = CommandHandler(evolve, initialState);
 
 type AddProductItemRequest = Request<
   Partial<{ clientId: string; shoppingCartId: string }>,

--- a/src/docs/snippets/gettingStarted/webApi/shoppingCartApiSetup.ts
+++ b/src/docs/snippets/gettingStarted/webApi/shoppingCartApiSetup.ts
@@ -14,10 +14,10 @@ import { getShoppingCartId } from './simpleApi';
 // #region getting-started-api-setup
 import { type WebApiSetup } from '@event-driven-io/emmett-expressjs';
 import { Router } from 'express';
-import { evolve, getInitialState } from '../shoppingCart';
+import { evolve, initialState } from '../shoppingCart';
 
 // Let's setup the command handler, we'll use it in endpoints
-const handle = CommandHandler(evolve, getInitialState);
+const handle = CommandHandler(evolve, initialState);
 
 export const shoppingCartApi =
   (

--- a/src/docs/snippets/gettingStarted/webApi/shoppingCartEndpointWithOn.ts
+++ b/src/docs/snippets/gettingStarted/webApi/shoppingCartEndpointWithOn.ts
@@ -9,10 +9,10 @@ import { NoContent, on } from '@event-driven-io/emmett-expressjs';
 import { Router, type Request } from 'express';
 import { addProductItem } from '../businessLogic';
 import type { AddProductItemToShoppingCart } from '../commands';
-import { evolve, getInitialState } from '../shoppingCart';
+import { evolve, initialState } from '../shoppingCart';
 import { getShoppingCartId } from './simpleApi';
 
-const handle = CommandHandler(evolve, getInitialState);
+const handle = CommandHandler(evolve, initialState);
 const router: Router = Router();
 
 const getUnitPrice = (_productId: string) => {

--- a/src/docs/snippets/gettingStarted/webApi/simpleApi.ts
+++ b/src/docs/snippets/gettingStarted/webApi/simpleApi.ts
@@ -25,9 +25,9 @@ import type {
   RemoveProductItemFromShoppingCart,
 } from '../commands';
 import type { ProductItem, ShoppingCartEvent } from '../events';
-import { evolve, getInitialState, type ShoppingCart } from '../shoppingCart';
+import { evolve, initialState, type ShoppingCart } from '../shoppingCart';
 
-export const handle = CommandHandler(evolve, getInitialState);
+export const handle = CommandHandler(evolve, initialState);
 
 export const getShoppingCartId = (clientId: string) =>
   `shopping_cart:${assertNotEmptyString(clientId)}:current`;
@@ -157,7 +157,7 @@ export const shoppingCartApi =
           ShoppingCartEvent
         >(shoppingCartId, {
           evolve,
-          getInitialState,
+          initialState,
         });
 
         if (result === null) return NotFound();

--- a/src/e2e/esmCompatibility/app/counter.ts
+++ b/src/e2e/esmCompatibility/app/counter.ts
@@ -83,7 +83,7 @@ export const decide = (rawCommand: CounterCommand, state: Counter) => {
     .exhaustive();
 };
 
-export const getInitialState = () => {
+export const initialState = () => {
   return {
     status: 'opened',
     value: 0,
@@ -113,4 +113,4 @@ export const evolve = (state: Counter, event: CounterEvent) => {
     .exhaustive();
 };
 
-export const handle = CommandHandler(evolve, getInitialState);
+export const handle = CommandHandler(evolve, initialState);

--- a/src/e2e/esmCompatibility/server/routes/counter/[streamId]/index.get.ts
+++ b/src/e2e/esmCompatibility/server/routes/counter/[streamId]/index.get.ts
@@ -1,4 +1,4 @@
-import { evolve, getInitialState } from '~/app/counter';
+import { evolve, initialState } from '~/app/counter';
 import { eventStore } from '~/app/event-store';
 
 export default eventHandler(async (event) => {
@@ -9,7 +9,7 @@ export default eventHandler(async (event) => {
   }
   const state = await eventStore.aggregateStream(streamId, {
     evolve,
-    getInitialState,
+    initialState,
   });
 
   return state;

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@event-driven-io/core",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@event-driven-io/core",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "workspaces": [
         "packages/emmett",
         "packages/emmett-esdb",
@@ -8058,7 +8058,7 @@
     },
     "packages/emmett": {
       "name": "@event-driven-io/emmett",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "devDependencies": {
         "@types/node": "^20.11.30"
       },
@@ -8072,12 +8072,12 @@
     },
     "packages/emmett-esdb": {
       "name": "@event-driven-io/emmett-esdb",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "devDependencies": {
         "@event-driven-io/emmett-testcontainers": "^0.5.0"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.9.0",
+        "@event-driven-io/emmett": "0.10.0",
         "@eventstore/db-client": "^6.1.0"
       }
     },
@@ -8099,10 +8099,10 @@
     },
     "packages/emmett-expressjs": {
       "name": "@event-driven-io/emmett-expressjs",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "devDependencies": {},
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.9.0",
+        "@event-driven-io/emmett": "0.10.0",
         "@types/express": "4.17.21",
         "@types/supertest": "6.0.2",
         "express": "4.19.2",
@@ -8113,10 +8113,10 @@
     },
     "packages/emmett-fastify": {
       "name": "@event-driven-io/emmett-fastify",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "devDependencies": {},
       "peerDependencies": {
-        "@event-driven-io/emmett": "^0.9.0",
+        "@event-driven-io/emmett": "^0.10.0",
         "@fastify/compress": "7.0.0",
         "@fastify/etag": "5.1.0",
         "@fastify/formbody": "7.4.0",
@@ -8126,9 +8126,9 @@
     },
     "packages/emmett-testcontainers": {
       "name": "@event-driven-io/emmett-testcontainers",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
-        "@event-driven-io/emmett": "0.9.0",
+        "@event-driven-io/emmett": "0.10.0",
         "testcontainers": "^10.7.2"
       },
       "devDependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/core",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Emmett - Event Sourcing development made simple",
   "engines": {
     "node": ">=20.11.1"

--- a/src/packages/emmett-esdb/package.json
+++ b/src/packages/emmett-esdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-esdb",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Emmett - EventStoreDB - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -50,7 +50,7 @@
     "@event-driven-io/emmett-testcontainers": "^0.5.0"
   },
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.9.0",
+    "@event-driven-io/emmett": "0.10.0",
     "@eventstore/db-client": "^6.1.0"
   }
 }

--- a/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.ts
+++ b/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.ts
@@ -57,11 +57,11 @@ export const getEventStoreDBEventStore = (
       options: AggregateStreamOptions<State, EventType>,
     ): Promise<AggregateStreamResult<State> | null> {
       try {
-        const { evolve, getInitialState, read } = options;
+        const { evolve, initialState, read } = options;
 
         const expectedStreamVersion = read?.expectedStreamVersion;
 
-        let state = getInitialState();
+        let state = initialState();
         let currentStreamVersion: bigint | undefined = undefined;
 
         for await (const { event } of eventStore.readStream(

--- a/src/packages/emmett-expressjs/package.json
+++ b/src/packages/emmett-expressjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-expressjs",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -48,7 +48,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.9.0",
+    "@event-driven-io/emmett": "0.10.0",
     "@types/express": "4.17.21",
     "@types/supertest": "6.0.2",
     "express": "4.19.2",

--- a/src/packages/emmett-expressjs/src/e2e/decider/businessLogic.ts
+++ b/src/packages/emmett-expressjs/src/e2e/decider/businessLogic.ts
@@ -185,5 +185,5 @@ export const decider: Decider<
 > = {
   decide,
   evolve,
-  getInitialState: () => emptyShoppingCart,
+  initialState: () => emptyShoppingCart,
 };

--- a/src/packages/emmett-fastify/package.json
+++ b/src/packages/emmett-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-fastify",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -52,7 +52,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "@event-driven-io/emmett": "^0.9.0",
+    "@event-driven-io/emmett": "^0.10.0",
     "fastify": "4.26.2",
     "@fastify/compress": "7.0.0",
     "@fastify/etag": "5.1.0",

--- a/src/packages/emmett-fastify/src/e2e/decider/businessLogic.ts
+++ b/src/packages/emmett-fastify/src/e2e/decider/businessLogic.ts
@@ -185,5 +185,5 @@ export const decider: Decider<
 > = {
   decide,
   evolve,
-  getInitialState: () => emptyShoppingCart,
+  initialState: () => emptyShoppingCart,
 };

--- a/src/packages/emmett-testcontainers/package.json
+++ b/src/packages/emmett-testcontainers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-testcontainers",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Emmett - TestContainers - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -46,7 +46,7 @@
     "dist"
   ],
   "dependencies": {
-    "@event-driven-io/emmett": "0.9.0",
+    "@event-driven-io/emmett": "0.10.0",
     "testcontainers": "^10.7.2"
   },
   "devDependencies": {

--- a/src/packages/emmett/package.json
+++ b/src/packages/emmett/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",

--- a/src/packages/emmett/src/commandHandling/handleCommand.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.ts
@@ -21,7 +21,7 @@ export type CommandHandlerResult<
 export const CommandHandler =
   <State, StreamEvent extends Event, StreamVersion = DefaultStreamVersionType>(
     evolve: (state: State, event: StreamEvent) => State,
-    getInitialState: () => State,
+    initialState: () => State,
     mapToStreamId: (id: string) => string = (id) => id,
   ) =>
   async <Store extends EventStore<StreamVersion>>(
@@ -40,7 +40,7 @@ export const CommandHandler =
       StreamEvent
     >(streamName, {
       evolve,
-      getInitialState,
+      initialState,
       read: {
         // expected stream version is passed to fail fast
         // if stream is in the wrong state
@@ -50,7 +50,7 @@ export const CommandHandler =
     });
 
     // 2. Use the aggregate state or the initial one (when e.g. stream does not exist)
-    const state = aggregationResult?.state ?? getInitialState();
+    const state = aggregationResult?.state ?? initialState();
     const currentStreamVersion = aggregationResult?.currentStreamVersion;
 
     // 3. Run business logic

--- a/src/packages/emmett/src/commandHandling/handleCommand.unit.spec.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.unit.spec.ts
@@ -43,7 +43,7 @@ const evolve = (
   }
 };
 
-const getInitialState = (): ShoppingCart => {
+const initialState = (): ShoppingCart => {
   return { productItems: [], totalAmount: 0 };
 };
 
@@ -81,7 +81,7 @@ const addProductItemWithDiscount = (
 
 const handleCommand = CommandHandler<ShoppingCart, ShoppingCartEvent>(
   evolve,
-  getInitialState,
+  initialState,
 );
 
 void describe('Command Handler', () => {

--- a/src/packages/emmett/src/commandHandling/handleCommandWithDecider.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommandWithDecider.ts
@@ -15,11 +15,7 @@ export const DeciderCommandHandler =
     StreamEvent extends Event,
     StreamVersion = DefaultStreamVersionType,
   >(
-    {
-      decide,
-      evolve,
-      getInitialState,
-    }: Decider<State, CommandType, StreamEvent>,
+    { decide, evolve, initialState }: Decider<State, CommandType, StreamEvent>,
     mapToStreamId: (id: string) => string = (id) => id,
   ) =>
   async (
@@ -32,7 +28,7 @@ export const DeciderCommandHandler =
   ) =>
     CommandHandler<State, StreamEvent, StreamVersion>(
       evolve,
-      getInitialState,
+      initialState,
       mapToStreamId,
     )(eventStore, id, (state) => decide(command, state), options);
 // #endregion command-handler

--- a/src/packages/emmett/src/eventStore/eventStore.ts
+++ b/src/packages/emmett/src/eventStore/eventStore.ts
@@ -80,7 +80,7 @@ export type AggregateStreamOptions<
   ReadEventMetadataType extends ReadEventMetadata = ReadEventMetadata,
 > = {
   evolve: Evolve<State, EventType, ReadEventMetadataType>;
-  getInitialState: () => State;
+  initialState: () => State;
   read?: ReadStreamOptions<StreamVersion>;
 };
 

--- a/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
+++ b/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
@@ -37,7 +37,7 @@ export const getInMemoryEventStore = (): EventStore<
       streamName: string,
       options: AggregateStreamOptions<State, EventType>,
     ): Promise<AggregateStreamResult<State> | null> {
-      const { evolve, getInitialState, read } = options;
+      const { evolve, initialState, read } = options;
 
       const result = await this.readStream<EventType>(streamName, read);
 
@@ -47,7 +47,7 @@ export const getInMemoryEventStore = (): EventStore<
 
       return {
         currentStreamVersion: BigInt(events.length),
-        state: events.reduce(evolve, getInitialState()),
+        state: events.reduce(evolve, initialState()),
       };
     },
 

--- a/src/packages/emmett/src/testing/deciderSpecification.unit.spec.ts
+++ b/src/packages/emmett/src/testing/deciderSpecification.unit.spec.ts
@@ -17,7 +17,7 @@ const decide = (
   return { type: 'Did', data: { something } };
 };
 
-const getInitialState = (): Entity => ({ something: 'Meh' });
+const initialState = (): Entity => ({ something: 'Meh' });
 
 const evolve = (_entity: Entity, _event: SomethingHappened): Entity => ({
   something: 'Nothing',
@@ -26,7 +26,7 @@ const evolve = (_entity: Entity, _event: SomethingHappened): Entity => ({
 const given = DeciderSpecification.for({
   decide: decide,
   evolve,
-  initialState: getInitialState,
+  initialState: initialState,
 });
 
 void describe('DeciderSpecification', () => {

--- a/src/packages/emmett/src/testing/features.ts
+++ b/src/packages/emmett/src/testing/features.ts
@@ -5,7 +5,7 @@ import { assertDeepEqual, assertEqual, assertOk } from './assertions';
 import {
   evolve,
   evolveWithMetadata,
-  getInitialState,
+  initialState,
   type PricedProductItem,
   type ShoppingCartEvent,
 } from './shoppingCart.domain';
@@ -66,17 +66,17 @@ export async function testAggregateStream(
         // when
         const resultAt1 = await eventStore.aggregateStream(shoppingCartId, {
           evolve: testCase.evolve,
-          getInitialState,
+          initialState,
           read: { to: 1n },
         });
         const resultAt2 = await eventStore.aggregateStream(shoppingCartId, {
           evolve: testCase.evolve,
-          getInitialState,
+          initialState,
           read: { to: 2n },
         });
         const resultAt3 = await eventStore.aggregateStream(shoppingCartId, {
           evolve: testCase.evolve,
-          getInitialState,
+          initialState,
           read: { to: 3n },
         });
 

--- a/src/packages/emmett/src/testing/shoppingCart.domain.ts
+++ b/src/packages/emmett/src/testing/shoppingCart.domain.ts
@@ -61,6 +61,6 @@ export const evolveWithMetadata = (
   }
 };
 
-export const getInitialState = (): ShoppingCart => {
+export const initialState = (): ShoppingCart => {
   return { productItems: [], totalAmount: 0 };
 };

--- a/src/packages/emmett/src/typing/decider.ts
+++ b/src/packages/emmett/src/typing/decider.ts
@@ -7,5 +7,5 @@ export type Decider<
 > = {
   decide: (command: CommandType, state: State) => StreamEvent | StreamEvent[];
   evolve: (currentState: State, event: StreamEvent) => State;
-  getInitialState: () => State;
+  initialState: () => State;
 };

--- a/src/packages/emmett/src/typing/workflow.ts
+++ b/src/packages/emmett/src/typing/workflow.ts
@@ -10,7 +10,7 @@ export type Workflow<
 > = {
   decide: (command: Input, state: State) => WorkflowOutput<Output>[];
   evolve: (currentState: State, event: WorkflowEvent<Output>) => State;
-  getInitialState: () => State;
+  initialState: () => State;
 };
 
 export type WorkflowEvent<Output extends Command | Event> = Extract<


### PR DESCRIPTION
It wasn't consistent, sometimes it was called initialState, sometimes getInitialState.

Bumped to 0.10.0.