### PR TITLE
Refactored Postgres projections registrations

### DIFF
--- a/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.e2e.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.e2e.spec.ts
@@ -27,7 +27,7 @@ import {
   type PostgresEventStore,
 } from './postgreSQLEventStore';
 import { postgreSQLProjection } from './projections';
-import { pongoSingleProjection } from './projections/pongo';
+import { pongoSingleStreamProjection } from './projections/pongo';
 
 void describe('EventStoreDBEventStore', async () => {
   let postgres: StartedPostgreSqlContainer;
@@ -133,7 +133,7 @@ const evolve = (
   }
 };
 
-const shoppingCartShortInfoProjection = pongoSingleProjection({
+const shoppingCartShortInfoProjection = pongoSingleStreamProjection({
   collectionName: shoppingCartShortInfoCollectionName,
   evolve,
   canHandle: ['ProductItemAdded', 'DiscountApplied'],

--- a/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.e2e.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.e2e.spec.ts
@@ -133,12 +133,11 @@ const evolve = (
   }
 };
 
-const shoppingCartShortInfoProjection = pongoSingleProjection(
-  shoppingCartShortInfoCollectionName,
+const shoppingCartShortInfoProjection = pongoSingleProjection({
+  collectionName: shoppingCartShortInfoCollectionName,
   evolve,
-  'ProductItemAdded',
-  'DiscountApplied',
-);
+  canHandle: ['ProductItemAdded', 'DiscountApplied'],
+});
 
 let handledEventsInCustomProjection: ReadEvent<ShoppingCartEvent>[] = [];
 

--- a/src/packages/emmett-postgresql/src/eventStore/projections/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/index.ts
@@ -7,9 +7,9 @@ import {
 import {
   type Event,
   type EventTypeOf,
-  type ProjectionDefintion,
   type ProjectionHandler,
   type ReadEvent,
+  type TypedProjectionDefintion,
 } from '@event-driven-io/emmett';
 import type { PostgresEventStoreOptions } from '../postgreSQLEventStore';
 
@@ -24,8 +24,7 @@ export type PostgreSQLProjectionHandler<EventType extends Event = Event> =
   ProjectionHandler<EventType, PostgreSQLProjectionHandlerContext>;
 
 export interface PostgreSQLProjectionDefintion<EventType extends Event = Event>
-  extends ProjectionDefintion<
-    'inline',
+  extends TypedProjectionDefintion<
     EventType,
     PostgreSQLProjectionHandlerContext
   > {}
@@ -60,19 +59,10 @@ export const handleProjections = async <EventType extends Event = Event>(
 
 export const postgreSQLProjection = <EventType extends Event>(
   definition: PostgreSQLProjectionDefintion<EventType>,
-): PostgreSQLProjectionDefintion =>
-  definition as unknown as PostgreSQLProjectionDefintion;
+): PostgreSQLProjectionDefintion<EventType> => definition;
 
 /** @deprecated use postgreSQLProjection instead */
 export const projection = postgreSQLProjection;
-
-export const postgreSQLInlineProjection = <EventType extends Event>(
-  definition: Omit<PostgreSQLProjectionDefintion<EventType>, 'type'>,
-): PostgreSQLProjectionDefintion =>
-  postgreSQLProjection({ type: 'inline', ...definition });
-
-/** @deprecated use postgreSQLSingleProjection instead */
-export const inlineProjection = postgreSQLInlineProjection;
 
 export const postgreSQLRawBatchSQLProjection = <EventType extends Event>(
   handle: (
@@ -81,7 +71,7 @@ export const postgreSQLRawBatchSQLProjection = <EventType extends Event>(
   ) => Promise<SQL[]> | SQL[],
   ...canHandle: EventTypeOf<EventType>[]
 ): PostgreSQLProjectionDefintion =>
-  postgreSQLInlineProjection<EventType>({
+  postgreSQLProjection<EventType>({
     canHandle,
     handle: async (events, context) => {
       const sqls: SQL[] = await handle(events, context);

--- a/src/packages/emmett-postgresql/src/eventStore/projections/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/index.ts
@@ -6,8 +6,8 @@ import {
 } from '@event-driven-io/dumbo';
 import {
   projection,
+  type CanHandle,
   type Event,
-  type EventTypeOf,
   type ProjectionHandler,
   type ReadEvent,
   type TypedProjectionDefinition,
@@ -72,7 +72,7 @@ export const postgreSQLRawBatchSQLProjection = <EventType extends Event>(
     events: EventType[],
     context: PostgreSQLProjectionHandlerContext,
   ) => Promise<SQL[]> | SQL[],
-  ...canHandle: EventTypeOf<EventType>[]
+  ...canHandle: CanHandle<EventType>
 ): PostgreSQLProjectionDefinition =>
   postgreSQLProjection<EventType>({
     canHandle,
@@ -88,7 +88,7 @@ export const postgreSQLRawSQLProjection = <EventType extends Event>(
     event: EventType,
     context: PostgreSQLProjectionHandlerContext,
   ) => Promise<SQL> | SQL,
-  ...canHandle: EventTypeOf<EventType>[]
+  ...canHandle: CanHandle<EventType>
 ): PostgreSQLProjectionDefinition =>
   postgreSQLRawBatchSQLProjection<EventType>(
     async (events, context) => {

--- a/src/packages/emmett-postgresql/src/eventStore/projections/pongo.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/pongo.ts
@@ -1,6 +1,6 @@
 import {
+  type CanHandle,
   type Event,
-  type EventTypeOf,
   type ReadEvent,
 } from '@event-driven-io/emmett';
 import {
@@ -37,7 +37,7 @@ export type PongoProjectionOptions<EventType extends Event> = {
     events: ReadEvent<EventType>[],
     context: PongoProjectionHandlerContext,
   ) => Promise<void>;
-  canHandle: EventTypeOf<EventType>[];
+  canHandle: CanHandle<EventType>;
 };
 
 export const pongoProjection = <EventType extends Event>({
@@ -60,7 +60,7 @@ export type PongoMultiStreamProjectionOptions<
   collectionName: string;
   getDocumentId: (event: ReadEvent<EventType>) => string;
   evolve: PongoDocumentEvolve<Document, EventType>;
-  canHandle: EventTypeOf<EventType>[];
+  canHandle: CanHandle<EventType>;
 };
 
 export const pongoMultiStreamProjection = <
@@ -94,7 +94,7 @@ export type PongoSingleStreamProjectionOptions<
 > = {
   collectionName: string;
   evolve: PongoDocumentEvolve<Document, EventType>;
-  canHandle: EventTypeOf<EventType>[];
+  canHandle: CanHandle<EventType>;
 };
 
 export const pongoSingleProjection = <

--- a/src/packages/emmett-postgresql/src/eventStore/projections/pongo.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/pongo.ts
@@ -97,7 +97,7 @@ export type PongoSingleStreamProjectionOptions<
   canHandle: CanHandle<EventType>;
 };
 
-export const pongoSingleProjection = <
+export const pongoSingleStreamProjection = <
   Document extends PongoDocument,
   EventType extends Event,
 >({

--- a/src/packages/emmett/src/projections/index.ts
+++ b/src/packages/emmett/src/projections/index.ts
@@ -1,5 +1,7 @@
 import type { DefaultRecord, Event, EventTypeOf, ReadEvent } from '../typing';
 
+export type ProjectionHandlingType = 'inline' | 'async';
+
 export type ProjectionHandler<
   EventType extends Event = Event,
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
@@ -8,13 +10,50 @@ export type ProjectionHandler<
   context: ProjectionHandlerContext,
 ) => Promise<void> | void;
 
-export interface ProjectionDefintion<
-  ProjectionType extends 'inline' | 'async',
+export interface ProjectionDefinition<
+  ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
+> {
+  name?: string;
+  canHandle: EventTypeOf<Event>[];
+  handle: ProjectionHandler<Event, ProjectionHandlerContext>;
+}
+
+export interface TypedProjectionDefintion<
   EventType extends Event = Event,
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
 > {
-  type: ProjectionType;
   name?: string;
   canHandle: EventTypeOf<EventType>[];
   handle: ProjectionHandler<EventType, ProjectionHandlerContext>;
 }
+
+export type ProjectionRegistration<
+  HandlingType extends ProjectionHandlingType,
+  ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
+> = {
+  type: HandlingType;
+  projection: ProjectionDefinition<ProjectionHandlerContext>;
+};
+
+export const inlineProjections = <
+  ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
+  ProjectionDefintionType extends
+    ProjectionDefinition<ProjectionHandlerContext> = ProjectionDefinition<ProjectionHandlerContext>,
+>(
+  definitions: ProjectionDefintionType[],
+): ProjectionRegistration<'inline', ProjectionHandlerContext>[] =>
+  definitions.map((projection) => ({ type: 'inline', projection }));
+
+export const asyncProjections = <
+  ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
+  ProjectionDefintionType extends
+    ProjectionDefinition<ProjectionHandlerContext> = ProjectionDefinition<ProjectionHandlerContext>,
+>(
+  definitions: ProjectionDefintionType[],
+): ProjectionRegistration<'async', ProjectionHandlerContext>[] =>
+  definitions.map((projection) => ({ type: 'async', projection }));
+
+export const projections = {
+  inline: inlineProjections,
+  async: asyncProjections,
+};

--- a/src/packages/emmett/src/projections/index.ts
+++ b/src/packages/emmett/src/projections/index.ts
@@ -1,4 +1,4 @@
-import type { DefaultRecord, Event, EventTypeOf, ReadEvent } from '../typing';
+import type { CanHandle, DefaultRecord, Event, ReadEvent } from '../typing';
 
 export type ProjectionHandlingType = 'inline' | 'async';
 
@@ -14,7 +14,7 @@ export interface ProjectionDefinition<
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
 > {
   name?: string;
-  canHandle: EventTypeOf<Event>[];
+  canHandle: CanHandle<Event>;
   handle: ProjectionHandler<Event, ProjectionHandlerContext>;
 }
 
@@ -23,7 +23,7 @@ export interface TypedProjectionDefinition<
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
 > {
   name?: string;
-  canHandle: EventTypeOf<EventType>[];
+  canHandle: CanHandle<EventType>;
   handle: ProjectionHandler<EventType, ProjectionHandlerContext>;
 }
 

--- a/src/packages/emmett/src/projections/index.ts
+++ b/src/packages/emmett/src/projections/index.ts
@@ -18,7 +18,7 @@ export interface ProjectionDefinition<
   handle: ProjectionHandler<Event, ProjectionHandlerContext>;
 }
 
-export interface TypedProjectionDefintion<
+export interface TypedProjectionDefinition<
   EventType extends Event = Event,
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
 > {
@@ -34,6 +34,17 @@ export type ProjectionRegistration<
   type: HandlingType;
   projection: ProjectionDefinition<ProjectionHandlerContext>;
 };
+
+export const projection = <
+  EventType extends Event = Event,
+  ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
+  ProjectionDefintionType extends TypedProjectionDefinition<
+    EventType,
+    ProjectionHandlerContext
+  > = ProjectionDefinition<ProjectionHandlerContext>,
+>(
+  definition: ProjectionDefintionType,
+): ProjectionDefintionType => definition;
 
 export const inlineProjections = <
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,

--- a/src/packages/emmett/src/typing/event.ts
+++ b/src/packages/emmett/src/typing/event.ts
@@ -17,6 +17,8 @@ export type EventTypeOf<T extends Event> = T['type'];
 export type EventDataOf<T extends Event> = T['data'];
 export type EventMetaDataOf<T extends Event> = T['metadata'];
 
+export type CanHandle<T extends Event> = EventTypeOf<T>[];
+
 export type CreateEventType<
   EventType extends string,
   EventData extends DefaultRecord,


### PR DESCRIPTION
- Separated projection definition from registration. Thanks to that, projections will be able to switch their type in the future or be used in both (e.g., for rebuilds).
- Refactored projections to take params object instead of a list of parameters. That will cut the number of permutations and make it easier to define them.
- Added reusable type CanHandle to unified Event Handlers typing restrictions.
- Renamed `pongoSingleProjection to `pongoSingleStreamProjection` to keep naming consistency.

Now, registration will look like this (notice `projections.inline` helper):

```ts
const eventStore = getPostgreSQLEventStore(connectionString, {
  projections: projections.inline(
    [shoppingCartShortInfoProjection, customProjection]
  ),
});
````

And Pongo projection definition as:

````ts
const shoppingCartShortInfoProjection = pongoSingleStreamProjection({
  collectionName: 'shoppingCartsShortInfo',
  evolve,
  canHandle: ['ProductItemAdded', 'DiscountApplied'],
});
````