### PR TITLE
Command handling idempotency improvements

### DIFF
--- a/samples/webApi/expressjs-with-esdb/package-lock.json
+++ b/samples/webApi/expressjs-with-esdb/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@event-driven-io/emmett-esdb": "0.19.0",
-        "@event-driven-io/emmett-expressjs": "0.19.0",
-        "@event-driven-io/emmett-testcontainers": "0.19.0"
+        "@event-driven-io/emmett-esdb": "0.20.0-alpha.1",
+        "@event-driven-io/emmett-expressjs": "0.20.0-alpha.1",
+        "@event-driven-io/emmett-testcontainers": "0.20.0-alpha.1"
       },
       "devDependencies": {
         "@types/node": "20.11.30",
@@ -512,37 +512,37 @@
       }
     },
     "node_modules/@event-driven-io/emmett": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett/-/emmett-0.19.0.tgz",
-      "integrity": "sha512-NvZ1JrIcQZIEYI/bWjZVLW687gx8eCQP/hWsJsijC/8PdIplKLF9KiHIJlnBJ/LA1LO/OBajIT+jYwVRrEojQw==",
+      "version": "0.20.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett/-/emmett-0.20.0-alpha.1.tgz",
+      "integrity": "sha512-cOV3JeeaNafpamYbGh+BoX+4GWrliMpYcgAZojrMPnIY3hupIHP2uToLiiv/iv8/vjaJIkG2fNOOUqOHUefNpw==",
       "bin": {
         "emmett": "dist/cli.js"
       },
       "peerDependencies": {
+        "@event-driven-io/emmett-shims": "0.20.0-alpha.1",
         "@types/async-retry": "^1.4.8",
         "@types/uuid": "^10.0.0",
         "async-retry": "^1.3.3",
         "commander": "^12.1.0",
         "ts-node": "^10.9.2",
-        "uuid": "^10.0.0",
-        "web-streams-polyfill": "^4.0.0"
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/@event-driven-io/emmett-esdb": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett-esdb/-/emmett-esdb-0.19.0.tgz",
-      "integrity": "sha512-5A/eDNWOn9NTR4dx/kXMjxFTJzB3WT/TxK1Ior+pO4MzTVklagZL6im9wAazDM4uOSem9cmsD8HOWuuo/q02pg==",
+      "version": "0.20.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett-esdb/-/emmett-esdb-0.20.0-alpha.1.tgz",
+      "integrity": "sha512-z3dQTd6yTzl7uesjn4z4Nqr+uDOrixBqG1Bzl0wvKvvehoR9nLQOmW1E47tDYlTjXSMofdRahTs+DoIb4YWLsw==",
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.19.0",
+        "@event-driven-io/emmett": "0.20.0-alpha.1",
         "@eventstore/db-client": "^6.2.1"
       }
     },
     "node_modules/@event-driven-io/emmett-expressjs": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett-expressjs/-/emmett-expressjs-0.19.0.tgz",
-      "integrity": "sha512-pVQTGjV6Q48ZeihU0vi2FizjhvSaAmLmHoFpK6vGa96krJqFPg/9W1wmvESr+NVGMdutSS422byoHDjLFgr+DQ==",
+      "version": "0.20.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett-expressjs/-/emmett-expressjs-0.20.0-alpha.1.tgz",
+      "integrity": "sha512-Qlo2hJuuDCQ+v6X77csuWMLJl4OOJGb9Lq2Wn5gHvEwvUrcxgv7Fk92ng4+qS8C0M3HEGhdQkjDBDJHdfi2PJg==",
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.19.0",
+        "@event-driven-io/emmett": "0.20.0-alpha.1",
         "@types/express": "^4.17.21",
         "@types/supertest": "^6.0.2",
         "express": "^4.19.2",
@@ -551,12 +551,21 @@
         "supertest": "^7.0.0"
       }
     },
+    "node_modules/@event-driven-io/emmett-shims": {
+      "version": "0.20.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett-shims/-/emmett-shims-0.20.0-alpha.1.tgz",
+      "integrity": "sha512-3SBYHJcaIlgM7+csOnHvmyoGpDA+6o2ybtqkRo+m9MW3yfRL9CaPA3iyPc3yDwLBlKM8EatM5IZqKWAEuY7tZA==",
+      "peer": true,
+      "peerDependencies": {
+        "web-streams-polyfill": "^4.0.0"
+      }
+    },
     "node_modules/@event-driven-io/emmett-testcontainers": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett-testcontainers/-/emmett-testcontainers-0.19.0.tgz",
-      "integrity": "sha512-PyttyDzLNOV0tJUf8K12zVXOs8749LwJSjR+TwcvQdkLjh1tq9SgJQwJkvyzB3EP97bVdQBTfj8v4r7AbTbKJg==",
+      "version": "0.20.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett-testcontainers/-/emmett-testcontainers-0.20.0-alpha.1.tgz",
+      "integrity": "sha512-Sw7Nb+R9VWgGqU4XPWzuAWHpJqxIBRc7diWLtytBXvYkYuk7WWkZD/PY40A30HS8kjhcNSmKqXcz+KvsdCyOpA==",
       "dependencies": {
-        "@event-driven-io/emmett": "0.19.0",
+        "@event-driven-io/emmett": "0.20.0-alpha.1",
         "testcontainers": "^10.12.0"
       }
     },

--- a/samples/webApi/expressjs-with-esdb/package.json
+++ b/samples/webApi/expressjs-with-esdb/package.json
@@ -38,9 +38,9 @@
   },
   "homepage": "https://github.com/event-driven-io/emmett#readme",
   "dependencies": {
-    "@event-driven-io/emmett-esdb": "0.19.0",
-    "@event-driven-io/emmett-expressjs": "0.19.0",
-    "@event-driven-io/emmett-testcontainers": "0.19.0"
+    "@event-driven-io/emmett-esdb": "0.20.0-alpha.1",
+    "@event-driven-io/emmett-expressjs": "0.20.0-alpha.1",
+    "@event-driven-io/emmett-testcontainers": "0.20.0-alpha.1"
   },
   "devDependencies": {
     "@types/node": "20.11.30",

--- a/samples/webApi/expressjs-with-esdb/src/shoppingCarts/api.ts
+++ b/samples/webApi/expressjs-with-esdb/src/shoppingCarts/api.ts
@@ -66,8 +66,11 @@ export const shoppingCartApi =
           metadata: { now: getCurrentTime() },
         };
 
-        await handle(eventStore, shoppingCartId, (state) =>
-          addProductItem(command, state),
+        await handle(
+          eventStore,
+          shoppingCartId,
+          (state) => addProductItem(command, state),
+          { expectedStreamVersion: 'STREAM_DOES_NOT_EXIST' },
         );
 
         return NoContent();

--- a/samples/webApi/expressjs-with-esdb/src/shoppingCarts/api.ts
+++ b/samples/webApi/expressjs-with-esdb/src/shoppingCarts/api.ts
@@ -31,7 +31,7 @@ import {
   type ShoppingCartEvent,
 } from './shoppingCart';
 
-export const handle = CommandHandler(evolve, initialState);
+export const handle = CommandHandler({ evolve, initialState });
 
 export const getShoppingCartId = (clientId: string) =>
   `shopping_cart:${assertNotEmptyString(clientId)}:current`;
@@ -66,11 +66,8 @@ export const shoppingCartApi =
           metadata: { now: getCurrentTime() },
         };
 
-        await handle(
-          eventStore,
-          shoppingCartId,
-          (state) => addProductItem(command, state),
-          { expectedStreamVersion: 'STREAM_DOES_NOT_EXIST' },
+        await handle(eventStore, shoppingCartId, (state) =>
+          addProductItem(command, state),
         );
 
         return NoContent();

--- a/samples/webApi/expressjs-with-postgresql/package-lock.json
+++ b/samples/webApi/expressjs-with-postgresql/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@event-driven-io/emmett": "0.19.0",
-        "@event-driven-io/emmett-expressjs": "0.19.0",
-        "@event-driven-io/emmett-postgresql": "0.19.0"
+        "@event-driven-io/emmett": "0.20.0-alpha.1",
+        "@event-driven-io/emmett-expressjs": "0.20.0-alpha.1",
+        "@event-driven-io/emmett-postgresql": "0.20.0-alpha.1"
       },
       "devDependencies": {
         "@testcontainers/postgresql": "^10.10.3",
@@ -515,9 +515,9 @@
       }
     },
     "node_modules/@event-driven-io/dumbo": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@event-driven-io/dumbo/-/dumbo-0.11.0.tgz",
-      "integrity": "sha512-7DQGiplkZqAAcdbKXEMuQHAvCqIGC3VdqnBlFYT/fYJl/CBw++Kyz97tiNb0BkCWhBTvXcaHfuvDO/m5MF6n2w==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@event-driven-io/dumbo/-/dumbo-0.11.1.tgz",
+      "integrity": "sha512-MdhkHjpKYl1BxTeitswPYgmuQ6h11zwTe48E7XbR4BlQ2FtDhZMBsUJRdRsAFhRXb2fzS4jTxkw46De9E7ZTcg==",
       "peer": true,
       "peerDependencies": {
         "@types/pg": "^8.11.6",
@@ -528,28 +528,28 @@
       }
     },
     "node_modules/@event-driven-io/emmett": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett/-/emmett-0.19.0.tgz",
-      "integrity": "sha512-NvZ1JrIcQZIEYI/bWjZVLW687gx8eCQP/hWsJsijC/8PdIplKLF9KiHIJlnBJ/LA1LO/OBajIT+jYwVRrEojQw==",
+      "version": "0.20.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett/-/emmett-0.20.0-alpha.1.tgz",
+      "integrity": "sha512-cOV3JeeaNafpamYbGh+BoX+4GWrliMpYcgAZojrMPnIY3hupIHP2uToLiiv/iv8/vjaJIkG2fNOOUqOHUefNpw==",
       "bin": {
         "emmett": "dist/cli.js"
       },
       "peerDependencies": {
+        "@event-driven-io/emmett-shims": "0.20.0-alpha.1",
         "@types/async-retry": "^1.4.8",
         "@types/uuid": "^10.0.0",
         "async-retry": "^1.3.3",
         "commander": "^12.1.0",
         "ts-node": "^10.9.2",
-        "uuid": "^10.0.0",
-        "web-streams-polyfill": "^4.0.0"
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/@event-driven-io/emmett-expressjs": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett-expressjs/-/emmett-expressjs-0.19.0.tgz",
-      "integrity": "sha512-pVQTGjV6Q48ZeihU0vi2FizjhvSaAmLmHoFpK6vGa96krJqFPg/9W1wmvESr+NVGMdutSS422byoHDjLFgr+DQ==",
+      "version": "0.20.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett-expressjs/-/emmett-expressjs-0.20.0-alpha.1.tgz",
+      "integrity": "sha512-Qlo2hJuuDCQ+v6X77csuWMLJl4OOJGb9Lq2Wn5gHvEwvUrcxgv7Fk92ng4+qS8C0M3HEGhdQkjDBDJHdfi2PJg==",
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.19.0",
+        "@event-driven-io/emmett": "0.20.0-alpha.1",
         "@types/express": "^4.17.21",
         "@types/supertest": "^6.0.2",
         "express": "^4.19.2",
@@ -559,24 +559,33 @@
       }
     },
     "node_modules/@event-driven-io/emmett-postgresql": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett-postgresql/-/emmett-postgresql-0.19.0.tgz",
