### PR TITLE
Added benchmark configuration to generate schema upfront

### DIFF
--- a/src/packages/emmett-postgresql/src/benchmarks/index.ts
+++ b/src/packages/emmett-postgresql/src/benchmarks/index.ts
@@ -18,6 +18,9 @@ const connectionOptions: PostgresEventStoreConnectionOptions | undefined =
         pooled: false,
       };
 
+const generateSchemaUpfront =
+  process.env.BENCHMARK_GENERATE_SCHEMA_UPFRONT === 'true';
+
 const eventStore = getPostgreSQLEventStore(connectionString, {
   connectionOptions: connectionOptions,
 });
@@ -33,11 +36,16 @@ const appendEvents = () => {
   ]);
 };
 
-const readEvents = () => eventStore.readStream(ids[0]!);
+const readEvents = () => eventStore.readStream(ids[0] ?? 'not-existing');
 
 // eslint-disable-next-line @typescript-eslint/require-await
 async function runBenchmark() {
   const suite = new Benchmark.Suite();
+
+  if (generateSchemaUpfront) {
+    // this will trigger generating schema
+    await readEvents();
+  }
 
   return (
     suite


### PR DESCRIPTION
It can be set through `BENCHMARK_GENERATE_SCHEMA_UPFRONT` env.

Follow up to: https://github.com/event-driven-io/emmett/pull/108.