### PR TITLE
Fix `CommandHandler` type definition for `handleOptions`

### DIFF
--- a/src/packages/emmett/src/commandHandling/handleCommand.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.ts
@@ -88,7 +88,7 @@ export const CommandHandler =
       | StreamEvent[]
       | Promise<StreamEvent>
       | Promise<StreamEvent[]>,
-    handleOptions?: HandleOptions<StreamVersion, EventStore<StreamVersion>>,
+    handleOptions?: HandleOptions<StreamVersion, Store>,
   ): Promise<CommandHandlerResult<State, StreamEvent, StreamVersion>> =>
     asyncRetry(
       async () => {


### PR DESCRIPTION
The original code specified that `handleOptions` was of the type `HandleOptions<StreamVersion, EventStore<...>>` using the emmett `EventStore` instead of the generic `Store`. This prevented TS from allowing you to pass any custom options from a custom implementation of event store to the command handler.

This fixes what I assume was a typo and allows you to have custom options again.