-      "integrity": "sha512-33Njnos0ahdlzl11zo1HIrD2MrYGfEteE0NZy2Bb/fCUuPe+uDztgjY4fL1brgxH11MCe6xLl0kEW9o1gI/Org==",
+      "version": "0.20.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett-postgresql/-/emmett-postgresql-0.20.0-alpha.1.tgz",
+      "integrity": "sha512-QCkc/pllWp37vV7Ka9N89rbxrEjeeEOayVIbtSFt12NMmNnHgwtChgIY+mV+SF+TFRDCP2BGVHWpWNKhtK3t2w==",
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.19.0",
-        "@event-driven-io/pongo": "0.15.0"
+        "@event-driven-io/emmett": "0.20.0-alpha.1",
+        "@event-driven-io/pongo": "0.15.3"
+      }
+    },
+    "node_modules/@event-driven-io/emmett-shims": {
+      "version": "0.20.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett-shims/-/emmett-shims-0.20.0-alpha.1.tgz",
+      "integrity": "sha512-3SBYHJcaIlgM7+csOnHvmyoGpDA+6o2ybtqkRo+m9MW3yfRL9CaPA3iyPc3yDwLBlKM8EatM5IZqKWAEuY7tZA==",
+      "peer": true,
+      "peerDependencies": {
+        "web-streams-polyfill": "^4.0.0"
       }
     },
     "node_modules/@event-driven-io/pongo": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@event-driven-io/pongo/-/pongo-0.15.0.tgz",
-      "integrity": "sha512-awzlvTzweXUPuR/am2qsttRsS+JktYajCyutIpmA9Zl+PqueeeA59oB3j5nP30Tt2xL2VzyCgn7H9iHZX27RJA==",
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@event-driven-io/pongo/-/pongo-0.15.3.tgz",
+      "integrity": "sha512-KNEK21z3vaan8oX+WrUq6DSb7CWL/g+044FLDnDZ2zN4HkMMCc/oAWPSchRo+NgTi7oEV5sl0dYeFa4hrIodhw==",
       "peer": true,
       "bin": {
         "pongo": "dist/cli.js"
       },
       "peerDependencies": {
-        "@event-driven-io/dumbo": "0.11.0",
+        "@event-driven-io/dumbo": "0.11.1",
         "@types/mongodb": "^4.0.7",
         "@types/pg": "^8.11.6",
         "@types/uuid": "^10.0.0",

--- a/samples/webApi/expressjs-with-postgresql/package.json
+++ b/samples/webApi/expressjs-with-postgresql/package.json
@@ -38,9 +38,9 @@
   },
   "homepage": "https://github.com/event-driven-io/emmett#readme",
   "dependencies": {
-    "@event-driven-io/emmett": "0.19.0",
-    "@event-driven-io/emmett-expressjs": "0.19.0",
-    "@event-driven-io/emmett-postgresql": "0.19.0"
+    "@event-driven-io/emmett": "0.20.0-alpha.1",
+    "@event-driven-io/emmett-expressjs": "0.20.0-alpha.1",
+    "@event-driven-io/emmett-postgresql": "0.20.0-alpha.1"
   },
   "devDependencies": {
     "@testcontainers/postgresql": "^10.10.3",

--- a/samples/webApi/expressjs-with-postgresql/src/shoppingCarts/api.ts
+++ b/samples/webApi/expressjs-with-postgresql/src/shoppingCarts/api.ts
@@ -28,7 +28,7 @@ import { getClientShoppingSummary } from './getClientShoppingSummary';
 import { getDetailsById } from './getDetails';
 import { evolve, initialState } from './shoppingCart';
 
-export const handle = CommandHandler(evolve, initialState);
+export const handle = CommandHandler({ evolve, initialState });
 
 export const getShoppingCartId = (clientId: string) =>
   `shopping_cart:${assertNotEmptyString(clientId)}:current`;

--- a/src/docs/snippets/gettingStarted/commandHandler.ts
+++ b/src/docs/snippets/gettingStarted/commandHandler.ts
@@ -2,5 +2,5 @@
 import { CommandHandler } from '@event-driven-io/emmett';
 import { evolve, initialState } from './shoppingCart';
 
-export const handle = CommandHandler(evolve, initialState);
+export const handle = CommandHandler({ evolve, initialState });
 // #endregion command-handler

--- a/src/docs/snippets/gettingStarted/webApi/addProductVerticalSlice.ts
+++ b/src/docs/snippets/gettingStarted/webApi/addProductVerticalSlice.ts
@@ -19,7 +19,7 @@ import { getShoppingCartId } from './simpleApi';
 
 // #region vertical-slice
 
-const handle = CommandHandler(evolve, initialState);
+const handle = CommandHandler({ evolve, initialState });
 
 type AddProductItemRequest = Request<
   Partial<{ clientId: string; shoppingCartId: string }>,

--- a/src/docs/snippets/gettingStarted/webApi/shoppingCartApiSetup.ts
+++ b/src/docs/snippets/gettingStarted/webApi/shoppingCartApiSetup.ts
@@ -17,7 +17,7 @@ import { Router } from 'express';
 import { evolve, initialState } from '../shoppingCart';
 
 // Let's setup the command handler, we'll use it in endpoints
-const handle = CommandHandler(evolve, initialState);
+const handle = CommandHandler({ evolve, initialState });
 
 export const shoppingCartApi =
   (

--- a/src/docs/snippets/gettingStarted/webApi/shoppingCartEndpointWithOn.ts
+++ b/src/docs/snippets/gettingStarted/webApi/shoppingCartEndpointWithOn.ts
@@ -11,7 +11,7 @@ import type { AddProductItemToShoppingCart } from '../commands';
 import { evolve, initialState } from '../shoppingCart';
 import { getShoppingCartId } from './simpleApi';
 
-const handle = CommandHandler(evolve, initialState);
+const handle = CommandHandler({ evolve, initialState });
 const router: Router = Router();
 
 const getUnitPrice = (_productId: string) => {

--- a/src/docs/snippets/gettingStarted/webApi/simpleApi.ts
+++ b/src/docs/snippets/gettingStarted/webApi/simpleApi.ts
@@ -27,7 +27,7 @@ import type {
 import type { ProductItem, ShoppingCartEvent } from '../events';
 import { evolve, initialState, type ShoppingCart } from '../shoppingCart';
 
-export const handle = CommandHandler(evolve, initialState);
+export const handle = CommandHandler({ evolve, initialState });
 
 export const getShoppingCartId = (clientId: string) =>
   `shopping_cart:${assertNotEmptyString(clientId)}:current`;

--- a/src/e2e/esmCompatibility/app/counter.ts
+++ b/src/e2e/esmCompatibility/app/counter.ts
@@ -1,5 +1,5 @@
-import type { Event, Command } from '@event-driven-io/emmett';
-import { IllegalStateError, CommandHandler } from '@event-driven-io/emmett';
+import type { Command, Event } from '@event-driven-io/emmett';
+import { CommandHandler, IllegalStateError } from '@event-driven-io/emmett';
 import { match } from 'ts-pattern';
 
 export type CounterIncremented = Event<'CounterIncremented', { by: number }>;
@@ -113,4 +113,4 @@ export const evolve = (state: Counter, event: CounterEvent) => {
     .exhaustive();
 };
 
-export const handle = CommandHandler(evolve, initialState);
+export const handle = CommandHandler({ evolve, initialState });

--- a/src/e2e/esmCompatibility/package-lock.json
+++ b/src/e2e/esmCompatibility/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "hasInstallScript": true,
       "dependencies": {
-        "@event-driven-io/emmett": "0.5.1",
+        "@event-driven-io/emmett": "0.20.0-alpha.1",
         "nuxt": "^3.10.3",
         "ts-pattern": "^5.0.8"
       }
@@ -539,6 +539,28 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.20.1",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.1.tgz",
@@ -555,9 +577,30 @@
       }
     },
     "node_modules/@event-driven-io/emmett": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett/-/emmett-0.5.1.tgz",
-      "integrity": "sha512-KwegmkubBf6/Btv8CL4tTN38QY9Mfg3NzbtI1Kkd7bk7duNu/VnBEswF598CBmGKl9pbMbQpco2r3bc8d6PePw=="
+      "version": "0.20.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett/-/emmett-0.20.0-alpha.1.tgz",
+      "integrity": "sha512-cOV3JeeaNafpamYbGh+BoX+4GWrliMpYcgAZojrMPnIY3hupIHP2uToLiiv/iv8/vjaJIkG2fNOOUqOHUefNpw==",
+      "bin": {
+        "emmett": "dist/cli.js"
+      },
+      "peerDependencies": {
+        "@event-driven-io/emmett-shims": "0.20.0-alpha.1",
+        "@types/async-retry": "^1.4.8",
+        "@types/uuid": "^10.0.0",
+        "async-retry": "^1.3.3",
+        "commander": "^12.1.0",
+        "ts-node": "^10.9.2",
+        "uuid": "^10.0.0"
+      }
+    },
+    "node_modules/@event-driven-io/emmett-shims": {
+      "version": "0.20.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett-shims/-/emmett-shims-0.20.0-alpha.1.tgz",
+      "integrity": "sha512-3SBYHJcaIlgM7+csOnHvmyoGpDA+6o2ybtqkRo+m9MW3yfRL9CaPA3iyPc3yDwLBlKM8EatM5IZqKWAEuY7tZA==",
+      "peer": true,
+      "peerDependencies": {
+        "web-streams-polyfill": "^4.0.0"
+      }
     },
     "node_modules/@fastify/busboy": {
       "version": "2.1.1",
@@ -1697,6 +1740,30 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "peer": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "peer": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "peer": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "peer": true
+    },
     "node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
@@ -1731,6 +1798,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@types/async-retry": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/async-retry/-/async-retry-1.4.9.tgz",
+      "integrity": "sha512-s1ciZQJzRh3708X/m3vPExr5KJlzlZJvXsKpbtE2luqNcbROr64qU+3KpJsYHqWMeaxI839OvXf9PrUSw1Xtyg==",
+      "peer": true,
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -1756,6 +1832,18 @@
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
+      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
+      "peer": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "peer": true
     },
     "node_modules/@unhead/dom": {
       "version": "1.8.11",
@@ -2130,6 +2218,18 @@
         "acorn": "^8"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "peer": true,
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -2267,6 +2367,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "peer": true
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2314,6 +2420,24 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
       "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "peer": true,
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/async-retry/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/async-sema": {
       "version": "3.1.1",
@@ -2836,11 +2960,12 @@
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw=="
     },
     "node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "peer": true,
       "engines": {
-        "node": ">= 10"
+        "node": ">=18"
       }
     },
     "node_modules/commondir": {
@@ -4698,6 +4823,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "peer": true
     },
     "node_modules/make-fetch-happen": {
       "version": "13.0.0",
@@ -7334,6 +7465,14 @@
         "url": "https://opencollective.com/svgo"
       }
     },
