### PR TITLE
Added idempotence check tests for PostgreSQL projections

### DIFF
--- a/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.e2e.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.e2e.spec.ts
@@ -79,7 +79,10 @@ void describe('EventStoreDBEventStore', async () => {
       { type: 'ProductItemAdded', data: { productItem } },
     ]);
     await eventStore.appendToStream<ShoppingCartEvent>(shoppingCartId, [
-      { type: 'DiscountApplied', data: { percent: discount } },
+      {
+        type: 'DiscountApplied',
+        data: { percent: discount, couponId: uuid() },
+      },
     ]);
 
     const shoppingCartShortInfo = pongo

--- a/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.ts
@@ -188,13 +188,15 @@ export const getPostgreSQLEventStore = (
         events,
         {
           ...options,
-          preCommitHook: (client, events) =>
-            handleProjections(
-              inlineProjections,
-              connectionString,
-              client,
+          preCommitHook: (events, { transaction }) =>
+            handleProjections({
+              projections: inlineProjections,
+              connection: {
+                connectionString,
+                transaction,
+              },
               events,
-            ),
+            }),
         },
       );
 

--- a/src/packages/emmett-postgresql/src/eventStore/projections/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/index.ts
@@ -23,12 +23,23 @@ export type PostgreSQLProjectionHandlerContext = {
   transaction: NodePostgresTransaction;
 };
 
-export type PostgreSQLProjectionHandler<EventType extends Event = Event> =
-  ProjectionHandler<EventType, PostgreSQLProjectionHandlerContext>;
+export type PostgreSQLProjectionHandler<
+  EventType extends Event = Event,
+  EventMetaDataType extends EventMetaDataOf<EventType> &
+    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+> = ProjectionHandler<
+  EventType,
+  EventMetaDataType,
+  PostgreSQLProjectionHandlerContext
+>;
 
-export interface PostgreSQLProjectionDefinition<EventType extends Event = Event>
-  extends TypedProjectionDefinition<
+export interface PostgreSQLProjectionDefinition<
+  EventType extends Event = Event,
+  EventMetaDataType extends EventMetaDataOf<EventType> &
+    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+> extends TypedProjectionDefinition<
     EventType,
+    EventMetaDataType,
     PostgreSQLProjectionHandlerContext
   > {}
 
@@ -80,11 +91,16 @@ export const handleProjections = async <
   }
 };
 
