### PR TITLE
Fixed the issue in Pongo projection that gets the empty object instead of null when document doesn't exist

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@event-driven-io/core",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@event-driven-io/core",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "workspaces": [
         "packages/emmett-shims",
         "packages/emmett",
@@ -11045,7 +11045,7 @@
     },
     "packages/emmett": {
       "name": "@event-driven-io/emmett",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "bin": {
         "emmett": "dist/cli.js"
       },
@@ -11060,21 +11060,21 @@
     },
     "packages/emmett-esdb": {
       "name": "@event-driven-io/emmett-esdb",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "devDependencies": {
-        "@event-driven-io/emmett-testcontainers": "0.21.0"
+        "@event-driven-io/emmett-testcontainers": "0.21.1"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.21.0",
+        "@event-driven-io/emmett": "0.21.1",
         "@eventstore/db-client": "^6.2.1"
       }
     },
     "packages/emmett-expressjs": {
       "name": "@event-driven-io/emmett-expressjs",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "devDependencies": {},
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.21.0",
+        "@event-driven-io/emmett": "0.21.1",
         "@types/express": "^4.17.21",
         "@types/supertest": "^6.0.2",
         "express": "^4.19.2",
@@ -11085,10 +11085,10 @@
     },
     "packages/emmett-fastify": {
       "name": "@event-driven-io/emmett-fastify",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "devDependencies": {},
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.21.0",
+        "@event-driven-io/emmett": "0.21.1",
         "@fastify/compress": "^7.0.3",
         "@fastify/etag": "^5.2.0",
         "@fastify/formbody": "^7.4.0",
@@ -11098,31 +11098,31 @@
     },
     "packages/emmett-mongodb": {
       "name": "@event-driven-io/emmett-mongodb",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "devDependencies": {
-        "@event-driven-io/emmett-testcontainers": "0.21.0",
+        "@event-driven-io/emmett-testcontainers": "0.21.1",
         "@testcontainers/mongodb": "^10.13.2"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.21.0",
+        "@event-driven-io/emmett": "0.21.1",
         "mongodb": "^6.10.0"
       }
     },
     "packages/emmett-postgresql": {
       "name": "@event-driven-io/emmett-postgresql",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "devDependencies": {
-        "@event-driven-io/emmett-testcontainers": "0.21.0",
+        "@event-driven-io/emmett-testcontainers": "0.21.1",
         "@testcontainers/postgresql": "^10.12.0"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.21.0",
+        "@event-driven-io/emmett": "0.21.1",
         "@event-driven-io/pongo": "0.16.3"
       }
     },
     "packages/emmett-shims": {
       "name": "@event-driven-io/emmett-shims",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "devDependencies": {
         "@types/node": "^20.11.30"
       },
@@ -11141,9 +11141,9 @@
     },
     "packages/emmett-testcontainers": {
       "name": "@event-driven-io/emmett-testcontainers",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "dependencies": {
-        "@event-driven-io/emmett": "0.21.0",
+        "@event-driven-io/emmett": "0.21.1",
         "testcontainers": "^10.12.0"
       },
       "devDependencies": {
@@ -11152,12 +11152,12 @@
     },
     "packages/emmett-tests": {
       "name": "@event-driven-io/emmett-tests",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "devDependencies": {
-        "@event-driven-io/emmett": "0.21.0",
-        "@event-driven-io/emmett-esdb": "0.21.0",
-        "@event-driven-io/emmett-postgresql": "0.21.0",
-        "@event-driven-io/emmett-testcontainers": "0.21.0",
+        "@event-driven-io/emmett": "0.21.1",
+        "@event-driven-io/emmett-esdb": "0.21.1",
+        "@event-driven-io/emmett-postgresql": "0.21.1",
+        "@event-driven-io/emmett-testcontainers": "0.21.1",
         "@testcontainers/postgresql": "^10.12.0"
       }
     }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -51,7 +51,7 @@
         "node": ">=20.11.1"
       },
       "peerDependencies": {
-        "@event-driven-io/pongo": "0.16.1",
+        "@event-driven-io/pongo": "0.16.2",
         "@types/express": "4.17.21",
         "@types/node": "^22.4.1",
         "@types/supertest": "6.0.2",
@@ -1033,9 +1033,9 @@
       "link": true
     },
     "node_modules/@event-driven-io/pongo": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@event-driven-io/pongo/-/pongo-0.16.1.tgz",