+    "node_modules/svgo/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/system-architecture": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/system-architecture/-/system-architecture-0.1.0.tgz",
@@ -7481,6 +7620,58 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "peer": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/ts-pattern": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.0.8.tgz",
@@ -7508,6 +7699,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/ufo": {
@@ -7877,6 +8081,25 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "peer": true
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -8370,6 +8593,15 @@
         "vue": "^3.2.0"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0.tgz",
+      "integrity": "sha512-0zJXHRAYEjM2tUfZ2DiSOHAa2aw1tisnnhU3ufD57R8iefL+DcdJyRBRyJpG+NUimDgbTI/lH+gAE1PAvV3Cgw==",
+      "peer": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -8584,6 +8816,15 @@
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/zhead": {

--- a/src/e2e/esmCompatibility/package.json
+++ b/src/e2e/esmCompatibility/package.json
@@ -9,7 +9,7 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
-    "@event-driven-io/emmett": "0.5.1",
+    "@event-driven-io/emmett": "0.20.0-alpha.1",
     "nuxt": "^3.10.3",
     "ts-pattern": "^5.0.8"
   }

--- a/src/e2e/esmCompatibility/server/routes/counter/[streamId]/index.get.ts
+++ b/src/e2e/esmCompatibility/server/routes/counter/[streamId]/index.get.ts
@@ -7,7 +7,7 @@ export default eventHandler(async (event) => {
     setResponseStatus(event, 400);
     return sendError(event, new Error('Stream id not provided!'));
   }
-  const state = await eventStore.aggregateStream(streamId, {
+  const { state } = await eventStore.aggregateStream(streamId, {
     evolve,
     initialState,
   });

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@event-driven-io/core",
-  "version": "0.19.1",
+  "version": "0.20.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@event-driven-io/core",
-      "version": "0.19.1",
+      "version": "0.20.0-alpha.1",
       "workspaces": [
         "packages/emmett-shims",
         "packages/emmett",
@@ -11028,12 +11028,12 @@
     },
     "packages/emmett": {
       "name": "@event-driven-io/emmett",
-      "version": "0.19.1",
+      "version": "0.20.0-alpha.1",
       "bin": {
         "emmett": "dist/cli.js"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett-shims": "0.19.1",
+        "@event-driven-io/emmett-shims": "0.20.0-alpha.1",
         "@types/async-retry": "^1.4.8",
         "@types/uuid": "^10.0.0",
         "async-retry": "^1.3.3",
@@ -11044,21 +11044,21 @@
     },
     "packages/emmett-esdb": {
       "name": "@event-driven-io/emmett-esdb",
-      "version": "0.19.1",
+      "version": "0.20.0-alpha.1",
       "devDependencies": {
-        "@event-driven-io/emmett-testcontainers": "0.19.1"
+        "@event-driven-io/emmett-testcontainers": "0.20.0-alpha.1"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.19.1",
+        "@event-driven-io/emmett": "0.20.0-alpha.1",
         "@eventstore/db-client": "^6.2.1"
       }
     },
     "packages/emmett-expressjs": {
       "name": "@event-driven-io/emmett-expressjs",
-      "version": "0.19.1",
+      "version": "0.20.0-alpha.1",
       "devDependencies": {},
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.19.1",
+        "@event-driven-io/emmett": "0.20.0-alpha.1",
         "@types/express": "^4.17.21",
         "@types/supertest": "^6.0.2",
         "express": "^4.19.2",
@@ -11069,10 +11069,10 @@
     },
     "packages/emmett-fastify": {
       "name": "@event-driven-io/emmett-fastify",
-      "version": "0.19.1",
+      "version": "0.20.0-alpha.1",
       "devDependencies": {},
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.19.1",
+        "@event-driven-io/emmett": "0.20.0-alpha.1",
         "@fastify/compress": "^7.0.3",
         "@fastify/etag": "^5.2.0",
         "@fastify/formbody": "^7.4.0",
@@ -11082,19 +11082,19 @@
     },
     "packages/emmett-postgresql": {
       "name": "@event-driven-io/emmett-postgresql",
-      "version": "0.19.1",
+      "version": "0.20.0-alpha.1",
       "devDependencies": {
-        "@event-driven-io/emmett-testcontainers": "0.19.1",
+        "@event-driven-io/emmett-testcontainers": "0.20.0-alpha.1",
         "@testcontainers/postgresql": "^10.12.0"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.19.1",
+        "@event-driven-io/emmett": "0.20.0-alpha.1",
         "@event-driven-io/pongo": "0.15.3"
       }
     },
     "packages/emmett-shims": {
       "name": "@event-driven-io/emmett-shims",
-      "version": "0.19.1",
+      "version": "0.20.0-alpha.1",
       "devDependencies": {
         "@types/node": "^20.11.30"
       },
@@ -11113,9 +11113,9 @@
     },
     "packages/emmett-testcontainers": {
       "name": "@event-driven-io/emmett-testcontainers",
-      "version": "0.19.1",
+      "version": "0.20.0-alpha.1",
       "dependencies": {
-        "@event-driven-io/emmett": "0.19.1",
+        "@event-driven-io/emmett": "0.20.0-alpha.1",
         "testcontainers": "^10.12.0"
       },
       "devDependencies": {
@@ -11124,12 +11124,12 @@
     },
     "packages/emmett-tests": {
       "name": "@event-driven-io/emmett-tests",
-      "version": "0.19.1",
+      "version": "0.20.0-alpha.1",
       "devDependencies": {
-        "@event-driven-io/emmett": "0.19.1",
-        "@event-driven-io/emmett-esdb": "0.19.1",
-        "@event-driven-io/emmett-postgresql": "0.19.1",
-        "@event-driven-io/emmett-testcontainers": "0.19.1",
+        "@event-driven-io/emmett": "0.20.0-alpha.1",
+        "@event-driven-io/emmett-esdb": "0.20.0-alpha.1",
+        "@event-driven-io/emmett-postgresql": "0.20.0-alpha.1",
+        "@event-driven-io/emmett-testcontainers": "0.20.0-alpha.1",
         "@testcontainers/postgresql": "^10.12.0"
       }
     }

--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@event-driven-io/core",
   "type": "module",
-  "version": "0.19.1",
+  "version": "0.20.0-alpha.1",
   "description": "Emmett - Event Sourcing development made simple",
   "engines": {
     "node": ">=20.11.1"

--- a/src/packages/emmett-esdb/package.json
+++ b/src/packages/emmett-esdb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@event-driven-io/emmett-esdb",
   "type": "module",
-  "version": "0.19.1",
+  "version": "0.20.0-alpha.1",
   "description": "Emmett - EventStoreDB - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -48,10 +48,10 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "@event-driven-io/emmett-testcontainers": "0.19.1"
+    "@event-driven-io/emmett-testcontainers": "0.20.0-alpha.1"
   },
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.19.1",
+    "@event-driven-io/emmett": "0.20.0-alpha.1",
     "@eventstore/db-client": "^6.2.1"
   }
 }

--- a/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.ts
+++ b/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.ts
@@ -176,7 +176,12 @@ export const getEventStoreDBEventStore = (
           },
         );
 
-        return { nextExpectedStreamVersion: appendResult.nextExpectedRevision };
+        return {
+          nextExpectedStreamVersion: appendResult.nextExpectedRevision,
+          createdNewStream:
+            appendResult.nextExpectedRevision >=
+            BigInt(serializedEvents.length),
+        };
       } catch (error) {
         if (error instanceof WrongExpectedVersionError) {
           throw new ExpectedVersionConflictError(

--- a/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.ts
+++ b/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.ts
@@ -124,7 +124,8 @@ export const getEventStoreDBEventStore = (
         ReadEventMetadataWithGlobalPosition
       >[] = [];
 
-      let currentStreamVersion: bigint | undefined = undefined;
+      let currentStreamVersion: bigint =
+        EventStoreDBEventStoreDefaultStreamVersion;
 
       try {
         for await (const { event } of eventStore.readStream<EventType>(
@@ -135,15 +136,18 @@ export const getEventStoreDBEventStore = (
           events.push(mapFromESDBEvent(event));
           currentStreamVersion = event.revision;
         }
-        return currentStreamVersion
-          ? {
-              currentStreamVersion,
-              events,
-            }
-          : null;
+        return {
+          currentStreamVersion,
+          events,
+          streamExists: true,
+        };
       } catch (error) {
         if (error instanceof StreamNotFoundError) {
-          return null;
+          return {
+            currentStreamVersion,
+            events: [],
+            streamExists: false,
+          };
         }
 
         throw error;

--- a/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.ts
+++ b/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.ts
@@ -3,6 +3,7 @@ import {
   NO_CONCURRENCY_CHECK,
   STREAM_DOES_NOT_EXIST,
   STREAM_EXISTS,
+  assertExpectedVersionMatchesCurrent,
   globalStreamCaughtUp,
   streamTransformations,
   type AggregateStreamOptions,
@@ -89,6 +90,7 @@ export const getEventStoreDBEventStore = (
         assertExpectedVersionMatchesCurrent(
           currentStreamVersion,
           expectedStreamVersion,
+          EventStoreDBEventStoreDefaultStreamVersion,
         );
 
         return {
@@ -234,29 +236,6 @@ const toExpectedVersion = (
   if (expected == ESDB_STREAM_EXISTS) return STREAM_EXISTS;
 
   return expected;
-};
-
-const matchesExpectedVersion = (
-  current: bigint | undefined,
-  expected: ExpectedStreamVersion,
-): boolean => {
-  if (expected === NO_CONCURRENCY_CHECK) return true;
-
-  if (expected == STREAM_DOES_NOT_EXIST) return current === undefined;
-
-  if (expected == STREAM_EXISTS) return current !== undefined;
-
-  return current === expected;
-};
-
-const assertExpectedVersionMatchesCurrent = (
-  current: bigint | undefined,
-  expected: ExpectedStreamVersion | undefined,
-): void => {
-  expected ??= NO_CONCURRENCY_CHECK;
-
-  if (!matchesExpectedVersion(current, expected))
-    throw new ExpectedVersionConflictError(current, expected);
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/packages/emmett-expressjs/package.json
+++ b/src/packages/emmett-expressjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-expressjs",
-  "version": "0.19.1",
+  "version": "0.20.0-alpha.1",
   "type": "module",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
@@ -49,7 +49,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.19.1",
+    "@event-driven-io/emmett": "0.20.0-alpha.1",
     "@types/express": "^4.17.21",
     "@types/supertest": "^6.0.2",
     "express": "^4.19.2",

--- a/src/packages/emmett-fastify/package.json
+++ b/src/packages/emmett-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-fastify",
-  "version": "0.19.1",
+  "version": "0.20.0-alpha.1",
   "type": "module",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
@@ -53,7 +53,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.19.1",
+    "@event-driven-io/emmett": "0.20.0-alpha.1",
     "fastify": "^4.28.1",
     "@fastify/compress": "^7.0.3",
     "@fastify/etag": "^5.2.0",

--- a/src/packages/emmett-postgresql/package.json
+++ b/src/packages/emmett-postgresql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-postgresql",
-  "version": "0.19.1",
+  "version": "0.20.0-alpha.1",
   "type": "module",
   "description": "Emmett - PostgreSQL - Event Sourcing development made simple",
   "scripts": {
@@ -70,10 +70,10 @@
   ],
   "devDependencies": {
     "@testcontainers/postgresql": "^10.12.0",
-    "@event-driven-io/emmett-testcontainers": "0.19.1"
+    "@event-driven-io/emmett-testcontainers": "0.20.0-alpha.1"
   },
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.19.1",
+    "@event-driven-io/emmett": "0.20.0-alpha.1",
     "@event-driven-io/pongo": "0.15.3"
   }
 }

--- a/src/packages/emmett-postgresql/src/benchmarks/index.ts
+++ b/src/packages/emmett-postgresql/src/benchmarks/index.ts
@@ -64,7 +64,7 @@ const aggregateStream = () =>
     initialState,
   });
 
-export const handle = CommandHandler(evolve, initialState);
+export const handle = CommandHandler({ evolve, initialState });
 
 const handleCommand = () =>
   handle(eventStore, ids[0]!, (state) => ({

--- a/src/packages/emmett-postgresql/src/eventStore/commandHandler.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/commandHandler.int.spec.ts
@@ -74,6 +74,7 @@ void describe('Postgres Projections', () => {
     const couponId = uuid();
 
     assertEqual(1n, result.nextExpectedStreamVersion);
+    assertEqual(true, result.createdNewStream);
 
     await handle(eventStore, shoppingCartId, () => ({
       type: 'ProductItemAdded',

--- a/src/packages/emmett-postgresql/src/eventStore/commandHandler.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/commandHandler.int.spec.ts
@@ -56,7 +56,7 @@ void describe('Postgres Projections', () => {
   });
 
   void it('should handle command correctly', async () => {
-    const handle = CommandHandler(evolve, initialState);
+    const handle = CommandHandler({ evolve, initialState });
 
     const productItem: PricedProductItem = {
       productId: '123',

--- a/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.ts
@@ -7,10 +7,9 @@ import {
   type NodePostgresPoolClientConnection,
 } from '@event-driven-io/dumbo';
 import {
+  assertExpectedVersionMatchesCurrent,
   ExpectedVersionConflictError,
   NO_CONCURRENCY_CHECK,
-  STREAM_DOES_NOT_EXIST,
-  STREAM_EXISTS,
   type AggregateStreamOptions,
   type AggregateStreamResult,
   type AppendToStreamOptions,
@@ -20,7 +19,6 @@ import {
   type EventStore,
   type EventStoreSession,
   type EventStoreSessionFactory,
-  type ExpectedStreamVersion,
   type ProjectionRegistration,
   type ReadEventMetadataWithGlobalPosition,
   type ReadStreamOptions,
@@ -201,6 +199,7 @@ export const getPostgreSQLEventStore = (
       assertExpectedVersionMatchesCurrent(
         currentStreamVersion,
         expectedStreamVersion,
+        PostgreSQLEventStoreDefaultStreamVersion,
       );
 
       for (const event of result.events) {
@@ -291,27 +290,4 @@ export const getPostgreSQLEventStore = (
       });
     },
   };
-};
-
-const matchesExpectedVersion = (
-  current: bigint | undefined,
-  expected: ExpectedStreamVersion,
-): boolean => {
-  if (expected === NO_CONCURRENCY_CHECK) return true;
-
-  if (expected == STREAM_DOES_NOT_EXIST) return current === undefined;
-
-  if (expected == STREAM_EXISTS) return current !== undefined;
-
-  return current === expected;
-};
-
-const assertExpectedVersionMatchesCurrent = (
-  current: bigint | undefined,
-  expected: ExpectedStreamVersion | undefined,
-): void => {
-  expected ??= NO_CONCURRENCY_CHECK;
-
-  if (!matchesExpectedVersion(current, expected))
-    throw new ExpectedVersionConflictError(current, expected);
 };

--- a/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.ts
@@ -196,14 +196,6 @@ export const getPostgreSQLEventStore = (
       let state = initialState();
 
       const result = await this.readStream<EventType>(streamName, options.read);
-
-      if (result === null)
-        return {
-          currentStreamVersion: PostgreSQLEventStoreDefaultStreamVersion,
-          state,
-          streamExists: false,
-        };
-
       const currentStreamVersion = result.currentStreamVersion;
 
       assertExpectedVersionMatchesCurrent(
@@ -220,7 +212,7 @@ export const getPostgreSQLEventStore = (
       return {
         currentStreamVersion: currentStreamVersion,
         state,
-        streamExists: true,
+        streamExists: result.streamExists,
       };
     },
 

--- a/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.ts
@@ -258,7 +258,11 @@ export const getPostgreSQLEventStore = (
           options?.expectedStreamVersion ?? NO_CONCURRENCY_CHECK,
         );
 
-      return { nextExpectedStreamVersion: appendResult.nextStreamPosition };
+      return {
+        nextExpectedStreamVersion: appendResult.nextStreamPosition,
+        createdNewStream:
+          appendResult.nextStreamPosition >= BigInt(events.length),
+      };
     },
     close: () => pool.close(),
 

--- a/src/packages/emmett-postgresql/src/eventStore/schema/readStream.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/readStream.int.spec.ts
@@ -1,9 +1,11 @@
 import { dumbo, type Dumbo } from '@event-driven-io/dumbo';
 import {
+  assertDeepEqual,
   assertEqual,
+  assertFalse,
   assertIsNotNull,
-  assertIsNull,
   assertMatches,
+  assertTrue,
   type Event,
 } from '@event-driven-io/emmett';
 import {
@@ -13,6 +15,7 @@ import {
 import { after, before, describe, it } from 'node:test';
 import { v4 as uuid } from 'uuid';
 import { createEventStoreSchema } from '.';
+import { PostgreSQLEventStoreDefaultStreamVersion } from '../postgreSQLEventStore';
 import { appendToStream } from './appendToStream';
 import { readStream } from './readStream';
 
@@ -92,9 +95,10 @@ void describe('appendEvent', () => {
       },
     }));
     assertMatches(result.events, expected);
+    assertTrue(result.streamExists);
   });
 
-  void it('returns null from non-existing stream', async () => {
+  void it('returns result with default information from non-existing stream', async () => {
     // Given
     const nonExistingStreamId = uuid();
 
@@ -102,6 +106,11 @@ void describe('appendEvent', () => {
     const result = await readStream(pool.execute, nonExistingStreamId);
 
     // Then
-    assertIsNull(result);
+    assertEqual(
+      PostgreSQLEventStoreDefaultStreamVersion,
+      result.currentStreamVersion,
+    );
+    assertDeepEqual([], result.events);
+    assertFalse(result.streamExists);
   });
 });

--- a/src/packages/emmett-postgresql/src/eventStore/schema/readStream.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/readStream.ts
@@ -12,6 +12,7 @@ import {
   type ReadStreamResult,
 } from '@event-driven-io/emmett';
 import { defaultTag, eventsTable } from './typing';
+import { PostgreSQLEventStoreDefaultStreamVersion } from '../postgreSQLEventStore';
 
 type ReadStreamSqlResult<EventType extends Event> = {
   stream_position: string;
@@ -87,6 +88,11 @@ export const readStream = async <EventType extends Event>(
         currentStreamVersion:
           events[events.length - 1]!.metadata.streamPosition,
         events,
+        streamExists: true,
       }
-    : null;
+    : {
+        currentStreamVersion: PostgreSQLEventStoreDefaultStreamVersion,
+        events: [],
+        streamExists: false,
+      };
 };

--- a/src/packages/emmett-shims/package.json
+++ b/src/packages/emmett-shims/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-shims",
-  "version": "0.19.1",
+  "version": "0.20.0-alpha.1",
   "type": "module",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {

--- a/src/packages/emmett-testcontainers/package.json
+++ b/src/packages/emmett-testcontainers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-testcontainers",
-  "version": "0.19.1",
+  "version": "0.20.0-alpha.1",
   "type": "module",
   "description": "Emmett - TestContainers - Event Sourcing development made simple",
   "scripts": {
@@ -47,7 +47,7 @@
     "dist"
   ],
   "dependencies": {
-    "@event-driven-io/emmett": "0.19.1",
+    "@event-driven-io/emmett": "0.20.0-alpha.1",
     "testcontainers": "^10.12.0"
   },
   "devDependencies": {

--- a/src/packages/emmett-tests/package.json
+++ b/src/packages/emmett-tests/package.json
@@ -2,7 +2,7 @@
   "name": "@event-driven-io/emmett-tests",
   "type": "module",
   "private": true,
-  "version": "0.19.1",
+  "version": "0.20.0-alpha.1",
   "description": "Emmett - Internal E2E Tests",
   "scripts": {
     "build": "tsup",
@@ -55,10 +55,10 @@
     "dist"
   ],
   "devDependencies": {
-    "@event-driven-io/emmett": "0.19.1",
-    "@event-driven-io/emmett-esdb": "0.19.1",
-    "@event-driven-io/emmett-postgresql": "0.19.1",
-    "@event-driven-io/emmett-testcontainers": "0.19.1",
+    "@event-driven-io/emmett": "0.20.0-alpha.1",
+    "@event-driven-io/emmett-esdb": "0.20.0-alpha.1",
+    "@event-driven-io/emmett-postgresql": "0.20.0-alpha.1",
+    "@event-driven-io/emmett-testcontainers": "0.20.0-alpha.1",
     "@testcontainers/postgresql": "^10.12.0"
   }
 }

--- a/src/packages/emmett/package.json
+++ b/src/packages/emmett/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@event-driven-io/emmett",
   "type": "module",
-  "version": "0.19.1",
+  "version": "0.20.0-alpha.1",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -70,7 +70,7 @@
     "emmett": "./dist/cli.js"
   },
   "peerDependencies": {
-    "@event-driven-io/emmett-shims": "0.19.1",
+    "@event-driven-io/emmett-shims": "0.20.0-alpha.1",
     "@types/async-retry": "^1.4.8",
     "@types/uuid": "^10.0.0",
     "async-retry": "^1.3.3",

--- a/src/packages/emmett/src/commandHandling/handleCommand.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.ts
@@ -1,6 +1,6 @@
 import {
   canCreateEventStoreSession,
-  ExpectedVersionConflictError,
+  isExpectedVersionConflictError,
   NO_CONCURRENCY_CHECK,
   nulloSessionFactory,
   STREAM_DOES_NOT_EXIST,
@@ -16,7 +16,9 @@ import { asyncRetry, NoRetries, type AsyncRetryOptions } from '../utils';
 export const CommandHandlerStreamVersionConflictRetryOptions: AsyncRetryOptions =
   {
     retries: 3,
-    shouldRetryError: (error) => error instanceof ExpectedVersionConflictError,
+    minTimeout: 100,
+    factor: 1.5,
+    shouldRetryError: isExpectedVersionConflictError,
   };
 
 export type CommandHandlerRetryOptions =

--- a/src/packages/emmett/src/commandHandling/handleCommand.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.ts
@@ -66,6 +66,14 @@ export const CommandHandler =
 
       const newEvents = Array.isArray(result) ? result : [result];
 
+      if (newEvents.length === 0) {
+        return {
+          newEvents: [],
+          newState: state,
+          nextExpectedStreamVersion: currentStreamVersion,
+        };
+      }
+
       // Either use:
       // - provided expected stream version,
       // - current stream version got from stream aggregation,

--- a/src/packages/emmett/src/commandHandling/handleCommand.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.ts
@@ -71,6 +71,7 @@ export const CommandHandler =
           newEvents: [],
           newState: state,
           nextExpectedStreamVersion: currentStreamVersion,
+          createdNewStream: false,
         };
       }
 

--- a/src/packages/emmett/src/commandHandling/handleCommand.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.ts
@@ -57,9 +57,9 @@ export const CommandHandler =
         },
       });
 
-      // 2. Use the aggregate state or the initial one (when e.g. stream does not exist)
-      const state = aggregationResult?.state ?? initialState();
-      const currentStreamVersion = aggregationResult?.currentStreamVersion;
+      // 2. Use the aggregate state
+      const state = aggregationResult.state;
+      const currentStreamVersion = aggregationResult.currentStreamVersion;
 
       // 3. Run business logic
       const result = handle(state);
@@ -80,8 +80,9 @@ export const CommandHandler =
       // - or expect stream not to exists otherwise.
       const expectedStreamVersion: ExpectedStreamVersion<StreamVersion> =
         options?.expectedStreamVersion ??
-        currentStreamVersion ??
-        STREAM_DOES_NOT_EXIST;
+        (aggregationResult.streamExists
+          ? (currentStreamVersion as ExpectedStreamVersion<StreamVersion>)
+          : STREAM_DOES_NOT_EXIST);
 
       // 4. Append result to the stream
       const appendResult = await eventStore.appendToStream(

--- a/src/packages/emmett/src/commandHandling/handleCommand.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.ts
@@ -1,5 +1,6 @@
 import {
   canCreateEventStoreSession,
+  ExpectedVersionConflictError,
   NO_CONCURRENCY_CHECK,
   nulloSessionFactory,
   STREAM_DOES_NOT_EXIST,
@@ -10,6 +11,36 @@ import {
   type ExpectedStreamVersion,
 } from '../eventStore';
 import type { Event } from '../typing';
+import { asyncRetry, NoRetries, type AsyncRetryOptions } from '../utils';
+
+export const CommandHandlerStreamVersionConflictRetryOptions: AsyncRetryOptions =
+  {
+    retries: 3,
+    shouldRetry: (error) => error instanceof ExpectedVersionConflictError,
+  };
+
+export type CommandHandlerRetryOptions =
+  | AsyncRetryOptions
+  | { onVersionConflict: true | number | AsyncRetryOptions };
+
+const fromCommandHandlerRetryOptions = (
+  retryOptions: CommandHandlerRetryOptions | undefined,
+): AsyncRetryOptions => {
+  if (retryOptions === undefined) return NoRetries;
+
+  if ('onVersionConflict' in retryOptions) {
+    if (typeof retryOptions.onVersionConflict === 'boolean')
+      return CommandHandlerStreamVersionConflictRetryOptions;
+    else if (typeof retryOptions.onVersionConflict === 'number')
+      return {
+        ...CommandHandlerStreamVersionConflictRetryOptions,
+        retries: retryOptions.onVersionConflict,
+      };
+    else return retryOptions.onVersionConflict;
+  }
+
+  return retryOptions;
+};
 
 // #region command-handler
 export type CommandHandlerResult<
@@ -31,80 +62,92 @@ export const CommandHandler =
     store: Store,
     id: string,
     handle: (state: State) => StreamEvent | StreamEvent[],
-    options?: Parameters<Store['appendToStream']>[2] & {
-      expectedStreamVersion?: ExpectedStreamVersion<StreamVersion>;
-    },
-  ): Promise<CommandHandlerResult<State, StreamEvent, StreamVersion>> => {
-    const result = await withSession<
-      Store,
-      StreamVersion,
-      CommandHandlerResult<State, StreamEvent, StreamVersion>
-    >(store, async ({ eventStore }) => {
-      const streamName = mapToStreamId(id);
+    options?: Parameters<Store['appendToStream']>[2] &
+      (
+        | {
+            expectedStreamVersion?: ExpectedStreamVersion<StreamVersion>;
+          }
+        | {
+            retry?: CommandHandlerRetryOptions;
+          }
+      ),
+  ): Promise<CommandHandlerResult<State, StreamEvent, StreamVersion>> =>
+    asyncRetry(
+      async () => {
+        const result = await withSession<
+          Store,
+          StreamVersion,
+          CommandHandlerResult<State, StreamEvent, StreamVersion>
+        >(store, async ({ eventStore }) => {
+          const streamName = mapToStreamId(id);
 
-      // 1. Aggregate the stream
-      const aggregationResult = await eventStore.aggregateStream<
-        State,
-        StreamEvent
-      >(streamName, {
-        evolve,
-        initialState,
-        read: {
-          // expected stream version is passed to fail fast
-          // if stream is in the wrong state
-          expectedStreamVersion:
-            options?.expectedStreamVersion ?? NO_CONCURRENCY_CHECK,
-        },
-      });
+          // 1. Aggregate the stream
+          const aggregationResult = await eventStore.aggregateStream<
+            State,
+            StreamEvent
+          >(streamName, {
+            evolve,
+            initialState,
+            read: {
+              // expected stream version is passed to fail fast
+              // if stream is in the wrong state
+              expectedStreamVersion:
+                options?.expectedStreamVersion ?? NO_CONCURRENCY_CHECK,
+            },
+          });
 
-      // 2. Use the aggregate state
-      const state = aggregationResult.state;
-      const currentStreamVersion = aggregationResult.currentStreamVersion;
+          // 2. Use the aggregate state
+          const state = aggregationResult.state;
+          const currentStreamVersion = aggregationResult.currentStreamVersion;
 
-      // 3. Run business logic
-      const result = handle(state);
+          // 3. Run business logic
+          const result = handle(state);
 
-      const newEvents = Array.isArray(result) ? result : [result];
+          const newEvents = Array.isArray(result) ? result : [result];
 
-      if (newEvents.length === 0) {
-        return {
-          newEvents: [],
-          newState: state,
-          nextExpectedStreamVersion: currentStreamVersion,
-          createdNewStream: false,
-        };
-      }
+          if (newEvents.length === 0) {
+            return {
+              newEvents: [],
+              newState: state,
+              nextExpectedStreamVersion: currentStreamVersion,
+              createdNewStream: false,
+            };
+          }
 
-      // Either use:
-      // - provided expected stream version,
-      // - current stream version got from stream aggregation,
-      // - or expect stream not to exists otherwise.
-      const expectedStreamVersion: ExpectedStreamVersion<StreamVersion> =
-        options?.expectedStreamVersion ??
-        (aggregationResult.streamExists
-          ? (currentStreamVersion as ExpectedStreamVersion<StreamVersion>)
-          : STREAM_DOES_NOT_EXIST);
+          // Either use:
+          // - provided expected stream version,
+          // - current stream version got from stream aggregation,
+          // - or expect stream not to exists otherwise.
+          const expectedStreamVersion: ExpectedStreamVersion<StreamVersion> =
+            options?.expectedStreamVersion ??
+            (aggregationResult.streamExists
+              ? (currentStreamVersion as ExpectedStreamVersion<StreamVersion>)
+              : STREAM_DOES_NOT_EXIST);
 
-      // 4. Append result to the stream
-      const appendResult = await eventStore.appendToStream(
-        streamName,
-        newEvents,
-        {
-          ...options,
-          expectedStreamVersion,
-        },
-      );
+          // 4. Append result to the stream
+          const appendResult = await eventStore.appendToStream(
+            streamName,
+            newEvents,
+            {
+              ...options,
+              expectedStreamVersion,
+            },
+          );
 
-      // 5. Return result with updated state
-      return {
-        ...appendResult,
-        newEvents,
-        newState: newEvents.reduce(evolve, state),
-      };
-    });
+          // 5. Return result with updated state
+          return {
+            ...appendResult,
+            newEvents,
+            newState: newEvents.reduce(evolve, state),
+          };
+        });
 
-    return result;
-  };
+        return result;
+      },
+      fromCommandHandlerRetryOptions(
+        options && 'retry' in options ? options.retry : undefined,
+      ),
+    );
 // #endregion command-handler
 
 const withSession = <

--- a/src/packages/emmett/src/commandHandling/handleCommand.unit.spec.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.unit.spec.ts
@@ -88,10 +88,10 @@ const addProductItemWithDiscount = (
   ];
 };
 
-const handleCommand = CommandHandler<ShoppingCart, ShoppingCartEvent>(
+const handleCommand = CommandHandler<ShoppingCart, ShoppingCartEvent>({
   evolve,
   initialState,
-);
+});
 
 void describe('Command Handler', () => {
   const eventStore = getInMemoryEventStore();

--- a/src/packages/emmett/src/commandHandling/handleCommand.unit.spec.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.unit.spec.ts
@@ -154,8 +154,21 @@ void describe('Command Handler', () => {
     assertEqual(nextExpectedStreamVersion, 1n);
   });
 
-  void it('retries handling for wrong version and succeeds if conditions are correct', async () => {
-    // Given
+  void it('Returns initial state when no events are returned from the handler', async () => {
+    const entityId = randomUUID();
+
+    const { newEvents, newState, nextExpectedStreamVersion, createdNewStream } =
+      await handleCommand(eventStore, entityId, () => {
+        return [];
+      });
+
+    assertThatArray(newEvents).isEmpty();
+    assertDeepEqual(newState, initialState());
+    assertEqual(nextExpectedStreamVersion, 0n);
+    assertFalse(createdNewStream);
+  });
+
+  void it('Creates new stream on first command and follows up with next expected version', async () => {
     const productItem: PricedProductItem = {
       productId: '123',
       quantity: 10,
@@ -168,18 +181,70 @@ void describe('Command Handler', () => {
       data: { productItem },
     };
 
-    // Create the stream
-    await handleCommand(
+    const { newState: state1, nextExpectedStreamVersion } = await handleCommand(
       eventStore,
       shoppingCartId,
       (state) => addProductItem(command, state),
-      { expectedStreamVersion: 'STREAM_DOES_NOT_EXIST' },
     );
 
-    let tried = 0;
+    assertDeepEqual(state1, {
+      productItems: [productItem],
+      totalAmount: productItem.price * productItem.quantity,
+    });
+    assertEqual(nextExpectedStreamVersion, 1n);
 
-    const { nextExpectedStreamVersion, newState, newEvents, createdNewStream } =
+    const { nextExpectedStreamVersion: version2 } = await handleCommand(
+      eventStore,
+      shoppingCartId,
+      (state) => addProductItem(command, state),
+      { expectedStreamVersion: nextExpectedStreamVersion },
+    );
+
+    assertEqual(version2, 2n);
+  });
+
+  void it('Does not create a new stream if no events are produced on first command', async () => {
+    const entityId = randomUUID();
+
+    const { createdNewStream, newEvents, nextExpectedStreamVersion } =
+      await handleCommand(eventStore, entityId, () => []);
+
+    assertFalse(createdNewStream);
+    assertThatArray(newEvents).isEmpty();
+    assertEqual(nextExpectedStreamVersion, 0n);
+  });
+
+  void describe('retries', () => {
+    void it('retries handling for wrong version and succeeds if conditions are correct', async () => {
+      // Given
+      const productItem: PricedProductItem = {
+        productId: '123',
+        quantity: 10,
+        price: 3,
+      };
+
+      const shoppingCartId = randomUUID();
+      const command: AddProductItem = {
+        type: 'AddProductItem',
+        data: { productItem },
+      };
+
+      // Create the stream
       await handleCommand(
+        eventStore,
+        shoppingCartId,
+        (state) => addProductItem(command, state),
+        { expectedStreamVersion: 'STREAM_DOES_NOT_EXIST' },
+      );
+
+      let tried = 0;
+
+      const {
+        nextExpectedStreamVersion,
+        newState,
+        newEvents,
+        createdNewStream,
+      } = await handleCommand(
         eventStore,
         shoppingCartId,
         (state) => {
@@ -193,224 +258,235 @@ void describe('Command Handler', () => {
         },
       );
 
-    assertEqual(2, tried);
-    assertFalse(createdNewStream);
-    assertThatArray(newEvents).hasSize(1);
-    assertDeepEqual(newState, {
-      productItems: [productItem, productItem],
-      totalAmount: productItem.price * productItem.quantity * 2,
+      assertEqual(2, tried);
+      assertFalse(createdNewStream);
+      assertThatArray(newEvents).hasSize(1);
+      assertDeepEqual(newState, {
+        productItems: [productItem, productItem],
+        totalAmount: productItem.price * productItem.quantity * 2,
+      });
+      assertEqual(nextExpectedStreamVersion, 2n);
     });
-    assertEqual(nextExpectedStreamVersion, 2n);
-  });
 
-  void it('When called successfuly returns new state for multiple returned events', async () => {
-    const productItem: PricedProductItem = {
-      productId: '123',
-      quantity: 10,
-      price: 3,
-    };
+    void it('When called successfuly returns new state for multiple returned events', async () => {
+      const productItem: PricedProductItem = {
+        productId: '123',
+        quantity: 10,
+        price: 3,
+      };
 
-    const shoppingCartId = randomUUID();
-    const command: AddProductItem = {
-      type: 'AddProductItem',
-      data: { productItem },
-    };
+      const shoppingCartId = randomUUID();
+      const command: AddProductItem = {
+        type: 'AddProductItem',
+        data: { productItem },
+      };
 
-    const { nextExpectedStreamVersion, newState, newEvents, createdNewStream } =
-      await handleCommand(eventStore, shoppingCartId, (state) =>
+      const {
+        nextExpectedStreamVersion,
+        newState,
+        newEvents,
+        createdNewStream,
+      } = await handleCommand(eventStore, shoppingCartId, (state) =>
         addProductItemWithDiscount(command, state),
       );
 
-    assertTrue(createdNewStream);
-    assertThatArray(newEvents).hasSize(2);
-    assertDeepEqual(newState, {
-      productItems: [productItem],
-      totalAmount:
-        productItem.price * productItem.quantity * (1 - defaultDiscount),
+      assertTrue(createdNewStream);
+      assertThatArray(newEvents).hasSize(2);
+      assertDeepEqual(newState, {
+        productItems: [productItem],
+        totalAmount:
+          productItem.price * productItem.quantity * (1 - defaultDiscount),
+      });
+      assertEqual(nextExpectedStreamVersion, 2n);
     });
-    assertEqual(nextExpectedStreamVersion, 2n);
-  });
 
-  void it('When returning an empty array of events returns the same state', async () => {
-    const productItem: PricedProductItem = {
-      productId: '123',
-      quantity: 10,
-      price: 3,
-    };
+    void it('When returning an empty array of events returns the same state', async () => {
+      const productItem: PricedProductItem = {
+        productId: '123',
+        quantity: 10,
+        price: 3,
+      };
 
-    const shoppingCartId = randomUUID();
-    const command: AddProductItem = {
-      type: 'AddProductItem',
-      data: { productItem },
-    };
+      const shoppingCartId = randomUUID();
+      const command: AddProductItem = {
+        type: 'AddProductItem',
+        data: { productItem },
+      };
 
-    const { nextExpectedStreamVersion, newState, newEvents, createdNewStream } =
-      await handleCommand(eventStore, shoppingCartId, (state) =>
+      const {
+        nextExpectedStreamVersion,
+        newState,
+        newEvents,
+        createdNewStream,
+      } = await handleCommand(eventStore, shoppingCartId, (state) =>
         command.data.productItem.price > 100
           ? addProductItemWithDiscount(command, state)
           : [],
       );
 
-    assertFalse(createdNewStream);
-    assertEqual(nextExpectedStreamVersion, 0n);
-    assertDeepEqual(newEvents, []);
-    assertDeepEqual(newState, initialState());
-  });
+      assertFalse(createdNewStream);
+      assertEqual(nextExpectedStreamVersion, 0n);
+      assertDeepEqual(newEvents, []);
+      assertDeepEqual(newState, initialState());
+    });
 
-  void it('Fails after retrying multiple times due to version conflicts', async () => {
-    const productItem: PricedProductItem = {
-      productId: '123',
-      quantity: 10,
-      price: 3,
-    };
+    void it('Fails after retrying multiple times due to version conflicts', async () => {
+      const productItem: PricedProductItem = {
+        productId: '123',
+        quantity: 10,
+        price: 3,
+      };
 
-    const shoppingCartId = randomUUID();
-    const command: AddProductItem = {
-      type: 'AddProductItem',
-      data: { productItem },
-    };
+      const shoppingCartId = randomUUID();
+      const command: AddProductItem = {
+        type: 'AddProductItem',
+        data: { productItem },
+      };
 
-    // Create the stream
-    await handleCommand(
-      eventStore,
-      shoppingCartId,
-      (state) => addProductItem(command, state),
-      { expectedStreamVersion: 'STREAM_DOES_NOT_EXIST' },
-    );
+      // Create the stream
+      await handleCommand(
+        eventStore,
+        shoppingCartId,
+        (state) => addProductItem(command, state),
+        { expectedStreamVersion: 'STREAM_DOES_NOT_EXIST' },
+      );
 
-    let tried = 0;
+      let tried = 0;
 
-    await assertThrowsAsync(
-      async () => {
-        await handleCommand(
-          eventStore,
-          shoppingCartId,
-          () => {
+      await assertThrowsAsync(
+        async () => {
+          await handleCommand(
+            eventStore,
+            shoppingCartId,
+            () => {
+              tried++;
+              throw new ExpectedVersionConflictError(0, 1);
+            },
+            {
+              retry: { onVersionConflict: 2 },
+            },
+          );
+        },
+        (error) => error instanceof ExpectedVersionConflictError,
+      );
+
+      assertEqual(3, tried);
+    });
+
+    void it('Succeeds after retrying with custom retry options', async () => {
+      const productItem: PricedProductItem = {
+        productId: '123',
+        quantity: 10,
+        price: 3,
+      };
+
+      const shoppingCartId = randomUUID();
+      const command: AddProductItem = {
+        type: 'AddProductItem',
+        data: { productItem },
+      };
+
+      // Create the stream
+      await handleCommand(
+        eventStore,
+        shoppingCartId,
+        (state) => addProductItem(command, state),
+        { expectedStreamVersion: 'STREAM_DOES_NOT_EXIST' },
+      );
+
+      let tried = 0;
+
+      const { newState, newEvents } = await handleCommand(
+        eventStore,
+        shoppingCartId,
+        (state) => {
+          if (tried++ < 3) throw new ExpectedVersionConflictError(0, 1);
+          return addProductItem(command, state);
+        },
+        {
+          retry: {
+            onVersionConflict: { retries: 3, factor: 1, minTimeout: 10 },
+          },
+        },
+      );
+
+      assertEqual(4, tried);
+      assertThatArray(newEvents).hasSize(1);
+      assertDeepEqual(newState, {
+        productItems: [productItem, productItem],
+        totalAmount: productItem.price * productItem.quantity * 2,
+      });
+    });
+
+    void it('Does not retry if version conflict error is not thrown', async () => {
+      const productItem: PricedProductItem = {
+        productId: '123',
+        quantity: 10,
+        price: 3,
+      };
+
+      const shoppingCartId = randomUUID();
+      const command: AddProductItem = {
+        type: 'AddProductItem',
+        data: { productItem },
+      };
+
+      let tried = 0;
+
+      const { newState, newEvents } = await handleCommand(
+        eventStore,
+        shoppingCartId,
+        (state) => {
+          tried++;
+          return addProductItem(command, state);
+        },
+        {
+          retry: { onVersionConflict: 5 },
+        },
+      );
+
+      assertEqual(1, tried);
+      assertThatArray(newEvents).hasSize(1);
+      assertDeepEqual(newState, {
+        productItems: [productItem],
+        totalAmount: productItem.price * productItem.quantity,
+      });
+    });
+
+    void it('Correctly handles no retries on version conflict when retry is disabled', async () => {
+      const productItem: PricedProductItem = {
+        productId: '123',
+        quantity: 10,
+        price: 3,
+      };
+
+      const shoppingCartId = randomUUID();
+      const command: AddProductItem = {
+        type: 'AddProductItem',
+        data: { productItem },
+      };
+
+      // Create the stream
+      await handleCommand(
+        eventStore,
+        shoppingCartId,
+        (state) => addProductItem(command, state),
+        { expectedStreamVersion: 'STREAM_DOES_NOT_EXIST' },
+      );
+
+      let tried = 0;
+
+      await assertThrowsAsync(
+        async () => {
+          await handleCommand(eventStore, shoppingCartId, () => {
             tried++;
             throw new ExpectedVersionConflictError(0, 1);
-          },
-          {
-            retry: { onVersionConflict: 2 },
-          },
-        );
-      },
-      (error) => error instanceof ExpectedVersionConflictError,
-    );
+          });
+        },
+        (error) => error instanceof ExpectedVersionConflictError,
+      );
 
-    assertEqual(3, tried);
-  });
-
-  void it('Succeeds after retrying with custom retry options', async () => {
-    const productItem: PricedProductItem = {
-      productId: '123',
-      quantity: 10,
-      price: 3,
-    };
-
-    const shoppingCartId = randomUUID();
-    const command: AddProductItem = {
-      type: 'AddProductItem',
-      data: { productItem },
-    };
-
-    // Create the stream
-    await handleCommand(
-      eventStore,
-      shoppingCartId,
-      (state) => addProductItem(command, state),
-      { expectedStreamVersion: 'STREAM_DOES_NOT_EXIST' },
-    );
-
-    let tried = 0;
-
-    const { newState, newEvents } = await handleCommand(
-      eventStore,
-      shoppingCartId,
-      (state) => {
-        if (tried++ < 3) throw new ExpectedVersionConflictError(0, 1);
-        return addProductItem(command, state);
-      },
-      {
-        retry: { onVersionConflict: { retries: 3, factor: 1, minTimeout: 10 } },
-      },
-    );
-
-    assertEqual(4, tried);
-    assertThatArray(newEvents).hasSize(1);
-    assertDeepEqual(newState, {
-      productItems: [productItem, productItem],
-      totalAmount: productItem.price * productItem.quantity * 2,
+      assertEqual(1, tried);
     });
-  });
-
-  void it('Does not retry if version conflict error is not thrown', async () => {
-    const productItem: PricedProductItem = {
-      productId: '123',
-      quantity: 10,
-      price: 3,
-    };
-
-    const shoppingCartId = randomUUID();
-    const command: AddProductItem = {
-      type: 'AddProductItem',
-      data: { productItem },
-    };
-
-    let tried = 0;
-
-    const { newState, newEvents } = await handleCommand(
-      eventStore,
-      shoppingCartId,
-      (state) => {
-        tried++;
-        return addProductItem(command, state);
-      },
-      {
-        retry: { onVersionConflict: 5 },
-      },
-    );
-
-    assertEqual(1, tried);
-    assertThatArray(newEvents).hasSize(1);
-    assertDeepEqual(newState, {
-      productItems: [productItem],
-      totalAmount: productItem.price * productItem.quantity,
-    });
-  });
-
-  void it('Correctly handles no retries on version conflict when retry is disabled', async () => {
-    const productItem: PricedProductItem = {
-      productId: '123',
-      quantity: 10,
-      price: 3,
-    };
-
-    const shoppingCartId = randomUUID();
-    const command: AddProductItem = {
-      type: 'AddProductItem',
-      data: { productItem },
-    };
-
-    // Create the stream
-    await handleCommand(
-      eventStore,
-      shoppingCartId,
-      (state) => addProductItem(command, state),
-      { expectedStreamVersion: 'STREAM_DOES_NOT_EXIST' },
-    );
-
-    let tried = 0;
-
-    await assertThrowsAsync(
-      async () => {
-        await handleCommand(eventStore, shoppingCartId, () => {
-          tried++;
-          throw new ExpectedVersionConflictError(0, 1);
-        });
-      },
-      (error) => error instanceof ExpectedVersionConflictError,
-    );
-
-    assertEqual(1, tried);
   });
 });

--- a/src/packages/emmett/src/commandHandling/handleCommand.unit.spec.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.unit.spec.ts
@@ -139,4 +139,29 @@ void describe('Command Handler', () => {
     });
     assertEqual(nextExpectedStreamVersion, 2n);
   });
+
+  void it('When returning an empty array of events returns the same state', async () => {
+    const productItem: PricedProductItem = {
+      productId: '123',
+      quantity: 10,
+      price: 3,
+    };
+
+    const shoppingCartId = randomUUID();
+    const command: AddProductItem = {
+      type: 'AddProductItem',
+      data: { productItem },
+    };
+
+    const { nextExpectedStreamVersion, newState, newEvents } =
+      await handleCommand(eventStore, shoppingCartId, (state) =>
+        command.data.productItem.price > 100
+          ? addProductItemWithDiscount(command, state)
+          : [],
+      );
+
+    assertEqual(nextExpectedStreamVersion, 0n);
+    assertDeepEqual(newEvents, []);
+    assertDeepEqual(newState, initialState());
+  });
 });

--- a/src/packages/emmett/src/commandHandling/handleCommandWithDecider.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommandWithDecider.ts
@@ -5,7 +5,10 @@ import type {
 } from '../eventStore';
 import type { Command, Event } from '../typing';
 import type { Decider } from '../typing/decider';
-import { CommandHandler } from './handleCommand';
+import {
+  CommandHandler,
+  type CommandHandlerRetryOptions,
+} from './handleCommand';
 
 // #region command-handler
 export const DeciderCommandHandler =
@@ -22,9 +25,13 @@ export const DeciderCommandHandler =
     eventStore: EventStore<StreamVersion>,
     id: string,
     command: CommandType,
-    options?: {
-      expectedStreamVersion?: ExpectedStreamVersion<StreamVersion>;
-    },
+    options?:
+      | {
+          expectedStreamVersion?: ExpectedStreamVersion<StreamVersion>;
+        }
+      | {
+          retry?: CommandHandlerRetryOptions;
+        },
   ) =>
     CommandHandler<State, StreamEvent, StreamVersion>(
       evolve,

--- a/src/packages/emmett/src/commandHandling/handleCommandWithDecider.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommandWithDecider.ts
@@ -7,10 +7,19 @@ import type { Command, Event } from '../typing';
 import type { Decider } from '../typing/decider';
 import {
   CommandHandler,
+  type CommandHandlerOptions,
   type CommandHandlerRetryOptions,
 } from './handleCommand';
 
 // #region command-handler
+
+export type DeciderCommandHandlerOptions<
+  State,
+  CommandType extends Command,
+  StreamEvent extends Event,
+> = CommandHandlerOptions<State, StreamEvent> &
+  Decider<State, CommandType, StreamEvent>;
+
 export const DeciderCommandHandler =
   <
     State,
@@ -25,7 +34,7 @@ export const DeciderCommandHandler =
     eventStore: EventStore<StreamVersion>,
     id: string,
     command: CommandType,
-    options?:
+    handleOptions?:
       | {
           expectedStreamVersion?: ExpectedStreamVersion<StreamVersion>;
         }
@@ -33,9 +42,9 @@ export const DeciderCommandHandler =
           retry?: CommandHandlerRetryOptions;
         },
   ) =>
-    CommandHandler<State, StreamEvent, StreamVersion>(
+    CommandHandler<State, StreamEvent, StreamVersion>({
       evolve,
       initialState,
       mapToStreamId,
-    )(eventStore, id, (state) => decide(command, state), options);
+    })(eventStore, id, (state) => decide(command, state), handleOptions);
 // #endregion command-handler

--- a/src/packages/emmett/src/eventStore/eventStore.ts
+++ b/src/packages/emmett/src/eventStore/eventStore.ts
@@ -104,7 +104,8 @@ export type ReadStreamResult<
 > = {
   currentStreamVersion: StreamVersion;
   events: ReadEvent<EventType, ReadEventMetadataType>[];
-} | null;
+  streamExists: boolean;
+};
 
 ////////////////////////////////////////////////////////////////////
 /// AggregateStream types

--- a/src/packages/emmett/src/eventStore/eventStore.ts
+++ b/src/packages/emmett/src/eventStore/eventStore.ts
@@ -16,7 +16,7 @@ export interface EventStore<
       StreamVersion,
       ReadEventMetadataType
     >,
-  ): Promise<AggregateStreamResult<State, StreamVersion> | null>;
+  ): Promise<AggregateStreamResult<State, StreamVersion>>;
 
   readStream<EventType extends Event>(
     streamName: string,
@@ -139,6 +139,7 @@ export type AggregateStreamResult<
 > = {
   currentStreamVersion: StreamVersion;
   state: State;
+  streamExists: boolean;
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/src/packages/emmett/src/eventStore/eventStore.ts
+++ b/src/packages/emmett/src/eventStore/eventStore.ts
@@ -153,4 +153,5 @@ export type AppendToStreamOptions<StreamVersion = DefaultStreamVersionType> = {
 
 export type AppendToStreamResult<StreamVersion = DefaultStreamVersionType> = {
   nextExpectedStreamVersion: StreamVersion;
+  createdNewStream: boolean;
 };

--- a/src/packages/emmett/src/eventStore/expectedVersion.ts
+++ b/src/packages/emmett/src/eventStore/expectedVersion.ts
@@ -63,3 +63,8 @@ export class ExpectedVersionConflictError<
     Object.setPrototypeOf(this, ExpectedVersionConflictError.prototype);
   }
 }
+
+export const isExpectedVersionConflictError = (
+  error: unknown,
+): error is ExpectedVersionConflictError =>
+  error instanceof ExpectedVersionConflictError;

--- a/src/packages/emmett/src/eventStore/expectedVersion.ts
+++ b/src/packages/emmett/src/eventStore/expectedVersion.ts
@@ -26,12 +26,13 @@ export const matchesExpectedVersion = <
 >(
   current: StreamVersion | undefined,
   expected: ExpectedStreamVersion<StreamVersion>,
+  defaultVersion: StreamVersion,
 ): boolean => {
   if (expected === NO_CONCURRENCY_CHECK) return true;
 
-  if (expected == STREAM_DOES_NOT_EXIST) return current === undefined;
+  if (expected == STREAM_DOES_NOT_EXIST) return current === defaultVersion;
 
-  if (expected == STREAM_EXISTS) return current !== undefined;
+  if (expected == STREAM_EXISTS) return current !== defaultVersion;
 
   return current === expected;
 };
@@ -39,12 +40,13 @@ export const matchesExpectedVersion = <
 export const assertExpectedVersionMatchesCurrent = <
   StreamVersion = DefaultStreamVersionType,
 >(
-  current: StreamVersion | undefined,
+  current: StreamVersion,
   expected: ExpectedStreamVersion<StreamVersion> | undefined,
+  defaultVersion: StreamVersion,
 ): void => {
   expected ??= NO_CONCURRENCY_CHECK;
 
-  if (!matchesExpectedVersion(current, expected))
+  if (!matchesExpectedVersion(current, expected, defaultVersion))
     throw new ExpectedVersionConflictError(current, expected);
 };
 
@@ -52,7 +54,7 @@ export class ExpectedVersionConflictError<
   VersionType = DefaultStreamVersionType,
 > extends ConcurrencyError {
   constructor(
-    current: VersionType | undefined,
+    current: VersionType,
     expected: ExpectedStreamVersion<VersionType>,
   ) {
     super(current?.toString(), expected?.toString());

--- a/src/packages/emmett/src/eventStore/expectedVersion.unit.spec.ts
+++ b/src/packages/emmett/src/eventStore/expectedVersion.unit.spec.ts
@@ -8,48 +8,74 @@ import {
 } from './expectedVersion';
 
 void describe('matchesExpectedVersion', () => {
+  const defaultVersion = -123;
   void it('When NO_CONCURRENCY_CHECK provided returns `true` for any current version', () => {
-    const allCurrentVersions = [undefined, 0, -1, 1, 100, 'random', ''];
+    const allCurrentVersions = [defaultVersion, 0, -1, 1, 100, 'random', ''];
 
     for (const currentStreamVersion of allCurrentVersions) {
       assertOk(
-        matchesExpectedVersion(currentStreamVersion, NO_CONCURRENCY_CHECK),
+        matchesExpectedVersion(
+          currentStreamVersion,
+          NO_CONCURRENCY_CHECK,
+          defaultVersion,
+        ),
       );
     }
   });
 
-  void it('When STREAM_DOES_NOT_EXIST provided returns `true` for current equals `undefined`', () => {
-    assertOk(matchesExpectedVersion(undefined, STREAM_DOES_NOT_EXIST));
+  void it('When STREAM_DOES_NOT_EXIST provided returns `true` for current equals default version', () => {
+    assertOk(
+      matchesExpectedVersion(
+        defaultVersion,
+        STREAM_DOES_NOT_EXIST,
+        defaultVersion,
+      ),
+    );
   });
 
-  void it('When STREAM_DOES_NOT_EXIST provided returns `false` for current different than `undefined`', () => {
+  void it('When STREAM_DOES_NOT_EXIST provided returns `false` for current different than default version', () => {
     const definedStreamVersion = [0, -1, 1, 100, 'random', ''];
 
     for (const currentStreamVersion of definedStreamVersion) {
       assertEqual(
-        matchesExpectedVersion(currentStreamVersion, STREAM_DOES_NOT_EXIST),
+        matchesExpectedVersion(
+          currentStreamVersion,
+          STREAM_DOES_NOT_EXIST,
+          defaultVersion,
+        ),
         false,
       );
     }
   });
 
-  void it('When STREAM_EXISTS provided returns `true` for current different than `undefined`', () => {
+  void it('When STREAM_EXISTS provided returns `true` for current different than default version', () => {
     const definedStreamVersion = [0, -1, 1, 100, 'random', ''];
 
     for (const currentStreamVersion of definedStreamVersion) {
-      assertOk(matchesExpectedVersion(currentStreamVersion, STREAM_EXISTS));
+      assertOk(
+        matchesExpectedVersion(
+          currentStreamVersion,
+          STREAM_EXISTS,
+          defaultVersion,
+        ),
+      );
     }
   });
 
-  void it('When STREAM_EXISTS provided returns `false` for current equals `undefined`', () => {
-    assertEqual(matchesExpectedVersion(undefined, STREAM_EXISTS), false);
+  void it('When STREAM_EXISTS provided returns `false` for current equals default version', () => {
+    assertEqual(
+      matchesExpectedVersion(defaultVersion, STREAM_EXISTS, defaultVersion),
+      false,
+    );
   });
 
   void it('When value provided returns `true` for current matching expected value', () => {
     const definedStreamVersion = [0, -1, 1, 100, 'random', ''];
 
     for (const streamVersion of definedStreamVersion) {
-      assertOk(matchesExpectedVersion(streamVersion, streamVersion));
+      assertOk(
+        matchesExpectedVersion(streamVersion, streamVersion, defaultVersion),
+      );
     }
   });
 
@@ -65,7 +91,11 @@ void describe('matchesExpectedVersion', () => {
 
     for (const streamVersion of definedStreamVersion) {
       assertEqual(
-        matchesExpectedVersion(streamVersion.current, streamVersion.expected),
+        matchesExpectedVersion(
+          streamVersion.current,
+          streamVersion.expected,
+          defaultVersion,
+        ),
         false,
       );
     }

--- a/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
+++ b/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
@@ -75,6 +75,7 @@ export const getInMemoryEventStore = (): EventStore<
       assertExpectedVersionMatchesCurrent(
         currentStreamVersion,
         options?.expectedStreamVersion,
+        InMemoryEventStoreDefaultStreamVersion,
       );
 
       const from = Number(options && 'from' in options ? options.from : 0);
@@ -119,11 +120,14 @@ export const getInMemoryEventStore = (): EventStore<
     ): Promise<AppendToStreamResult> => {
       const currentEvents = streams.get(streamName) ?? [];
       const currentStreamVersion =
-        currentEvents.length > 0 ? BigInt(currentEvents.length) : undefined;
+        currentEvents.length > 0
+          ? BigInt(currentEvents.length)
+          : InMemoryEventStoreDefaultStreamVersion;
 
       assertExpectedVersionMatchesCurrent(
         currentStreamVersion,
         options?.expectedStreamVersion,
+        InMemoryEventStoreDefaultStreamVersion,
       );
 
       const newEvents: ReadEvent<

--- a/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
+++ b/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
@@ -155,6 +155,8 @@ export const getInMemoryEventStore = (): EventStore<
 
       const result: AppendToStreamResult = {
         nextExpectedStreamVersion: positionOfLastEventInTheStream,
+        createdNewStream:
+          currentStreamVersion === InMemoryEventStoreDefaultStreamVersion,
       };
 
       return result;

--- a/src/packages/emmett/src/streaming/restream.ts
+++ b/src/packages/emmett/src/streaming/restream.ts
@@ -3,10 +3,10 @@ import {
   type ReadableStreamDefaultReadResult,
   type TransformStreamDefaultController,
 } from '@event-driven-io/emmett-shims';
-import asyncRetry from 'async-retry';
 import type { Decoder } from './decoders';
 import { DefaultDecoder } from './decoders/composite';
 import { streamTransformations } from './transformations';
+import type { AsyncRetryOptions } from '../utils';
 
 const { retry } = streamTransformations;
 
@@ -18,7 +18,7 @@ export const restream = <
   createSourceStream: () => ReadableStream<StreamType>,
   transform: (input: Source) => Transformed = (source) =>
     source as unknown as Transformed,
-  retryOptions: asyncRetry.Options = { forever: true, minTimeout: 25 },
+  retryOptions: AsyncRetryOptions = { forever: true, minTimeout: 25 },
   decoder: Decoder<StreamType, Source> = new DefaultDecoder<Source>(),
 ): ReadableStream<Transformed> =>
   retry(createSourceStream, handleChunk(transform, decoder), retryOptions)

--- a/src/packages/emmett/src/streaming/transformations/index.ts
+++ b/src/packages/emmett/src/streaming/transformations/index.ts
@@ -5,7 +5,7 @@ import {
   NotifyAboutNoActiveReadersStream,
 } from './notifyAboutNoActiveReaders';
 import { reduce, ReduceTransformStream } from './reduce';
-import { retry } from './retry';
+import { retryStream } from './retry';
 import { skip, SkipTransformStream } from './skip';
 import { stopAfter } from './stopAfter';
 import { stopOn } from './stopOn';
@@ -23,7 +23,7 @@ export const streamTransformations = {
   NotifyAboutNoActiveReadersStream,
   reduce,
   ReduceTransformStream,
-  retry,
+  retry: retryStream,
   stopAfter,
   stopOn,
   waitAtMost,

--- a/src/packages/emmett/src/streaming/transformations/retry.ts
+++ b/src/packages/emmett/src/streaming/transformations/retry.ts
@@ -4,9 +4,9 @@ import streams, {
   type TransformStream,
   type TransformStreamDefaultController,
 } from '@event-driven-io/emmett-shims';
-import asyncRetry from 'async-retry';
+import { type AsyncRetryOptions, asyncRetry } from '../../utils';
 
-export const retry = <
+export const retryStream = <
   Source = unknown,
   Transformed = Source,
   StreamType = Source,
@@ -16,7 +16,7 @@ export const retry = <
     readResult: ReadableStreamDefaultReadResult<StreamType>,
     controller: TransformStreamDefaultController<Transformed>,
   ) => Promise<void> | void,
-  retryOptions: asyncRetry.Options = { forever: true, minTimeout: 25 },
+  retryOptions: AsyncRetryOptions = { forever: true, minTimeout: 25 },
 ): TransformStream<Source, Transformed> =>
   new streams.TransformStream<Source, Transformed>({
     start(controller) {

--- a/src/packages/emmett/src/streaming/transformations/retry.unit.spec.ts
+++ b/src/packages/emmett/src/streaming/transformations/retry.unit.spec.ts
@@ -5,7 +5,7 @@ import {
 import { describe, it } from 'node:test';
 import { assertDeepEqual, assertEqual } from '../../testing';
 import { fromArray } from '../generators/fromArray';
-import { retry } from './retry';
+import { retryStream } from './retry';
 
 void describe('retry', () => {
   void it('processes the stream successfully and terminate when done', async () => {
@@ -19,7 +19,7 @@ void describe('retry', () => {
       controller.enqueue(readResult.value * 2);
     };
 
-    const transformStream = retry(() => fromArray(data), handleChunk, {
+    const transformStream = retryStream(() => fromArray(data), handleChunk, {
       retries: 3,
       minTimeout: 10,
     });
@@ -50,7 +50,7 @@ void describe('retry', () => {
       controller.enqueue(readResult.value * 2);
     };
 
-    const transformStream = retry(() => fromArray(data), handleChunk, {
+    const transformStream = retryStream(() => fromArray(data), handleChunk, {
       retries: 3,
       minTimeout: 10,
     });
@@ -73,10 +73,14 @@ void describe('retry', () => {
 
     let errorCaught = false;
 
-    const transformStream = retry(() => fromArray([1, 2, 3]), handleChunk, {
-      retries: 1,
-      minTimeout: 10,
-    });
+    const transformStream = retryStream(
+      () => fromArray([1, 2, 3]),
+      handleChunk,
+      {
+        retries: 1,
+        minTimeout: 10,
+      },
+    );
 
     const reader = transformStream.readable.getReader();
     try {

--- a/src/packages/emmett/src/testing/wrapEventStore.ts
+++ b/src/packages/emmett/src/testing/wrapEventStore.ts
@@ -33,7 +33,7 @@ export const WrapEventStore = <
     async aggregateStream<State, EventType extends Event>(
       streamName: string,
       options: AggregateStreamOptions<State, EventType, StreamVersion>,
-    ): Promise<AggregateStreamResult<State, StreamVersion> | null> {
+    ): Promise<AggregateStreamResult<State, StreamVersion>> {
       return eventStore.aggregateStream(streamName, options);
     },
 

--- a/src/packages/emmett/src/utils/index.ts
+++ b/src/packages/emmett/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './deepEquals';
 export * from './iterators';
 export * from './merge';
+export * from './retry';
 
 export default {};

--- a/src/packages/emmett/src/utils/retry.ts
+++ b/src/packages/emmett/src/utils/retry.ts
@@ -1,7 +1,7 @@
 import retry from 'async-retry';
 
 export type AsyncRetryOptions = retry.Options & {
-  shouldRetry?: (error: unknown) => boolean;
+  shouldRetryError?: (error: unknown) => boolean;
 };
 
 export const NoRetries: AsyncRetryOptions = { retries: 0 };
@@ -17,7 +17,7 @@ export const asyncRetry = async <T>(
       try {
         return await fn();
       } catch (error) {
-        if (opts?.shouldRetry && !opts.shouldRetry(error)) {
+        if (opts?.shouldRetryError && !opts.shouldRetryError(error)) {
           bail(error as Error);
         }
         throw error;

--- a/src/packages/emmett/src/utils/retry.ts
+++ b/src/packages/emmett/src/utils/retry.ts
@@ -1,0 +1,28 @@
+import retry from 'async-retry';
+
+export type AsyncRetryOptions = retry.Options & {
+  shouldRetry?: (error: unknown) => boolean;
+};
+
+export const NoRetries: AsyncRetryOptions = { retries: 0 };
+
+export const asyncRetry = async <T>(
+  fn: () => Promise<T>,
+  opts?: AsyncRetryOptions,
+): Promise<T> => {
+  if (opts === undefined || opts.retries === 0) return fn();
+
+  return retry(
+    async (bail) => {
+      try {
+        return await fn();
+      } catch (error) {
+        if (opts?.shouldRetry && !opts.shouldRetry(error)) {
+          bail(error as Error);
+        }
+        throw error;
+      }
+    },
+    opts ?? { retries: 0 },
+  );
+};


### PR DESCRIPTION
1. Added built-in retries to handle concurrency issues, for instance retrying on the stream version conflict. 

2. **[BREAKING]: Changed the stream read and aggregation behaviour to always return the result and never `null` together with a flag if the stream exists.**

Now:
- `readStream` when there's no stream will return empty events array and `streamExists` set to `false`,
- `aggregateStream` when there's no stream will return the default state, and `streamExists` set to `false`,

Both will return the default stream position when the stream doesn't exist (for the event store, that will be `-1`, `0` for others).

3. **[BREAKING]:** Made Command handler signature take options object instead of an array of parameters.** This is needed to extend the command handler in the future and even now with common retry options.

Now, instead of:

```ts
const handle = CommandHandler(evolve, initialState);
````

you need to do:

```ts
const handle = CommandHandler({ evolve, initialState });
```
