### PR TITLE
Exposed custom projection builders and ProjectionDefinition types

### DIFF
--- a/samples/webApi/expressjs-with-postgresql/README.md
+++ b/samples/webApi/expressjs-with-postgresql/README.md
@@ -2,13 +2,13 @@
 
 ![](./docs/public/logo.png)
 
-# Emmett - Sample showing event-sourced WebApi with Express.js and EventStoreDB
+# Emmett - Sample showing event-sourced WebApi with Express.js and PostgreSQL
 
 Read more in [Emmett getting started guide](https://event-driven-io.github.io/emmett/getting-started.html).
 
 ## Prerequisities
 
-Sample require EventStoreDB, you can start it by running
+Sample require PostgreSQL, you can start it by running
 
 ```bash
 docker-compose up

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@event-driven-io/core",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@event-driven-io/core",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "workspaces": [
         "packages/emmett",
         "packages/emmett-postgresql",
@@ -8644,7 +8644,7 @@
     },
     "packages/emmett": {
       "name": "@event-driven-io/emmett",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "devDependencies": {
         "@types/node": "^20.11.30"
       },
@@ -8658,12 +8658,12 @@
     },
     "packages/emmett-esdb": {
       "name": "@event-driven-io/emmett-esdb",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "devDependencies": {
         "@event-driven-io/emmett-testcontainers": "^0.5.0"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.13.0",
+        "@event-driven-io/emmett": "0.14.0",
         "@eventstore/db-client": "^6.1.0"
       }
     },
@@ -8681,10 +8681,10 @@
     },
     "packages/emmett-expressjs": {
       "name": "@event-driven-io/emmett-expressjs",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "devDependencies": {},
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.13.0",
+        "@event-driven-io/emmett": "0.14.0",
         "@types/express": "4.17.21",
         "@types/supertest": "6.0.2",
         "express": "4.19.2",
@@ -8695,10 +8695,10 @@
     },
     "packages/emmett-fastify": {
       "name": "@event-driven-io/emmett-fastify",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "devDependencies": {},
       "peerDependencies": {
-        "@event-driven-io/emmett": "^0.13.0",
+        "@event-driven-io/emmett": "^0.14.0",
         "@fastify/compress": "7.0.0",
         "@fastify/etag": "5.1.0",
         "@fastify/formbody": "7.4.0",
@@ -8708,7 +8708,7 @@
     },
     "packages/emmett-postgresql": {
       "name": "@event-driven-io/emmett-postgresql",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "dependencies": {
         "@testcontainers/postgresql": "^10.10.3"
       },
@@ -8717,7 +8717,7 @@
       },
       "peerDependencies": {
         "@event-driven-io/dumbo": "0.4.1",
-        "@event-driven-io/emmett": "0.13.0",
+        "@event-driven-io/emmett": "0.14.0",
         "@event-driven-io/pongo": "0.7.0",
         "@types/pg": "^8.11.6",
         "@types/pg-format": "^1.0.5",
@@ -8739,9 +8739,9 @@
     },
     "packages/emmett-testcontainers": {
       "name": "@event-driven-io/emmett-testcontainers",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "dependencies": {
-        "@event-driven-io/emmett": "0.13.0",
+        "@event-driven-io/emmett": "0.14.0",
         "testcontainers": "^10.7.2"
       },
       "devDependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/core",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Emmett - Event Sourcing development made simple",
   "engines": {
     "node": ">=20.11.1"

--- a/src/packages/emmett-esdb/package.json
+++ b/src/packages/emmett-esdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-esdb",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Emmett - EventStoreDB - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -50,7 +50,7 @@
     "@event-driven-io/emmett-testcontainers": "^0.5.0"
   },
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.13.0",
+    "@event-driven-io/emmett": "0.14.0",
     "@eventstore/db-client": "^6.1.0"
   }
 }

--- a/src/packages/emmett-expressjs/package.json
+++ b/src/packages/emmett-expressjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-expressjs",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -48,7 +48,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.13.0",
+    "@event-driven-io/emmett": "0.14.0",
     "@types/express": "4.17.21",
     "@types/supertest": "6.0.2",
     "express": "4.19.2",

--- a/src/packages/emmett-fastify/package.json
+++ b/src/packages/emmett-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-fastify",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -52,7 +52,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "@event-driven-io/emmett": "^0.13.0",
+    "@event-driven-io/emmett": "^0.14.0",
     "fastify": "4.26.2",
     "@fastify/compress": "7.0.0",
     "@fastify/etag": "5.1.0",

--- a/src/packages/emmett-postgresql/package.json
+++ b/src/packages/emmett-postgresql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-postgresql",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Emmett - PostgreSQL - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -52,7 +52,7 @@
     "@event-driven-io/emmett-testcontainers": "^0.5.0"
   },
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.13.0",
+    "@event-driven-io/emmett": "0.14.0",
     "@types/pg": "^8.11.6",
     "@types/pg-format": "^1.0.5",
     "pg": "^8.12.0",

--- a/src/packages/emmett-postgresql/src/eventStore/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/index.ts
@@ -1,2 +1,3 @@
 export * from './postgreSQLEventStore';
+export * from './projections';
 export * from './schema';

--- a/src/packages/emmett-testcontainers/package.json
+++ b/src/packages/emmett-testcontainers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-testcontainers",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Emmett - TestContainers - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -46,7 +46,7 @@
     "dist"
   ],
   "dependencies": {
-    "@event-driven-io/emmett": "0.13.0",
+    "@event-driven-io/emmett": "0.14.0",
     "testcontainers": "^10.7.2"
   },
   "devDependencies": {

--- a/src/packages/emmett/package.json
+++ b/src/packages/emmett/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
It appeared that ProjectionDefinition types were not exposed and that caused issues with setting up custom projections.

Added builders to make that easier.

Reshaped also ProjectionDefnition helper method moving connection string and client to second context parameter. Thanks to that users that don't need it will have a simpler handle method definition.