-      "integrity": "sha512-5rfG6d2pQOkETx95cdJ7e5ybVTYZ3PE+VGHeu7vwEEe6e0MjUMqR0xuQB/gOgjc1fUwHoVaisSTs/dDUjeNL/A==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@event-driven-io/pongo/-/pongo-0.16.2.tgz",
+      "integrity": "sha512-sHwgNapMTqtNF500fcuDdvVSb01TQ8EasKNp+9+deeFDjs0jurdLbM222s5M/5Qnn8oBGKJ00K2Qw3EDFdMOJw==",
       "peer": true,
       "bin": {
         "pongo": "dist/cli.js"
@@ -11117,7 +11117,7 @@
       },
       "peerDependencies": {
         "@event-driven-io/emmett": "0.21.0",
-        "@event-driven-io/pongo": "0.16.1"
+        "@event-driven-io/pongo": "0.16.2"
       }
     },
     "packages/emmett-shims": {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -51,7 +51,7 @@
         "node": ">=20.11.1"
       },
       "peerDependencies": {
-        "@event-driven-io/pongo": "0.16.2",
+        "@event-driven-io/pongo": "0.16.3",
         "@types/express": "4.17.21",
         "@types/node": "^22.4.1",
         "@types/supertest": "6.0.2",
@@ -1033,9 +1033,9 @@
       "link": true
     },
     "node_modules/@event-driven-io/pongo": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@event-driven-io/pongo/-/pongo-0.16.2.tgz",
-      "integrity": "sha512-sHwgNapMTqtNF500fcuDdvVSb01TQ8EasKNp+9+deeFDjs0jurdLbM222s5M/5Qnn8oBGKJ00K2Qw3EDFdMOJw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@event-driven-io/pongo/-/pongo-0.16.3.tgz",
+      "integrity": "sha512-4gW+INq0p2AZjQ/1sn7A8YjVL9GZDM0A9NCT3eBDzb35ii1NmZKzp9SsdKHPqy8GBIZoDP1mqV1cQh7x1YVEhw==",
       "peer": true,
       "bin": {
         "pongo": "dist/cli.js"
@@ -11117,7 +11117,7 @@
       },
       "peerDependencies": {
         "@event-driven-io/emmett": "0.21.0",
-        "@event-driven-io/pongo": "0.16.2"
+        "@event-driven-io/pongo": "0.16.3"
       }
     },
     "packages/emmett-shims": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@event-driven-io/core",
   "type": "module",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Emmett - Event Sourcing development made simple",
   "engines": {
     "node": ">=20.11.1"

--- a/src/package.json
+++ b/src/package.json
@@ -82,7 +82,7 @@
     "vitepress": "^1.3.3"
   },
   "peerDependencies": {
-    "@event-driven-io/pongo": "0.16.2",
+    "@event-driven-io/pongo": "0.16.3",
     "@types/express": "4.17.21",
     "@types/node": "^22.4.1",
     "@types/supertest": "6.0.2",

--- a/src/package.json
+++ b/src/package.json
@@ -82,7 +82,7 @@
     "vitepress": "^1.3.3"
   },
   "peerDependencies": {
-    "@event-driven-io/pongo": "0.16.1",
+    "@event-driven-io/pongo": "0.16.2",
     "@types/express": "4.17.21",
     "@types/node": "^22.4.1",
     "@types/supertest": "6.0.2",

--- a/src/packages/emmett-esdb/package.json
+++ b/src/packages/emmett-esdb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@event-driven-io/emmett-esdb",
   "type": "module",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Emmett - EventStoreDB - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -48,10 +48,10 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "@event-driven-io/emmett-testcontainers": "0.21.0"
+    "@event-driven-io/emmett-testcontainers": "0.21.1"
   },
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.21.0",
+    "@event-driven-io/emmett": "0.21.1",
     "@eventstore/db-client": "^6.2.1"
   }
 }

--- a/src/packages/emmett-expressjs/package.json
+++ b/src/packages/emmett-expressjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-expressjs",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "type": "module",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
@@ -49,7 +49,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.21.0",
+    "@event-driven-io/emmett": "0.21.1",
     "@types/express": "^4.17.21",
     "@types/supertest": "^6.0.2",
     "express": "^4.19.2",

--- a/src/packages/emmett-fastify/package.json
+++ b/src/packages/emmett-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-fastify",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "type": "module",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
@@ -53,7 +53,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.21.0",
+    "@event-driven-io/emmett": "0.21.1",
     "fastify": "^4.28.1",
     "@fastify/compress": "^7.0.3",
     "@fastify/etag": "^5.2.0",

