### PR TITLE
Refactored PostgreSQL event store to benefit from the latest Pongo and Dumbo improvements

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@event-driven-io/core",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@event-driven-io/core",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "workspaces": [
         "packages/emmett",
         "packages/emmett-postgresql",
@@ -8643,7 +8643,7 @@
     },
     "packages/emmett": {
       "name": "@event-driven-io/emmett",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "devDependencies": {
         "@types/node": "^20.11.30"
       },
@@ -8657,12 +8657,12 @@
     },
     "packages/emmett-esdb": {
       "name": "@event-driven-io/emmett-esdb",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "devDependencies": {
         "@event-driven-io/emmett-testcontainers": "^0.5.0"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.14.1",
+        "@event-driven-io/emmett": "0.15.0",
         "@eventstore/db-client": "^6.1.0"
       }
     },
@@ -8680,10 +8680,10 @@
     },
     "packages/emmett-expressjs": {
       "name": "@event-driven-io/emmett-expressjs",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "devDependencies": {},
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.14.1",
+        "@event-driven-io/emmett": "0.15.0",
         "@types/express": "4.17.21",
         "@types/supertest": "6.0.2",
         "express": "4.19.2",
@@ -8694,10 +8694,10 @@
     },
     "packages/emmett-fastify": {
       "name": "@event-driven-io/emmett-fastify",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "devDependencies": {},
       "peerDependencies": {
-        "@event-driven-io/emmett": "^0.14.1",
+        "@event-driven-io/emmett": "^0.15.0",
         "@fastify/compress": "7.0.0",
         "@fastify/etag": "5.1.0",
         "@fastify/formbody": "7.4.0",
@@ -8707,7 +8707,7 @@
     },
     "packages/emmett-postgresql": {
       "name": "@event-driven-io/emmett-postgresql",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "dependencies": {
         "@testcontainers/postgresql": "^10.10.3"
       },
@@ -8715,7 +8715,7 @@
         "@event-driven-io/emmett-testcontainers": "^0.5.0"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.14.1",
+        "@event-driven-io/emmett": "0.15.0",
         "@event-driven-io/pongo": "0.10.0",
         "@types/pg": "^8.11.6",
         "@types/pg-format": "^1.0.5",
@@ -8737,9 +8737,9 @@
     },
     "packages/emmett-testcontainers": {
       "name": "@event-driven-io/emmett-testcontainers",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "dependencies": {
-        "@event-driven-io/emmett": "0.14.1",
+        "@event-driven-io/emmett": "0.15.0",
         "testcontainers": "^10.7.2"
       },
       "devDependencies": {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -45,8 +45,7 @@
         "node": ">=20.11.1"
       },
       "peerDependencies": {
-        "@event-driven-io/dumbo": "0.4.1",
-        "@event-driven-io/pongo": "0.7.0",
+        "@event-driven-io/pongo": "0.10.0",
         "@types/express": "4.17.21",
         "@types/node": "20.11.30",
         "@types/supertest": "6.0.2",
@@ -770,9 +769,9 @@
       }
     },
     "node_modules/@event-driven-io/dumbo": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@event-driven-io/dumbo/-/dumbo-0.4.1.tgz",
-      "integrity": "sha512-C1FIMZnQeIs2p4UOvChNj1TCAotlBSzB72u6ATl+MIXvBpSZG/KAI3kSApsAYPOlKDjf2cq4A3kLa3G677eDeQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@event-driven-io/dumbo/-/dumbo-0.7.0.tgz",
+      "integrity": "sha512-ye3PJrr7biB67zd5YjTHgPZXPO20gbyqUaw5DjkCg1/5AiGnseCaUwO2C8wKsLpnPQWqvxpoy904tV+j76tMFQ==",
       "peer": true,
       "peerDependencies": {
         "@types/pg": "^8.11.6",
@@ -810,16 +809,16 @@
       "link": true
     },
     "node_modules/@event-driven-io/pongo": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@event-driven-io/pongo/-/pongo-0.7.0.tgz",
-      "integrity": "sha512-Z0Ot5shA9AT8zHws1mHn7RrXXp+P9w8YQiAWxm7exq8vauDPmjoiMye9BDb9ARXiEY1bd6E5E3gkkt1bhmtdEA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@event-driven-io/pongo/-/pongo-0.10.0.tgz",
+      "integrity": "sha512-pnQkRAIIX8uovPqM+zRwTUMRxKzg/QgsTjcONOjexHfUuW0PZYfNN/nXii3SCyby2jiR6lN0k49ELLOEl7h2EA==",
       "peer": true,
       "dependencies": {
         "@types/pg-connection-string": "^2.0.0",
         "pg-connection-string": "^2.6.4"
       },
       "peerDependencies": {
-        "@event-driven-io/dumbo": "^0.4.1",
+        "@event-driven-io/dumbo": "0.7.0",
         "@types/mongodb": "^4.0.7",
         "@types/pg": "^8.11.6",
         "@types/pg-format": "^1.0.5",
@@ -8716,9 +8715,8 @@
         "@event-driven-io/emmett-testcontainers": "^0.5.0"
       },
       "peerDependencies": {
-        "@event-driven-io/dumbo": "0.4.1",
         "@event-driven-io/emmett": "0.14.1",
-        "@event-driven-io/pongo": "0.7.0",
+        "@event-driven-io/pongo": "0.10.0",
         "@types/pg": "^8.11.6",
         "@types/pg-format": "^1.0.5",
         "pg": "^8.12.0",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/core",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Emmett - Event Sourcing development made simple",
   "engines": {
     "node": ">=20.11.1"

--- a/src/package.json
+++ b/src/package.json
@@ -87,8 +87,7 @@
     "@types/express": "4.17.21",
     "@types/node": "20.11.30",
     "@types/supertest": "6.0.2",
-    "@event-driven-io/pongo": "0.7.0",
-    "@event-driven-io/dumbo": "0.4.1",
+    "@event-driven-io/pongo": "0.10.0",
     "supertest": "6.3.4"
   },
   "workspaces": [

--- a/src/packages/emmett-esdb/package.json
+++ b/src/packages/emmett-esdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-esdb",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Emmett - EventStoreDB - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -50,7 +50,7 @@
     "@event-driven-io/emmett-testcontainers": "^0.5.0"
   },
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.14.1",
+    "@event-driven-io/emmett": "0.15.0",
     "@eventstore/db-client": "^6.1.0"
   }
 }

