### PR TITLE
Fixed in-memory message bus declaration to correctly expose command and event processor methods

### DIFF
--- a/src/e2e/esmCompatibility/package-lock.json
+++ b/src/e2e/esmCompatibility/package-lock.json
@@ -1380,8 +1380,8 @@
       }
     },
     "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.1.tgz",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.2.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "optional": true,
       "engines": {
@@ -4398,7 +4398,7 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.1"
+        "@pkgjs/parseargs": "^0.11.2"
       }
     },
     "node_modules/jiti": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/core",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Emmett - Event Sourcing development made simple",
   "engines": {
     "node": ">=20.11.1"

--- a/src/packages/emmett-esdb/package.json
+++ b/src/packages/emmett-esdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-esdb",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Emmett - EventStoreDB - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -50,7 +50,7 @@
     "@event-driven-io/emmett-testcontainers": "^0.5.0"
   },
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.11.1",
+    "@event-driven-io/emmett": "0.11.2",
     "@eventstore/db-client": "^6.1.0"
   }
 }

--- a/src/packages/emmett-expressjs/package.json
+++ b/src/packages/emmett-expressjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-expressjs",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -48,7 +48,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.11.1",
+    "@event-driven-io/emmett": "0.11.2",
     "@types/express": "4.17.21",
     "@types/supertest": "6.0.2",
     "express": "4.19.2",

--- a/src/packages/emmett-fastify/package.json
+++ b/src/packages/emmett-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-fastify",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -52,7 +52,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "@event-driven-io/emmett": "^0.11.1",
+    "@event-driven-io/emmett": "^0.11.2",
     "fastify": "4.26.2",
     "@fastify/compress": "7.0.0",
     "@fastify/etag": "5.1.0",

--- a/src/packages/emmett-testcontainers/package.json
+++ b/src/packages/emmett-testcontainers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-testcontainers",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Emmett - TestContainers - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -46,7 +46,7 @@
     "dist"
   ],
   "dependencies": {
-    "@event-driven-io/emmett": "0.11.1",
+    "@event-driven-io/emmett": "0.11.2",
     "testcontainers": "^10.7.2"
   },
   "devDependencies": {

--- a/src/packages/emmett/package.json
+++ b/src/packages/emmett/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",

--- a/src/packages/emmett/src/messageBus/index.ts
+++ b/src/packages/emmett/src/messageBus/index.ts
@@ -72,7 +72,8 @@ export type MessageHandler = CommandHandler | EventHandler;
 export type MessageProcessor = EventProcessor | CommandProcessor;
 
 export const getInMemoryMessageBus = (): MessageBus &
-  MessageProcessor &
+  EventProcessor &
+  CommandProcessor &
   ScheduledMessageProcessor => {
   const allHandlers = new Map<string, MessageHandler[]>();
   let pendingMessages: ScheduledMessage[] = [];


### PR DESCRIPTION
By mistake I exposed previously just `MessageProcessor` declaration, which is not enough, as it can be either `CommandProcessor` or `EventProcessor`.

This doesn't give the proper typing as `InMemoryMessageBus` is `CommandProcessor` **AND** `EventProcessor`. 

Added explicit type declaration to `getInMemoryMessageBus` method.