--- a/src/packages/emmett-mongodb/package-lock.json
+++ b/src/packages/emmett-mongodb/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@event-driven-io/emmett-mongodb",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@event-driven-io/emmett-mongodb",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "devDependencies": {
-        "@event-driven-io/emmett-testcontainers": "0.21.0",
+        "@event-driven-io/emmett-testcontainers": "0.21.1",
         "@testcontainers/mongodb": "^10.13.2"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.21.0",
+        "@event-driven-io/emmett": "0.21.1",
         "mongodb": "^6.10.0"
       }
     },
@@ -35,8 +35,8 @@
       }
     },
     "node_modules/@event-driven-io/emmett": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett/-/emmett-0.21.0.tgz",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett/-/emmett-0.21.1.tgz",
       "integrity": "sha512-6pW/yNwlKGnrb/L0oQQOsVvfslMg31rvyHOlFF/aCqxbCeWpG+JhyN9FQzn1pKB8L/cidoC3Ekscdlk/dk/rbQ==",
       "bin": {
         "emmett": "dist/cli.js"
@@ -51,12 +51,12 @@
       }
     },
     "node_modules/@event-driven-io/emmett-testcontainers": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett-testcontainers/-/emmett-testcontainers-0.21.0.tgz",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@event-driven-io/emmett-testcontainers/-/emmett-testcontainers-0.21.1.tgz",
       "integrity": "sha512-sxSLNSAiPv49HWpcAinIyZ+sOqqiA6cRrce6Aac+ZIMzV1P94hTlNla0h3I4Z/v+15OPWE60aKewV2W0KFv7pg==",
       "dev": true,
       "dependencies": {
-        "@event-driven-io/emmett": "0.21.0",
+        "@event-driven-io/emmett": "0.21.1",
         "testcontainers": "^10.12.0"
       }
     },

--- a/src/packages/emmett-mongodb/package.json
+++ b/src/packages/emmett-mongodb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@event-driven-io/emmett-mongodb",
   "type": "module",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Emmett - MongoDB - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -47,11 +47,11 @@
     "dist"
   ],
   "devDependencies": {
-    "@event-driven-io/emmett-testcontainers": "0.21.0",
+    "@event-driven-io/emmett-testcontainers": "0.21.1",
     "@testcontainers/mongodb": "^10.13.2"
   },
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.21.0",
+    "@event-driven-io/emmett": "0.21.1",
     "mongodb": "^6.10.0"
   }
 }

--- a/src/packages/emmett-postgresql/package.json
+++ b/src/packages/emmett-postgresql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-postgresql",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "type": "module",
   "description": "Emmett - PostgreSQL - Event Sourcing development made simple",
   "scripts": {
@@ -70,10 +70,10 @@
   ],
   "devDependencies": {
     "@testcontainers/postgresql": "^10.12.0",
-    "@event-driven-io/emmett-testcontainers": "0.21.0"
+    "@event-driven-io/emmett-testcontainers": "0.21.1"
   },
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.21.0",
+    "@event-driven-io/emmett": "0.21.1",
     "@event-driven-io/pongo": "0.16.3"
   }
 }

--- a/src/packages/emmett-postgresql/package.json
+++ b/src/packages/emmett-postgresql/package.json
@@ -74,6 +74,6 @@
   },
   "peerDependencies": {
     "@event-driven-io/emmett": "0.21.0",
-    "@event-driven-io/pongo": "0.16.1"
+    "@event-driven-io/pongo": "0.16.2"
   }
 }

--- a/src/packages/emmett-postgresql/package.json
+++ b/src/packages/emmett-postgresql/package.json
@@ -74,6 +74,6 @@
   },
   "peerDependencies": {
     "@event-driven-io/emmett": "0.21.0",
-    "@event-driven-io/pongo": "0.16.2"
+    "@event-driven-io/pongo": "0.16.3"
   }
 }

