### PR TITLE
[MongoDB Event Store] Projection Registration & Helper for single stream projections

### DIFF
--- a/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.e2e.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.e2e.spec.ts
@@ -102,7 +102,11 @@ void describe('MongoDBEventStore', () => {
     assertDeepEqual(stream.projections[SHOPPING_CART_PROJECTION_NAME], {
       productItemsCount: 20,
       totalAmount: 54,
-      _metadata: { name: SHOPPING_CART_PROJECTION_NAME, streamPosition: 3n },
+      _metadata: {
+        name: SHOPPING_CART_PROJECTION_NAME,
+        streamPosition: 3n,
+        schemaVersion: 1,
+      },
     });
   });
 

--- a/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.e2e.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.e2e.spec.ts
@@ -124,13 +124,17 @@ void describe('EventStoreDBEventStore', () => {
       { expectedStreamVersion: STREAM_DOES_NOT_EXIST },
     );
 
-    const expectedStreamVersion = 2;
+    const expectedStreamVersion = 3n;
+    const expectedNumEvents = 2;
     const stream = await eventStore.readStream<ShoppingCartEvent>(streamName, {
-      expectedStreamVersion: BigInt(expectedStreamVersion),
+      from: 0n,
+      to: BigInt(expectedNumEvents),
+      expectedStreamVersion,
     });
 
     assertTrue(stream.streamExists);
-    assertEqual(expectedStreamVersion, stream.events.length);
+    assertEqual(expectedStreamVersion, stream.currentStreamVersion);
+    assertEqual(expectedNumEvents, stream.events.length);
   });
 });
 

