### PR TITLE
Support for an async `decide` / `handle` function for `CommandHandler`

### DIFF
--- a/src/packages/emmett/src/commandHandling/handleCommand.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.ts
@@ -27,7 +27,7 @@ export const CommandHandler =
   async <Store extends EventStore<StreamVersion>>(
     eventStore: Store,
     id: string,
-    handle: (state: State) => StreamEvent | StreamEvent[],
+    handle: (state: State) => StreamEvent | StreamEvent[] | Promise<StreamEvent> | Promise<StreamEvent[]>,
     options?: Parameters<Store['appendToStream']>[2] & {
       expectedStreamVersion?: ExpectedStreamVersion<StreamVersion>;
     },
@@ -54,7 +54,7 @@ export const CommandHandler =
     const currentStreamVersion = aggregationResult?.currentStreamVersion;
 
     // 3. Run business logic
-    const result = handle(state);
+    const result = await handle(state);
 
     const newEvents = Array.isArray(result) ? result : [result];
 


### PR DESCRIPTION
IRT: https://discord.com/channels/1211601942984532018/1270107659755847772/1270107980100145203

I am utilizing the built-in `CommandHandler` and have some business logic that requires me to pull data from an external source that will have to be `async`.  Basically, it's checking whether a person attempting to perform an action is within a certain group, that depends on my event sourced model's properties, but this group's users change frequently and would not make sense to store on the state directly besides a group ID.

So, in order to perform the logic, I need to do some `async` function calls, this should be enough to support it since the command handler this returns is already `async`, there shouldn't be a problem with the extra `await` and type defs for `handle`.

Let me know if this is not desired for specific reasons and I'll close it. Thank you for your help!