### PR TITLE
Exposed WrapEventStore and TestEventStream

### DIFF
--- a/src/packages/emmett-expressjs/src/testing/apiE2ESpecification.ts
+++ b/src/packages/emmett-expressjs/src/testing/apiE2ESpecification.ts
@@ -4,9 +4,9 @@ import type {
   DefaultStreamVersionType,
   EventStore,
 } from '@event-driven-io/emmett';
+import { WrapEventStore } from '@event-driven-io/emmett';
 import assert from 'assert';
 import type { Application } from 'express';
-import { WrapEventStore } from './utils';
 import type { TestRequest } from './apiSpecification';
 
 export type E2EResponseAssert = (response: Response) => boolean | void;

--- a/src/packages/emmett-expressjs/src/testing/apiSpecification.ts
+++ b/src/packages/emmett-expressjs/src/testing/apiSpecification.ts
@@ -1,17 +1,18 @@
 import {
+  WrapEventStore,
   assertEqual,
   assertFails,
   assertMatches,
   type DefaultStreamVersionType,
   type Event,
   type EventStore,
+  type TestEventStream,
 } from '@event-driven-io/emmett';
 import { type Application } from 'express';
 import type { ProblemDocument } from 'http-problem-details';
 import type { Response, Test } from 'supertest';
 import supertest from 'supertest';
 import type TestAgent from 'supertest/lib/agent';
-import { WrapEventStore, type TestEventStream } from './utils';
 
 ////////////////////////////////
 /////////// Setup

--- a/src/packages/emmett-expressjs/tsconfig.json
+++ b/src/packages/emmett-expressjs/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.shared.json",
-  "include": ["./src/**/*"],
+  "include": ["./src/**/*", "../emmett/src/testing/utils.ts"],
   "compilerOptions": {
     "composite": true,
     "outDir": "./dist" /* Redirect output structure to the directory. */,

--- a/src/packages/emmett/src/testing/assertions.ts
+++ b/src/packages/emmett/src/testing/assertions.ts
@@ -10,6 +10,9 @@ export const isSubset = (superObj: unknown, subObj: unknown): boolean => {
   const sup = superObj as DefaultRecord;
   const sub = subObj as DefaultRecord;
 
+  assertOk(sup);
+  assertOk(sub);
+
   return Object.keys(sub).every((ele: string) => {
     if (typeof sub[ele] == 'object') {
       return isSubset(sup[ele], sub[ele]);

--- a/src/packages/emmett/src/testing/index.ts
+++ b/src/packages/emmett/src/testing/index.ts
@@ -1,3 +1,3 @@
 export * from './assertions';
 export * from './deciderSpecification';
-export * from './shoppingCart.domain';
+export * from './wrapEventStore';

--- a/src/packages/emmett/src/testing/wrapEventStore.ts
+++ b/src/packages/emmett/src/testing/wrapEventStore.ts
@@ -4,11 +4,11 @@ import type {
   AppendToStreamOptions,
   AppendToStreamResult,
   DefaultStreamVersionType,
-  Event,
   EventStore,
   ReadStreamOptions,
   ReadStreamResult,
-} from '@event-driven-io/emmett';
+} from '../eventStore';
+import { type Event } from '../typing';
 
 export type TestEventStream<EventType extends Event = Event> = [
   string,


### PR DESCRIPTION
That will allow custom event store tracking to see appended events, e.g. for diagnostics or tests. @dilgerma fyi.

Improved also assertion for checking if one object is a subset of the other.