--- a/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjection.multi.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjection.multi.int.spec.ts
@@ -1,0 +1,218 @@
+import type { ReadEvent } from '@event-driven-io/emmett/src';
+import {
+  PostgreSqlContainer,
+  StartedPostgreSqlContainer,
+} from '@testcontainers/postgresql';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import { v4 as uuid } from 'uuid';
+import {
+  documentExists,
+  eventInStream,
+  eventsInStream,
+  expectPongoDocuments,
+  newEventsInStream,
+  pongoMultiStreamProjection,
+  PostgreSQLProjectionSpec,
+} from '.';
+import {
+  type DiscountApplied,
+  type ProductItemAdded,
+  type ShoppingCartConfirmed,
+} from '../../testing/shoppingCart.domain';
+
+void describe('Postgres Projections', () => {
+  let postgres: StartedPostgreSqlContainer;
+  let connectionString: string;
+  let given: PostgreSQLProjectionSpec<ProductItemAdded | DiscountApplied>;
+  let shoppingCartId: string;
+  let clientId: string;
+
+  before(async () => {
+    postgres = await new PostgreSqlContainer().start();
+    connectionString = postgres.getConnectionUri();
+
+    given = PostgreSQLProjectionSpec.for({
+      projection: shoppingCartsSummaryProjection,
+      connectionString,
+    });
+  });
+
+  beforeEach(() => {
+    clientId = uuid();
+    shoppingCartId = `shoppingCart:${clientId}:${uuid()}`;
+  });
+
+  after(async () => {
+    try {
+      await postgres.stop();
+    } catch (error) {
+      console.log(error);
+    }
+  });
+
+  void it('with empty given and raw when', () =>
+    given([])
+      .when([
+        {
+          type: 'ProductItemAdded',
+          data: {
+            productItem: { price: 100, productId: 'shoes', quantity: 100 },
+          },
+          metadata: {
+            streamName: shoppingCartId,
+          },
+        },
+      ])
+      .then(
+        documentExists<ShoppingCartSummary>(
+          {
+            activeCount: 1,
+            activeShopingCarts: [shoppingCartId],
+          },
+          {
+            inCollection: shoppingCartsSummaryCollectionName,
+            withId: clientId,
+          },
+        ),
+      ));
+
+  void it('with empty given and when eventsInStream', () =>
+    given([])
+      .when([
+        eventInStream(shoppingCartId, {
+          type: 'ProductItemAdded',
+          data: {
+            productItem: { price: 100, productId: 'shoes', quantity: 100 },
+          },
+        }),
+      ])
+      .then(
+        expectPongoDocuments
+          .fromCollection<ShoppingCartSummary>(
+            shoppingCartsSummaryCollectionName,
+          )
+          .withId(clientId)
+          .toBeEqual({
+            activeCount: 1,
+            activeShopingCarts: [shoppingCartId],
+          }),
+      ));
+
+  void it('with empty given and when eventsInStream', () => {
+    const otherShoppingCartId = `shoppingCart:${clientId}:${uuid()}`;
+
+    return given(
+      eventsInStream<ProductItemAdded>(shoppingCartId, [
+        {
+          type: 'ProductItemAdded',
+          data: {
+            productItem: { price: 100, productId: 'shoes', quantity: 100 },
+          },
+        },
+      ]),
+    )
+      .when(
+        newEventsInStream(otherShoppingCartId, [
+          {
+            type: 'ProductItemAdded',
+            data: {
+              productItem: { price: 30, productId: 'shoes', quantity: 30 },
+            },
+          },
+        ]),
+      )
+      .then(
+        expectPongoDocuments
+          .fromCollection<ShoppingCartSummary>(
+            shoppingCartsSummaryCollectionName,
+          )
+          .withId(clientId)
+          .toBeEqual({
+            activeCount: 2,
+            activeShopingCarts: [shoppingCartId, otherShoppingCartId],
+          }),
+      );
+  });
+
+  void it('with idempotency check', () => {
+    return given(
+      eventsInStream<ProductItemAdded>(shoppingCartId, [
+        {
+          type: 'ProductItemAdded',
+          data: {
+            productItem: { price: 100, productId: 'shoes', quantity: 100 },
+          },
+        },
+      ]),
+    )
+      .when(
+        newEventsInStream(shoppingCartId, [
+          {
+            type: 'ProductItemAdded',
+            data: {
+              productItem: { price: 100, productId: 'shoes', quantity: 100 },
+            },
+          },
+        ]),
+        { numberOfTimes: 2 },
+      )
+      .then(
+        expectPongoDocuments
+          .fromCollection<ShoppingCartSummary>(
+            shoppingCartsSummaryCollectionName,
+          )
+          .withId(clientId)
+          .toBeEqual({
+            activeCount: 1,
+            activeShopingCarts: [shoppingCartId],
+          }),
+      );
+  });
+});
+
+type ShoppingCartSummary = {
+  _id?: string;
+  activeCount: number;
+  activeShopingCarts: string[];
+};
+
+const shoppingCartsSummaryCollectionName = 'shoppingCartsSummary';
+
+const evolve = (
+  document: ShoppingCartSummary,
+  {
+    type,
+    metadata: { streamName },
+  }: ReadEvent<ProductItemAdded | ShoppingCartConfirmed>,
+): ShoppingCartSummary => {
+  switch (type) {
+    case 'ProductItemAdded': {
+      if (!document.activeShopingCarts.includes(streamName)) {
+        document.activeShopingCarts.push(streamName);
+        document.activeCount++;
+      }
+
+      return document;
+    }
+    case 'ShoppingCartConfirmed':
+      document.activeShopingCarts = document.activeShopingCarts.filter(
+        (item) => item !== streamName,
+      );
+      document.activeCount--;
+
+      return document;
+    default:
+      return document;
+  }
+};
+
+const shoppingCartsSummaryProjection = pongoMultiStreamProjection({
+  getDocumentId: (event) => event.metadata.streamName.split(':')[1]!,
+  collectionName: shoppingCartsSummaryCollectionName,
+  evolve,
+  canHandle: ['ProductItemAdded', 'ShoppingCartConfirmed'],
+  initialState: () => ({
+    activeCount: 0,
+    activeShopingCarts: [],
+  }),
+});