-export const postgreSQLProjection = <EventType extends Event>(
+export const postgreSQLProjection = <
+  EventType extends Event,
+  EventMetaDataType extends EventMetaDataOf<EventType> &
+    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+>(
   definition: PostgreSQLProjectionDefinition<EventType>,
 ): PostgreSQLProjectionDefinition =>
   projection<
     EventType,
+    EventMetaDataType,
     PostgreSQLProjectionHandlerContext,
     PostgreSQLProjectionDefinition<EventType>
   >(definition) as PostgreSQLProjectionDefinition;

--- a/src/packages/emmett-postgresql/src/eventStore/projections/pongo/pongoProjectionSpec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/pongo/pongoProjectionSpec.ts
@@ -181,13 +181,13 @@ export const documentDoesNotExist =
     );
 
 export const expectPongoDocuments = {
-  fromCollection: (collectionName: string) => {
+  fromCollection: <Doc extends PongoDocument | WithId<PongoDocument>>(
+    collectionName: string,
+  ) => {
     return {
       withId: (id: string) => {
         return {
-          toBeEqual: <Doc extends PongoDocument | WithId<PongoDocument>>(
-            document: Doc,
-          ) =>
+          toBeEqual: (document: Doc) =>
             documentExists(document, {
               withId: id,
               inCollection: collectionName,

--- a/src/packages/emmett-postgresql/src/eventStore/projections/pongo/projections.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/pongo/projections.ts
@@ -3,7 +3,7 @@ import {
   type Event,
   type EventMetaDataOf,
   type ReadEvent,
-  type ReadEventMetadata,
+  type ReadEventMetadataWithGlobalPosition,
 } from '@event-driven-io/emmett';
 import {
   pongoClient,
@@ -25,7 +25,8 @@ export type PongoWithNotNullDocumentEvolve<
   Document extends PongoDocument,
   EventType extends Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
+    ReadEventMetadataWithGlobalPosition,
 > =
   | ((
       document: Document,
@@ -40,7 +41,8 @@ export type PongoWithNullableDocumentEvolve<
   Document extends PongoDocument,
   EventType extends Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
+    ReadEventMetadataWithGlobalPosition,
 > =
   | ((
       document: Document | null,
@@ -55,7 +57,8 @@ export type PongoDocumentEvolve<
   Document extends PongoDocument,
   EventType extends Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
+    ReadEventMetadataWithGlobalPosition,
 > =
   | PongoWithNotNullDocumentEvolve<Document, EventType, EventMetaDataType>
   | PongoWithNullableDocumentEvolve<Document, EventType, EventMetaDataType>;
@@ -63,7 +66,8 @@ export type PongoDocumentEvolve<
 export type PongoProjectionOptions<
   EventType extends Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
+    ReadEventMetadataWithGlobalPosition,
 > = {
   handle: (
     events: ReadEvent<EventType, EventMetaDataType>[],
@@ -75,7 +79,8 @@ export type PongoProjectionOptions<
 export const pongoProjection = <
   EventType extends Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
+    ReadEventMetadataWithGlobalPosition,
 >({
   handle,
   canHandle,
@@ -99,7 +104,8 @@ export type PongoMultiStreamProjectionOptions<
   Document extends PongoDocument,
   EventType extends Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
+    ReadEventMetadataWithGlobalPosition,
 > = {
   canHandle: CanHandle<EventType>;
 
@@ -127,7 +133,8 @@ export const pongoMultiStreamProjection = <
   Document extends PongoDocument,
   EventType extends Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
+    ReadEventMetadataWithGlobalPosition,
 >(
   options: PongoMultiStreamProjectionOptions<
     Document,
@@ -163,7 +170,8 @@ export type PongoSingleStreamProjectionOptions<
   Document extends PongoDocument,
   EventType extends Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
+    ReadEventMetadataWithGlobalPosition,
 > = {
   canHandle: CanHandle<EventType>;
 
@@ -190,7 +198,8 @@ export const pongoSingleStreamProjection = <
   Document extends PongoDocument,
   EventType extends Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
+    ReadEventMetadataWithGlobalPosition,
 >(
   options: PongoSingleStreamProjectionOptions<
     Document,

--- a/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjectionSpec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjectionSpec.ts
@@ -12,6 +12,7 @@ import {
   assertTrue,
   isErrorConstructor,
   type Event,
+  type EventMetaDataOf,
   type ReadEvent,
   type ReadEventMetadataWithGlobalPosition,
   type ThenThrows,
@@ -19,8 +20,14 @@ import {
 import { v4 as uuid } from 'uuid';
 import { handleProjections, type PostgreSQLProjectionDefinition } from '.';
 
-export type PostgreSQLProjectionSpecEvent<EventType extends Event> =
-  EventType & { metadata?: Partial<ReadEventMetadataWithGlobalPosition> };
+export type PostgreSQLProjectionSpecEvent<
+  EventType extends Event,
+  EventMetaDataType extends EventMetaDataOf<EventType> &
+    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
+    ReadEventMetadataWithGlobalPosition,
+> = EventType & {
+  metadata?: Partial<EventMetaDataType>;
+};
 
 export type PostgreSQLProjectionSpecWhenOptions = { numberOfTimes: number };
 
@@ -166,23 +173,33 @@ export const PostgreSQLProjectionSpec = {
   },
 };
 
-export const eventInStream = <EventType extends Event = Event>(
+export const eventInStream = <
+  EventType extends Event = Event,
+  EventMetaDataType extends EventMetaDataOf<EventType> &
+    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
+    ReadEventMetadataWithGlobalPosition,
+>(
   streamName: string,
-  event: PostgreSQLProjectionSpecEvent<EventType>,
-): PostgreSQLProjectionSpecEvent<EventType> => {
+  event: PostgreSQLProjectionSpecEvent<EventType, EventMetaDataType>,
+): PostgreSQLProjectionSpecEvent<EventType, EventMetaDataType> => {
   return {
     ...event,
     metadata: {
       ...(event.metadata ?? {}),
       streamName: event.metadata?.streamName ?? streamName,
-    },
+    } as Partial<EventMetaDataType>,
   };
 };
 
-export const eventsInStream = <EventType extends Event = Event>(
+export const eventsInStream = <
+  EventType extends Event = Event,
+  EventMetaDataType extends EventMetaDataOf<EventType> &
+    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
+    ReadEventMetadataWithGlobalPosition,
+>(
   streamName: string,
-  events: PostgreSQLProjectionSpecEvent<EventType>[],
-): PostgreSQLProjectionSpecEvent<EventType>[] => {
+  events: PostgreSQLProjectionSpecEvent<EventType, EventMetaDataType>[],
+): PostgreSQLProjectionSpecEvent<EventType, EventMetaDataType>[] => {
   return events.map((e) => eventInStream(streamName, e));
 };
 

--- a/src/packages/emmett-postgresql/src/eventStore/schema/appendToStream.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/appendToStream.ts
@@ -122,8 +122,10 @@ export const appendToStream = (
   options?: AppendToStreamOptions & {
     partition?: string;
     preCommitHook?: (
-      transaction: NodePostgresTransaction,
       events: ReadEvent[],
+      context: {
+        transaction: NodePostgresTransaction;
+      },
     ) => Promise<void>;
   },
 ): Promise<AppendEventResult> =>
@@ -162,7 +164,7 @@ export const appendToStream = (
       );
 
       if (options?.preCommitHook)
-        await options.preCommitHook(transaction, eventsToAppend);
+        await options.preCommitHook(eventsToAppend, { transaction });
     } catch (error) {
       if (!isOptimisticConcurrencyError(error)) throw error;
 

--- a/src/packages/emmett/src/projections/index.ts
+++ b/src/packages/emmett/src/projections/index.ts
@@ -1,12 +1,21 @@
-import type { CanHandle, DefaultRecord, Event, ReadEvent } from '../typing';
+import type {
+  CanHandle,
+  DefaultRecord,
+  Event,
+  EventMetaDataOf,
+  ReadEvent,
+  ReadEventMetadata,
+} from '../typing';
 
 export type ProjectionHandlingType = 'inline' | 'async';
 
 export type ProjectionHandler<
   EventType extends Event = Event,
+  EventMetaDataType extends EventMetaDataOf<EventType> &
+    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
 > = (
-  events: ReadEvent<EventType>[],
+  events: ReadEvent<EventType, EventMetaDataType>[],
   context: ProjectionHandlerContext,
 ) => Promise<void> | void;
 
@@ -15,16 +24,22 @@ export interface ProjectionDefinition<
 > {
   name?: string;
   canHandle: CanHandle<Event>;
-  handle: ProjectionHandler<Event, ProjectionHandlerContext>;
+  handle: ProjectionHandler<Event, ReadEventMetadata, ProjectionHandlerContext>;
 }
 
 export interface TypedProjectionDefinition<
   EventType extends Event = Event,
+  EventMetaDataType extends EventMetaDataOf<EventType> &
+    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
 > {
   name?: string;
   canHandle: CanHandle<EventType>;
-  handle: ProjectionHandler<EventType, ProjectionHandlerContext>;
+  handle: ProjectionHandler<
+    EventType,
+    EventMetaDataType,
+    ProjectionHandlerContext
+  >;
 }
 
 export type ProjectionRegistration<
@@ -37,9 +52,12 @@ export type ProjectionRegistration<
 
 export const projection = <
   EventType extends Event = Event,
+  EventMetaDataType extends EventMetaDataOf<EventType> &
+    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
   ProjectionDefintionType extends TypedProjectionDefinition<
     EventType,
+    EventMetaDataType,
     ProjectionHandlerContext
   > = ProjectionDefinition<ProjectionHandlerContext>,
 >(

--- a/src/packages/emmett/src/testing/features.ts
+++ b/src/packages/emmett/src/testing/features.ts
@@ -1,5 +1,5 @@
-import { randomUUID } from 'node:crypto';
 import { after, before, describe, it } from 'node:test';
+import { v4 as uuid } from 'uuid';
 import type { EventStore } from '../eventStore';
 import { assertDeepEqual, assertEqual, assertOk } from './assertions';
 import {
@@ -51,7 +51,7 @@ export async function testAggregateStream(
           price: 3,
         };
         const discount = 10;
-        const shoppingCartId = randomUUID();
+        const shoppingCartId = uuid();
 
         await eventStore.appendToStream<ShoppingCartEvent>(shoppingCartId, [
           { type: 'ProductItemAdded', data: { productItem } },
@@ -60,7 +60,10 @@ export async function testAggregateStream(
           { type: 'ProductItemAdded', data: { productItem } },
         ]);
         await eventStore.appendToStream<ShoppingCartEvent>(shoppingCartId, [
-          { type: 'DiscountApplied', data: { percent: discount } },
+          {
+            type: 'DiscountApplied',
+            data: { percent: discount, couponId: uuid() },
+          },
         ]);
 
         // when

--- a/src/packages/emmett/src/testing/shoppingCart.domain.ts
+++ b/src/packages/emmett/src/testing/shoppingCart.domain.ts
@@ -15,7 +15,10 @@ export type ProductItemAdded = Event<
   'ProductItemAdded',
   { productItem: PricedProductItem }
 >;
-export type DiscountApplied = Event<'DiscountApplied', { percent: number }>;
+export type DiscountApplied = Event<
+  'DiscountApplied',
+  { percent: number; couponId: string }
+>;
 
 export type ShoppingCartEvent = ProductItemAdded | DiscountApplied;
 


### PR DESCRIPTION
Besides that:
- added `initialStat`e option to pongo projections to allow getting a non-nullable state,
- extended typing for PostgreSQL projections to include global store position in event metadata,
- Refactored projection handling and post-commit hooks are to be based on the object parameter to improve reusability.