--- a/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.e2e.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.e2e.spec.ts
@@ -1,4 +1,5 @@
 import {
+  assertDeepEqual,
   assertEqual,
   assertIsNotNull,
   assertTrue,
@@ -20,12 +21,13 @@ import {
 import {
   getMongoDBEventStore,
   toStreamName,
-  shortInfoProjection,
+  mongoDBInlineProjection,
   type EventStream,
   type MongoDBEventStore,
 } from './mongoDBEventStore';
 
 const DB_NAME = 'mongodbeventstore_testing';
+const SHOPPING_CART_PROJECTION_NAME = 'shoppingCartShortInfo';
 
 void describe('EventStoreDBEventStore', () => {
   let mongodb: StartedMongoDBContainer;
@@ -48,8 +50,8 @@ void describe('EventStoreDBEventStore', () => {
     eventStore = getMongoDBEventStore({
       collection,
       projections: [
-        shortInfoProjection({
-          name: 'shoppingCartShortInfo',
+        mongoDBInlineProjection({
+          name: SHOPPING_CART_PROJECTION_NAME,
           canHandle: ['ProductItemAdded', 'DiscountApplied'],
           evolve,
         }),
@@ -93,11 +95,10 @@ void describe('EventStoreDBEventStore', () => {
     const stream = await collection.findOne({ streamName });
     assertIsNotNull(stream);
     assertEqual('3', stream.metadata.streamPosition.toString());
-    // TODO: re-implement
-    // assertDeepEqual(stream.projection.short, {
-    //   productItemsCount: 20,
-    //   totalAmount: 54,
-    // });
+    assertDeepEqual(stream.projections[SHOPPING_CART_PROJECTION_NAME]?.short, {
+      productItemsCount: 20,
+      totalAmount: 54,
+    });
   });
 
   void it('should only return a subset of stream events based on expectedStreamVersion', async () => {

--- a/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.ts
@@ -111,8 +111,8 @@ export class MongoDBEventStore implements EventStore {
     );
 
     return {
-      // TODO: remove `.slice`?
       events: stream.events,
+      // TODO: if returning a slice, do we change this to be the expected stream version?
       currentStreamVersion: stream.metadata.streamPosition,
       streamExists: true,
     };

--- a/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.ts
@@ -37,7 +37,6 @@ export interface EventStream<
 > {
   streamName: string;
   events: Array<ReadEvent<EventType, ReadEventMetadata>>;
-  // TODO: storing metadata,
   metadata: {
     streamId: string;
     streamType: StreamType;
@@ -53,9 +52,6 @@ export interface EventStream<
 export type EventStreamEvent<EventType extends Event = Event> =
   EventStream<EventType>['events'][number];
 
-/*
- *  TODO: context for connection
- */
 export type MongoDBProjectionDefinition<
   EventType extends Event = Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
@@ -148,7 +144,6 @@ export class MongoDBEventStore implements EventStore {
         streamPositionSerializer({
           streamName,
           events: [],
-          // TODO:
           metadata: {
             streamId,
             streamType,
@@ -183,8 +178,7 @@ export class MongoDBEventStore implements EventStore {
       });
     }
 
-    // TODO: better error here, should rarely happen if ever
-    // if another error was not thrown before this
+    // TODO: error handling / implement retries
     if (!stream) throw new Error('Failed to create stream');
 
     assertExpectedVersionMatchesCurrent(
@@ -329,7 +323,7 @@ function maxEventIndex(
     }
   }
 
-  // TODO: possibly dangerous for very long event streams. May need to perform DB level
+  // TODO: possibly dangerous for very long event streams (overflow)?. May need to perform DB level
   // selections on the events that we return
   return Number(expectedStreamVersion);
 }

--- a/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.ts
@@ -218,12 +218,8 @@ export class MongoDBEventStore implements EventStore {
     );
 
     if (!updatedStream) {
-      const currentStream = await this.collection.findOne(
-        { streamName: { $eq: streamName } },
-        { useBigInt64: true },
-      );
       throw new ExpectedVersionConflictError(
-        currentStream?.metadata?.streamPosition ?? 0n,
+        0n, // TODO: some other value??
         options?.expectedStreamVersion ?? 0n,
       );
     }

--- a/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.ts
@@ -13,11 +13,15 @@ import {
   type ReadEvent,
   type ReadEventMetadata,
   type ExpectedStreamVersion,
+  type EventMetaDataOf,
+  type TypedProjectionDefinition,
+  type DefaultRecord,
+  type CanHandle,
 } from '@event-driven-io/emmett';
 import { type Collection, type WithId } from 'mongodb';
 import { v4 as uuid } from 'uuid';
 
-export const MongoDBEventStoreDefaultStreamVersion = 0;
+export const MongoDBEventStoreDefaultStreamVersion = 0n;
 
 export type StreamType = string;
 export type StreamName<T extends StreamType = StreamType> = `${T}:${string}`;
@@ -27,51 +31,67 @@ export type StreamNameParts<T extends StreamType = StreamType> = {
   streamId: string;
 };
 
-export type StreamToProject<EventType extends Event> = {
-  streamName: StreamName;
-  streamType: StreamType;
-  streamId: string;
-  streamVersion: number;
-  events: ReadEvent<EventType, ReadEventMetadata>[];
-};
-
-export type Projection<EventType extends Event> = (
-  stream: StreamToProject<EventType>,
-) => void | Promise<void>;
-
-export interface EventStream<EventType extends Event = Event> {
+export interface EventStream<
+  EventType extends Event = Event,
+  ShortInfoType extends DefaultRecord = DefaultRecord,
+> {
   streamName: string;
   events: Array<ReadEvent<EventType, ReadEventMetadata>>;
-  createdAt: Date;
-  updatedAt: Date;
+  // TODO: storing metadata,
+  metadata: {
+    streamId: string;
+    streamType: StreamType;
+    streamPosition: bigint;
+    createdAt: Date;
+    updatedAt: Date;
+  };
+  projection: {
+    details: { name?: string };
+    short: ShortInfoType | null;
+  };
 }
 export type EventStreamEvent<EventType extends Event = Event> =
   EventStream<EventType>['events'][number];
 
-export interface MongoDBConnectionOptions {
-  connectionString: string;
-  database: string;
-  collection?: string;
-}
+/*
+ *  TODO: context for connection
+ */
+export type MongoDBProjectionDefinition<
+  EventType extends Event = Event,
+  EventMetaDataType extends EventMetaDataOf<EventType> &
+    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+> = TypedProjectionDefinition<
+  EventType,
+  EventMetaDataType,
+  {
+    streamName: StreamName;
+    collection: Collection<EventStream>;
+  }
+>;
 
-export class MongoDBEventStore implements EventStore<number> {
+export class MongoDBEventStore implements EventStore {
   private readonly collection: Collection<EventStream>;
+  private readonly projections?: MongoDBProjectionDefinition[];
 
-  constructor(collection: typeof this.collection) {
-    this.collection = collection;
+  constructor(options: {
+    collection: Collection<EventStream>;
+    projections?: MongoDBProjectionDefinition[];
+  }) {
+    this.collection = options.collection;
+    this.projections = options.projections;
   }
 
   async readStream<EventType extends Event>(
     streamName: StreamName,
-    options?: ReadStreamOptions<number>,
-  ): Promise<Exclude<ReadStreamResult<EventType, number>, null>> {
+    options?: ReadStreamOptions,
+  ): Promise<Exclude<ReadStreamResult<EventType>, null>> {
     const expectedStreamVersion = options?.expectedStreamVersion;
 
-    const stream = await this.collection.findOne<
-      WithId<EventStream<EventType>>
-    >({
-      streamName: { $eq: streamName },
-    });
+    const stream = streamPositionDeserializer(
+      await this.collection.findOne<WithId<EventStream<EventType>>>({
+        streamName: { $eq: streamName },
+      }),
+    );
 
     if (!stream) {
       return {
@@ -82,22 +102,23 @@ export class MongoDBEventStore implements EventStore<number> {
     }
 
     assertExpectedVersionMatchesCurrent(
-      stream.events.length,
+      stream.metadata.streamPosition,
       expectedStreamVersion,
       MongoDBEventStoreDefaultStreamVersion,
     );
 
     return {
+      // TODO: remove `.slice`?
       events: stream.events.slice(0, maxEventIndex(expectedStreamVersion)),
-      currentStreamVersion: stream.events.length,
+      currentStreamVersion: stream.metadata.streamPosition,
       streamExists: true,
     };
   }
 
   async aggregateStream<State, EventType extends Event>(
     streamName: StreamName,
-    options: AggregateStreamOptions<State, EventType, number>,
-  ): Promise<AggregateStreamResult<State, number>> {
+    options: AggregateStreamOptions<State, EventType>,
+  ): Promise<AggregateStreamResult<State>> {
     const stream = await this.readStream<EventType>(streamName, options?.read);
     const state = stream.events.reduce(options.evolve, options.initialState());
     return {
@@ -110,31 +131,39 @@ export class MongoDBEventStore implements EventStore<number> {
   async appendToStream<EventType extends Event>(
     streamName: StreamName,
     events: EventType[],
-    options?: AppendToStreamOptions<number> & {
-      /**
-       * These will be ran after a the events have been successfully appended to
-       * the stream. `appendToStream` will return after every projection is completed.
-       */
-      projections?: Array<Projection<EventType>>;
-    },
-  ): Promise<AppendToStreamResult<number>> {
-    let stream = await this.collection.findOne({
-      streamName: { $eq: streamName },
-    });
-    let currentStreamPosition = stream?.events.length ?? 0;
+    options?: AppendToStreamOptions,
+  ): Promise<AppendToStreamResult> {
+    let stream = streamPositionDeserializer(
+      await this.collection.findOne({
+        streamName: { $eq: streamName },
+      }),
+    );
+    let currentStreamPosition = stream?.metadata?.streamPosition ?? 0n;
     let createdNewStream = false;
 
     if (!stream) {
+      const { streamId, streamType } = fromStreamName(streamName);
       const now = new Date();
-      const result = await this.collection.insertOne({
-        streamName,
-        events: [],
-        createdAt: now,
-        updatedAt: now,
-      });
-      stream = await this.collection.findOne({
-        _id: result.insertedId,
-      });
+      const result = await this.collection.insertOne(
+        streamPositionSerializer({
+          streamName,
+          events: [],
+          // TODO:
+          metadata: {
+            streamId,
+            streamType,
+            streamPosition: MongoDBEventStoreDefaultStreamVersion,
+            createdAt: now,
+            updatedAt: now,
+          },
+          projection: { details: {}, short: null },
+        }),
+      );
+      stream = streamPositionDeserializer(
+        await this.collection.findOne({
+          _id: result.insertedId,
+        }),
+      );
       createdNewStream = true;
     }
 
@@ -159,84 +188,150 @@ export class MongoDBEventStore implements EventStore<number> {
     if (!stream) throw new Error('Failed to create stream');
 
     assertExpectedVersionMatchesCurrent(
-      stream.events.length,
+      stream.metadata.streamPosition,
       options?.expectedStreamVersion,
       MongoDBEventStoreDefaultStreamVersion,
     );
+
+    if (this.projections) {
+      // Pre-commit
+      await handleProjections({
+        streamName,
+        events: eventCreateInputs,
+        projections: this.projections,
+        collection: this.collection,
+      });
+    }
 
     // @ts-expect-error The actual `EventType` is different across each stream document,
     // but the collection was instantiated as being `EventStream<Event>`. Unlike `findOne`,
     // `findOneAndUpdate` does not allow a generic to override what the return type is.
     const updatedStream: WithId<EventStream<EventType>> | null =
-      await this.collection.findOneAndUpdate(
-        {
-          streamName: { $eq: streamName },
-          events: { $size: stream.events.length },
-        },
-        {
-          $push: { events: { $each: eventCreateInputs } },
-          $set: { updatedAt: new Date() },
-        },
-        { returnDocument: 'after' },
+      streamPositionDeserializer(
+        await this.collection.findOneAndUpdate(
+          {
+            streamName: { $eq: streamName },
+            'metadata.streamPosition': {
+              $eq: stream.metadata.streamPosition.toString(),
+            },
+          },
+          {
+            $push: { events: { $each: eventCreateInputs } },
+            $set: {
+              'metadata.updatedAt': new Date(),
+              'metadata.streamPosition': (
+                stream.metadata.streamPosition + BigInt(events.length)
+              ).toString(),
+            },
+          },
+          { returnDocument: 'after' },
+        ),
       );
 
     if (!updatedStream) {
-      const currentStream = await this.collection.findOne({
-        streamName: { $eq: streamName },
-      });
+      const currentStream = streamPositionDeserializer(
+        await this.collection.findOne({
+          streamName: { $eq: streamName },
+        }),
+      );
       throw new ExpectedVersionConflictError(
-        currentStream?.events.length ?? -1,
-        stream.events.length,
+        currentStream?.metadata?.streamPosition ?? 0n,
+        stream.metadata.streamPosition,
       );
     }
 
-    const { streamType, streamId } = fromStreamName(streamName);
-
-    await executeProjections(
-      {
-        streamName,
-        streamType,
-        streamId,
-        streamVersion: updatedStream.events.length,
-        events: updatedStream.events,
-      },
-      options?.projections,
-    );
-
     return {
-      nextExpectedStreamVersion: updatedStream.events.length,
+      nextExpectedStreamVersion: updatedStream.metadata.streamPosition,
       createdNewStream,
     };
   }
 }
 
-export const getMongoDBEventStore = (collection: Collection<EventStream>) => {
-  const eventStore = new MongoDBEventStore(collection);
+export const getMongoDBEventStore = (
+  options: ConstructorParameters<typeof MongoDBEventStore>[0],
+) => {
+  const eventStore = new MongoDBEventStore(options);
   return eventStore;
 };
 
-function executeProjections<EventType extends Event>(
-  params: StreamToProject<EventType>,
-  projections?: Array<Projection<EventType>>,
-) {
-  return Promise.all((projections ?? []).map((project) => project(params)));
+async function handleProjections<
+  EventType extends Event = Event,
+  EventMetaDataType extends EventMetaDataOf<EventType> &
+    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+>(options: {
+  streamName: StreamName;
+  events: ReadEvent<EventType, EventMetaDataType>[];
+  projections: MongoDBProjectionDefinition<EventType>[];
+  collection: Collection<EventStream>;
+}) {
+  const eventTypes = options.events.map((e) => e.type);
+  const projections = options.projections.filter((p) =>
+    p.canHandle.some((t) => eventTypes.includes(t)),
+  );
+
+  for (const { handle } of projections) {
+    await handle(options.events, {
+      streamName: options.streamName,
+      collection: options.collection,
+    });
+  }
+}
+
+export function shortInfoProjection<
+  EventType extends Event,
+  ShortInfoType extends DefaultRecord,
+>(options: {
+  name?: string;
+  canHandle: CanHandle<EventType>;
+  evolve: (state: ShortInfoType, event: EventType) => ShortInfoType;
+}): MongoDBProjectionDefinition {
+  return {
+    name: options.name,
+    canHandle: options.canHandle,
+    handle: async (events, { streamName, collection }) => {
+      const stream = await collection.findOne<
+        EventStream<EventType, ShortInfoType>
+      >({ streamName });
+      // TODO: error handling
+      if (!stream) throw new Error();
+      const state = events.reduce(
+        // @ts-expect-error TS issues
+        options.evolve,
+        stream.projection.short,
+      );
+      await collection.updateOne(
+        {
+          streamName,
+          'metadata.streamPosition': stream.metadata.streamPosition,
+        },
+        {
+          $set: {
+            'projection.details.name': options.name,
+            'projection.short': state,
+          },
+        },
+      );
+    },
+  };
 }
 
 function maxEventIndex(
-  expectedStreamVersion?: ExpectedStreamVersion<number>,
+  expectedStreamVersion?: ExpectedStreamVersion,
 ): number | undefined {
   if (!expectedStreamVersion) return undefined;
 
-  if (typeof expectedStreamVersion === 'number') {
-    return expectedStreamVersion;
+  if (typeof expectedStreamVersion === 'string') {
+    switch (expectedStreamVersion) {
+      case STREAM_DOES_NOT_EXIST:
+        return 0;
+      default:
+        return undefined;
+    }
   }
 
-  switch (expectedStreamVersion) {
-    case STREAM_DOES_NOT_EXIST:
-      return 0;
-    default:
-      return undefined;
-  }
+  // TODO: possibly dangerous for very long event streams. May need to perform DB level
+  // selections on the events that we return
+  return Number(expectedStreamVersion);
 }
 
 /**
@@ -263,4 +358,29 @@ export function fromStreamName<T extends StreamType>(
     streamType: parts[0],
     streamId: parts[1],
   };
+}
+
+/**
+ * Converts the `stream.metadata.streamPosition` of the given `stream`
+ * to a `string` value to be stored in MongoDB
+ */
+function streamPositionSerializer<Stream extends EventStream>(
+  stream: Stream,
+): Stream {
+  // @ts-expect-error serializing as a `string`
+  stream.metadata.streamPosition = stream.metadata.streamPosition.toString();
+  return stream;
+}
+
+/**
+ * Converts the `stream.metadata.streamPosition` of the given `stream`
+ * to a `bigint` value to be used in application
+ */
+function streamPositionDeserializer<Stream extends EventStream | null>(
+  stream: Stream,
+): Stream {
+  if (!stream) return stream;
+  if (typeof stream.metadata.streamPosition === 'bigint') return stream;
+  stream.metadata.streamPosition = BigInt(stream.metadata.streamPosition);
+  return stream;
 }

--- a/src/packages/emmett-mongodb/src/eventStore/projections/index.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/projections/index.ts
@@ -1,0 +1,190 @@
+import {
+  type CanHandle,
+  type Event,
+  type EventMetaDataOf,
+  type ProjectionHandler,
+  type ReadEvent,
+  type TypedProjectionDefinition,
+} from '@event-driven-io/emmett';
+import type { Collection, Document, UpdateFilter } from 'mongodb';
+import type {
+  EventStream,
+  MongoDBReadEventMetadata,
+  MongoDBReadModel,
+} from '../mongoDBEventStore';
+
+export type MongoDBProjectionInlineHandlerContext<
+  EventType extends Event = Event,
+  EventMetaDataType extends EventMetaDataOf<EventType> &
+    MongoDBReadEventMetadata = EventMetaDataOf<EventType> &
+    MongoDBReadEventMetadata,
+> = {
+  document: MongoDBReadModel | null;
+  updates: UpdateFilter<EventStream<EventType, EventMetaDataType>>;
+  collection: Collection<EventStream<EventType, EventMetaDataType>>;
+};
+
+export type MongoDBInlineProjectionHandler<
+  EventType extends Event = Event,
+  EventMetaDataType extends EventMetaDataOf<EventType> &
+    MongoDBReadEventMetadata = EventMetaDataOf<EventType> &
+    MongoDBReadEventMetadata,
+> = ProjectionHandler<
+  EventType,
+  EventMetaDataType,
+  MongoDBProjectionInlineHandlerContext
+>;
+
+export type MongoDBInlineProjectionDefinition<
+  EventType extends Event = Event,
+  EventMetaDataType extends EventMetaDataOf<EventType> &
+    MongoDBReadEventMetadata = EventMetaDataOf<EventType> &
+    MongoDBReadEventMetadata,
+> = TypedProjectionDefinition<
+  EventType,
+  EventMetaDataType,
+  MongoDBProjectionInlineHandlerContext
+> & { name: string };
+
+export type InlineProjectionHandlerOptions<
+  EventType extends Event = Event,
+  EventMetaDataType extends EventMetaDataOf<EventType> &
+    MongoDBReadEventMetadata = EventMetaDataOf<EventType> &
+    MongoDBReadEventMetadata,
+> = {
+  readModels: Record<string, MongoDBReadModel>;
+  events: Array<ReadEvent<EventType, EventMetaDataType>>;
+  projections: MongoDBInlineProjectionDefinition<
+    EventType,
+    EventMetaDataType
+  >[];
+  collection: Collection<EventStream>;
+  updates: UpdateFilter<EventStream<Event>>;
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  client: {
+    //todo: add client here
+  };
+};
+
+export const handleInlineProjections = async <
+  EventType extends Event = Event,
+  EventMetaDataType extends EventMetaDataOf<EventType> &
+    MongoDBReadEventMetadata = EventMetaDataOf<EventType> &
+    MongoDBReadEventMetadata,
+>(
+  options: InlineProjectionHandlerOptions<EventType, EventMetaDataType>,
+): Promise<void> => {
+  const {
+    events,
+    projections: allProjections,
+    updates: update,
+    collection,
+    readModels,
+  } = options;
+
+  const eventTypes = events.map((e) => e.type);
+
+  const projections = allProjections.filter((p) =>
+    p.canHandle.some((type) => eventTypes.includes(type)),
+  );
+
+  for (const projection of projections) {
+    await projection.handle(events, {
+      document: readModels[projection.name] ?? null,
+      collection,
+      updates: update,
+    });
+  }
+};
+
+export type MongoDBWithNotNullDocumentEvolve<
+  Doc extends Document,
+  EventType extends Event,
+  EventMetaDataType extends EventMetaDataOf<EventType> &
+    MongoDBReadEventMetadata = EventMetaDataOf<EventType> &
+    MongoDBReadEventMetadata,
+> =
+  | ((
+      document: Doc,
+      event: ReadEvent<EventType, EventMetaDataType>,
+    ) => Doc | null)
+  | ((document: Doc, event: ReadEvent<EventType>) => Promise<Doc | null>);
+
+export type MongoDBWithNullableDocumentEvolve<
+  Doc extends Document,
+  EventType extends Event,
+  EventMetaDataType extends EventMetaDataOf<EventType> &
+    MongoDBReadEventMetadata = EventMetaDataOf<EventType> &
+    MongoDBReadEventMetadata,
+> =
+  | ((
+      document: Doc | null,
+      event: ReadEvent<EventType, EventMetaDataType>,
+    ) => Doc | null)
+  | ((
+      document: Doc | null,
+      event: ReadEvent<EventType>,
+    ) => Promise<Doc | null>);
+
+export type MongoDBInlineProjectionOptions<
+  Doc extends Document,
+  EventType extends Event,
+  EventMetaDataType extends EventMetaDataOf<EventType> &
+    MongoDBReadEventMetadata = EventMetaDataOf<EventType> &
+    MongoDBReadEventMetadata,
+> = {
+  name: string;
+  canHandle: CanHandle<EventType>;
+} & (
+  | {
+      evolve: MongoDBWithNullableDocumentEvolve<
+        Doc,
+        EventType,
+        EventMetaDataType
+      >;
+    }
+  | {
+      evolve: MongoDBWithNotNullDocumentEvolve<
+        Doc,
+        EventType,
+        EventMetaDataType
+      >;
+      initialState: () => Doc;
+    }
+);
+
+export const mongoDBInlineProjection = <
+  Doc extends Document,
+  EventType extends Event,
+  EventMetaDataType extends EventMetaDataOf<EventType> &
+    MongoDBReadEventMetadata = EventMetaDataOf<EventType> &
+    MongoDBReadEventMetadata,
+>(
+  options: MongoDBInlineProjectionOptions<Doc, EventType, EventMetaDataType>,
+): MongoDBInlineProjectionDefinition => {
+  return {
+    name: options.name,
+    canHandle: options.canHandle,
+    handle: async (events, { document, updates }) => {
+      let state =
+        'initialState' in options
+          ? (document ?? options.initialState())
+          : document;
+
+      for (const event of events) {
+        state = await options.evolve(
+          state as Doc,
+          event as ReadEvent<EventType, EventMetaDataType>,
+        );
+      }
+
+      updates.$set![`projections.${options.name}`] = {
+        ...state,
+        _metadata: {
+          name: options.name,
+          streamPosition: events[events.length - 1]?.metadata.streamPosition,
+        },
+      };
+    },
+  };
+};


### PR DESCRIPTION
- Changed the registration of projections to be event store wide options instead of per `appendToStream` call
- The "short info" read models are now stored directly on the event stream instead of a separate collection.
- Removed unused code
- Changed stream version of mongodb event store to `BigInt`.

The `streamPosition` is stored as a `string` value since MongoDB doesn't directly support storing `BigInt` objects from JS.