--- a/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjection.single.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjection.single.int.spec.ts
@@ -34,7 +34,7 @@ void describe('Postgres Projections', () => {
     });
   });
 
-  beforeEach(() => (shoppingCartId = `shoppingCart-${uuid()}`));
+  beforeEach(() => (shoppingCartId = `shoppingCart:${uuid()}:${uuid()}`));
 
   after(async () => {
     try {

--- a/src/packages/emmett-postgresql/src/testing/shoppingCart.domain.ts
+++ b/src/packages/emmett-postgresql/src/testing/shoppingCart.domain.ts
@@ -19,8 +19,15 @@ export type DiscountApplied = Event<
   'DiscountApplied',
   { percent: number; couponId: string }
 >;
+export type ShoppingCartConfirmed = Event<
+  'ShoppingCartConfirmed',
+  { confirmedAt: Date }
+>;
 
-export type ShoppingCartEvent = ProductItemAdded | DiscountApplied;
+export type ShoppingCartEvent =
+  | ProductItemAdded
+  | DiscountApplied
+  | ShoppingCartConfirmed;
 
 export const evolve = (
   state: ShoppingCart,
@@ -40,6 +47,8 @@ export const evolve = (
         ...state,
         totalAmount: state.totalAmount * (1 - data.percent / 100),
       };
+    case 'ShoppingCartConfirmed':
+      return state;
   }
 };
 
@@ -61,6 +70,8 @@ export const evolveWithMetadata = (
         ...state,
         totalAmount: state.totalAmount * (1 - data.percent / 100),
       };
+    case 'ShoppingCartConfirmed':
+      return state;
   }
 };
 

--- a/src/packages/emmett-shims/package.json
+++ b/src/packages/emmett-shims/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-shims",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "type": "module",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {

--- a/src/packages/emmett-testcontainers/package.json
+++ b/src/packages/emmett-testcontainers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-testcontainers",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "type": "module",
   "description": "Emmett - TestContainers - Event Sourcing development made simple",
   "scripts": {
@@ -47,7 +47,7 @@
     "dist"
   ],
   "dependencies": {
-    "@event-driven-io/emmett": "0.21.0",
+    "@event-driven-io/emmett": "0.21.1",
     "testcontainers": "^10.12.0"
   },
   "devDependencies": {

--- a/src/packages/emmett-tests/package.json
+++ b/src/packages/emmett-tests/package.json
@@ -2,7 +2,7 @@
   "name": "@event-driven-io/emmett-tests",
   "type": "module",
   "private": true,
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Emmett - Internal E2E Tests",
   "scripts": {
     "build": "tsup",
@@ -55,10 +55,10 @@
     "dist"
   ],
   "devDependencies": {
-    "@event-driven-io/emmett": "0.21.0",
-    "@event-driven-io/emmett-esdb": "0.21.0",
-    "@event-driven-io/emmett-postgresql": "0.21.0",
-    "@event-driven-io/emmett-testcontainers": "0.21.0",
+    "@event-driven-io/emmett": "0.21.1",
+    "@event-driven-io/emmett-esdb": "0.21.1",
+    "@event-driven-io/emmett-postgresql": "0.21.1",
+    "@event-driven-io/emmett-testcontainers": "0.21.1",
     "@testcontainers/postgresql": "^10.12.0"
   }
 }

--- a/src/packages/emmett/package.json
+++ b/src/packages/emmett/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@event-driven-io/emmett",
   "type": "module",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
Added tests for Pongo multi-stream projection. This reproduces a bug in Pongo 0.16.2 with a passing default object.

The real fix was in Pongo, see: https://github.com/event-driven-io/Pongo/pull/100.

@jameswoodley FYI