--- a/src/packages/emmett-expressjs/package.json
+++ b/src/packages/emmett-expressjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-expressjs",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -48,7 +48,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.14.1",
+    "@event-driven-io/emmett": "0.15.0",
     "@types/express": "4.17.21",
     "@types/supertest": "6.0.2",
     "express": "4.19.2",

--- a/src/packages/emmett-fastify/package.json
+++ b/src/packages/emmett-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-fastify",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -52,7 +52,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "@event-driven-io/emmett": "^0.14.1",
+    "@event-driven-io/emmett": "^0.15.0",
     "fastify": "4.26.2",
     "@fastify/compress": "7.0.0",
     "@fastify/etag": "5.1.0",

--- a/src/packages/emmett-postgresql/package.json
+++ b/src/packages/emmett-postgresql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-postgresql",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Emmett - PostgreSQL - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -52,7 +52,7 @@
     "@event-driven-io/emmett-testcontainers": "^0.5.0"
   },
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.14.1",
+    "@event-driven-io/emmett": "0.15.0",
     "@types/pg": "^8.11.6",
     "@types/pg-format": "^1.0.5",
     "pg": "^8.12.0",

--- a/src/packages/emmett-postgresql/package.json
+++ b/src/packages/emmett-postgresql/package.json
@@ -57,7 +57,6 @@
     "@types/pg-format": "^1.0.5",
     "pg": "^8.12.0",
     "pg-format": "^1.0.4",
-    "@event-driven-io/pongo": "0.7.0",
-    "@event-driven-io/dumbo": "0.4.1"
+    "@event-driven-io/pongo": "0.10.0"
   }
 }

--- a/src/packages/emmett-postgresql/src/eventStore/schema/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/index.ts
@@ -1,5 +1,4 @@
-import { executeSQLBatchInTransaction, type SQL } from '@event-driven-io/dumbo';
-import pg from 'pg';
+import { type NodePostgresPool, type SQL } from '@event-driven-io/dumbo';
 import { appendEventsSQL } from './appendToStream';
 import {
   addDefaultPartition,
@@ -35,5 +34,5 @@ export const schemaSQL: SQL[] = [
   addDefaultPartition,
 ];
 
-export const createEventStoreSchema = (pool: pg.Pool) =>
-  executeSQLBatchInTransaction(pool, ...schemaSQL);
+export const createEventStoreSchema = (pool: NodePostgresPool) =>
+  pool.withTransaction(({ execute }) => execute.batchCommand(schemaSQL));

--- a/src/packages/emmett-testcontainers/package.json
+++ b/src/packages/emmett-testcontainers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-testcontainers",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Emmett - TestContainers - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -46,7 +46,7 @@
     "dist"
   ],
   "dependencies": {
-    "@event-driven-io/emmett": "0.14.1",
+    "@event-driven-io/emmett": "0.15.0",
     "testcontainers": "^10.7.2"
   },
   "devDependencies": {

--- a/src/packages/emmett/package.json
+++ b/src/packages/emmett/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
Now, it's possible to inject ambient connections and use non-pooled event stores in the same way as in Pongo.

To run a non-pooled setup (e.g. for Cloudflare Hyperdrive or Supabase Supavisor) you need to do the following:

```ts
const eventStore = getPostgreSQLEventStore(connectionString, {
  projections: [shoppingCartShortInfoProjection, customProjection],
  connectionOptions: { pooled: false },
});
```

It'll also be easier to deliver SQL projections, but that'll come in the follow-up PR.