### PR TITLE
Updated TS config to fix debugging

### DIFF
--- a/src/packages/emmett-esdb/tsup.config.ts
+++ b/src/packages/emmett-esdb/tsup.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   watch: env === 'development',
   target: 'esnext',
   outDir: 'dist', //env === 'production' ? 'dist' : 'lib',
-  entry: ['src/**/*.ts', '!src/**/*.spec.ts', '!src/**/*.internal.ts'], //include all files under src but not specs
+  entry: ['src/index.ts'],
   sourcemap: true,
   tsconfig: 'tsconfig.build.json', // workaround for https://github.com/egoist/tsup/issues/571#issuecomment-1760052931
 });

--- a/src/packages/emmett-fastify/tsup.config.ts
+++ b/src/packages/emmett-fastify/tsup.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   watch: env === 'development',
   target: 'esnext',
   outDir: 'dist', //env === 'production' ? 'dist' : 'lib',
-  entry: ['src/**/*.ts', '!src/**/*.spec.ts', '!src/**/*.internal.ts'], //include all files under src but not specs
+  entry: ['src/index.ts'],
   sourcemap: true,
   tsconfig: 'tsconfig.build.json', // workaround for https://github.com/egoist/tsup/issues/571#issuecomment-1760052931
 });

--- a/src/packages/emmett-postgresql/tsup.config.ts
+++ b/src/packages/emmett-postgresql/tsup.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   watch: env === 'development',
   target: 'esnext',
   outDir: 'dist', //env === 'production' ? 'dist' : 'lib',
-  entry: ['src/**/*.ts', '!src/**/*.spec.ts', '!src/**/*.internal.ts'], //include all files under src but not specs
+  entry: ['src/index.ts'],
   sourcemap: true,
   tsconfig: 'tsconfig.build.json', // workaround for https://github.com/egoist/tsup/issues/571#issuecomment-1760052931
 });

--- a/src/packages/emmett-testcontainers/tsup.config.ts
+++ b/src/packages/emmett-testcontainers/tsup.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   watch: env === 'development',
   target: 'esnext',
   outDir: 'dist', //env === 'production' ? 'dist' : 'lib',
-  entry: ['src/**/*.ts', '!src/**/*.spec.ts', '!src/**/*.internal.ts'], //include all files under src but not specs
+  entry: ['src/index.ts'],
   sourcemap: true,
   tsconfig: 'tsconfig.build.json', // workaround for https://github.com/egoist/tsup/issues/571#issuecomment-1760052931
 });

--- a/src/packages/emmett/tsup.config.ts
+++ b/src/packages/emmett/tsup.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   watch: env === 'development',
   target: 'esnext',
   outDir: 'dist', //env === 'production' ? 'dist' : 'lib',
-  entry: ['src/**/*.ts', '!src/**/*.spec.ts', '!src/**/*.internal.ts'], //include all files under src but not specs
+  entry: ['src/index.ts'],
   sourcemap: true,
   tsconfig: 'tsconfig.build.json', // workaround for https://github.com/egoist/tsup/issues/571#issuecomment-1760052931
 });

--- a/src/tsconfig.shared.json
+++ b/src/tsconfig.shared.json
@@ -61,8 +61,8 @@
     /* Source Map Options */
     // "sourceRoot": "",                            /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "",                               /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,                     /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                       /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    "inlineSourceMap": false /* Emit a single file with source maps instead of having a separate file. */,
+    "inlineSources": true /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */,
 
     /* Experimental Options */
     // "experimentalDecorators": true,              /* Enables experimental support for ES7 decorators. */

--- a/src/tsup.config.ts
+++ b/src/tsup.config.ts
@@ -14,6 +14,6 @@ export default defineConfig({
   watch: env === 'development',
   target: 'esnext',
   outDir: 'dist', //env === 'production' ? 'dist' : 'lib',
-  entry: ['src/**/*.ts', '!src/**/*.spec.ts', '!src/**/*.internal.ts'], //include all files under src but not specs
+  entry: ['src/index.ts'],
   sourcemap: true,
 });


### PR DESCRIPTION
It seems that, if you have "inlineSourceMap": true in your tsconfig, this means that your source maps are embedded directly within the generated JavaScript files as a data URI rather than being written out as separate .map files. This can be helpful in some cases, but it might cause issues if you're also using external source maps (sourcemap: true in tsup), leading to confusion in your debugger.

Besides that, linked only index.ts to include in bundle only used files (so not e.g. benchmarks).