### PR TITLE
Reshaping event metadata with global position

### DIFF
--- a/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.ts
+++ b/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.ts
@@ -9,7 +9,7 @@ import {
   type AggregateStreamOptions,
   type AggregateStreamResult,
   type AppendToStreamOptions,
-  type AppendToStreamResult,
+  type AppendToStreamResultWithGlobalPosition,
   type Event,
   type EventStore,
   type ExpectedStreamVersion,
@@ -160,7 +160,7 @@ export const getEventStoreDBEventStore = (
       streamName: string,
       events: EventType[],
       options?: AppendToStreamOptions,
-    ): Promise<AppendToStreamResult> => {
+    ): Promise<AppendToStreamResultWithGlobalPosition> => {
       try {
         const serializedEvents = events.map(jsonEvent);
 
@@ -178,6 +178,7 @@ export const getEventStoreDBEventStore = (
 
         return {
           nextExpectedStreamVersion: appendResult.nextExpectedRevision,
+          lastEventGlobalPosition: appendResult.position!.commit,
           createdNewStream:
             appendResult.nextExpectedRevision >=
             BigInt(serializedEvents.length),

--- a/src/packages/emmett-expressjs/src/e2e/decider/api.ts
+++ b/src/packages/emmett-expressjs/src/e2e/decider/api.ts
@@ -5,6 +5,7 @@ import {
   assertPositiveNumber,
   assertUnsignedBigInt,
   type EventStore,
+  type ReadEventMetadataWithGlobalPosition,
 } from '@event-driven-io/emmett';
 import { type Request, type Router } from 'express';
 import {
@@ -23,149 +24,159 @@ const dummyPriceProvider = (_productId: string) => {
   return 100;
 };
 
-export const shoppingCartApi = (eventStore: EventStore) => (router: Router) => {
-  // Open Shopping cart
-  // #region created-example
-  router.post(
-    '/clients/:clientId/shopping-carts/',
-    on(async (request: Request) => {
-      const clientId = assertNotEmptyString(request.params.clientId);
-      const shoppingCartId = clientId;
+export const shoppingCartApi =
+  (eventStore: EventStore<ReadEventMetadataWithGlobalPosition>) =>
+  (router: Router) => {
+    // Open Shopping cart
+    // #region created-example
+    router.post(
+      '/clients/:clientId/shopping-carts/',
+      on(async (request: Request) => {
+        const clientId = assertNotEmptyString(request.params.clientId);
+        const shoppingCartId = clientId;
 
-      const result = await handle(
-        eventStore,
-        shoppingCartId,
-        {
-          type: 'OpenShoppingCart',
-          data: { clientId, shoppingCartId, now: new Date() },
-        },
-        { expectedStreamVersion: STREAM_DOES_NOT_EXIST },
-      );
-
-      return Created({
-        createdId: shoppingCartId,
-        eTag: toWeakETag(result.nextExpectedStreamVersion),
-      });
-    }),
-  );
-  // #endregion created-example
-
-  router.post(
-    '/clients/:clientId/shopping-carts/:shoppingCartId/product-items',
-    on(async (request: AddProductItemRequest) => {
-      const shoppingCartId = assertNotEmptyString(
-        request.params.shoppingCartId,
-      );
-      const productItem: ProductItem = {
-        productId: assertNotEmptyString(request.body.productId),
-        quantity: assertPositiveNumber(request.body.quantity),
-      };
-      const unitPrice = dummyPriceProvider(productItem.productId);
-
-      const result = await handle(
-        eventStore,
-        shoppingCartId,
-        {
-          type: 'AddProductItemToShoppingCart',
-          data: {
-            shoppingCartId,
-            productItem: { ...productItem, unitPrice },
+        const result = await handle(
+          eventStore,
+          shoppingCartId,
+          {
+            type: 'OpenShoppingCart',
+            data: { clientId, shoppingCartId, now: new Date() },
           },
-        },
-        {
-          expectedStreamVersion: assertUnsignedBigInt(
-            getETagValueFromIfMatch(request),
-          ),
-        },
-      );
+          { expectedStreamVersion: STREAM_DOES_NOT_EXIST },
+        );
 
-      return NoContent({ eTag: toWeakETag(result.nextExpectedStreamVersion) });
-    }),
-  );
+        return Created({
+          createdId: shoppingCartId,
+          eTag: toWeakETag(result.nextExpectedStreamVersion),
+        });
+      }),
+    );
+    // #endregion created-example
 
-  // Remove Product Item
-  router.delete(
-    '/clients/:clientId/shopping-carts/:shoppingCartId/product-items',
-    on(async (request: Request) => {
-      const shoppingCartId = assertNotEmptyString(
-        request.params.shoppingCartId,
-      );
-      const productItem: PricedProductItem = {
-        productId: assertNotEmptyString(request.query.productId),
-        quantity: assertPositiveNumber(Number(request.query.quantity)),
-        unitPrice: assertPositiveNumber(Number(request.query.unitPrice)),
-      };
+    router.post(
+      '/clients/:clientId/shopping-carts/:shoppingCartId/product-items',
+      on(async (request: AddProductItemRequest) => {
+        const shoppingCartId = assertNotEmptyString(
+          request.params.shoppingCartId,
+        );
+        const productItem: ProductItem = {
+          productId: assertNotEmptyString(request.body.productId),
+          quantity: assertPositiveNumber(request.body.quantity),
+        };
+        const unitPrice = dummyPriceProvider(productItem.productId);
 
-      const result = await handle(
-        eventStore,
-        shoppingCartId,
-        {
-          type: 'RemoveProductItemFromShoppingCart',
-          data: { shoppingCartId, productItem },
-        },
-        {
-          expectedStreamVersion: assertUnsignedBigInt(
-            getETagValueFromIfMatch(request),
-          ),
-        },
-      );
+        const result = await handle(
+          eventStore,
+          shoppingCartId,
+          {
+            type: 'AddProductItemToShoppingCart',
+            data: {
+              shoppingCartId,
+              productItem: { ...productItem, unitPrice },
+            },
+          },
+          {
+            expectedStreamVersion: assertUnsignedBigInt(
+              getETagValueFromIfMatch(request),
+            ),
+          },
+        );
 
-      return NoContent({ eTag: toWeakETag(result.nextExpectedStreamVersion) });
-    }),
-  );
+        return NoContent({
+          eTag: toWeakETag(result.nextExpectedStreamVersion),
+        });
+      }),
+    );
 
-  // Confirm Shopping Cart
-  router.post(
-    '/clients/:clientId/shopping-carts/:shoppingCartId/confirm',
-    on(async (request: Request) => {
-      const shoppingCartId = assertNotEmptyString(
-        request.params.shoppingCartId,
-      );
+    // Remove Product Item
+    router.delete(
+      '/clients/:clientId/shopping-carts/:shoppingCartId/product-items',
+      on(async (request: Request) => {
+        const shoppingCartId = assertNotEmptyString(
+          request.params.shoppingCartId,
+        );
+        const productItem: PricedProductItem = {
+          productId: assertNotEmptyString(request.query.productId),
+          quantity: assertPositiveNumber(Number(request.query.quantity)),
+          unitPrice: assertPositiveNumber(Number(request.query.unitPrice)),
+        };
 
-      const result = await handle(
-        eventStore,
-        shoppingCartId,
-        {
-          type: 'ConfirmShoppingCart',
-          data: { shoppingCartId, now: new Date() },
-        },
-        {
-          expectedStreamVersion: assertUnsignedBigInt(
-            getETagValueFromIfMatch(request),
-          ),
-        },
-      );
+        const result = await handle(
+          eventStore,
+          shoppingCartId,
+          {
+            type: 'RemoveProductItemFromShoppingCart',
+            data: { shoppingCartId, productItem },
+          },
+          {
+            expectedStreamVersion: assertUnsignedBigInt(
+              getETagValueFromIfMatch(request),
+            ),
+          },
+        );
 
-      return NoContent({ eTag: toWeakETag(result.nextExpectedStreamVersion) });
-    }),
-  );
+        return NoContent({
+          eTag: toWeakETag(result.nextExpectedStreamVersion),
+        });
+      }),
+    );
 
-  // Cancel Shopping Cart
-  router.delete(
-    '/clients/:clientId/shopping-carts/:shoppingCartId',
-    on(async (request: Request) => {
-      const shoppingCartId = assertNotEmptyString(
-        request.params.shoppingCartId,
-      );
+    // Confirm Shopping Cart
+    router.post(
+      '/clients/:clientId/shopping-carts/:shoppingCartId/confirm',
+      on(async (request: Request) => {
+        const shoppingCartId = assertNotEmptyString(
+          request.params.shoppingCartId,
+        );
 
-      const result = await handle(
-        eventStore,
-        shoppingCartId,
-        {
-          type: 'CancelShoppingCart',
-          data: { shoppingCartId, now: new Date() },
-        },
-        {
-          expectedStreamVersion: assertUnsignedBigInt(
-            getETagValueFromIfMatch(request),
-          ),
-        },
-      );
+        const result = await handle(
+          eventStore,
+          shoppingCartId,
+          {
+            type: 'ConfirmShoppingCart',
+            data: { shoppingCartId, now: new Date() },
+          },
+          {
+            expectedStreamVersion: assertUnsignedBigInt(
+              getETagValueFromIfMatch(request),
+            ),
+          },
+        );
 
-      return NoContent({ eTag: toWeakETag(result.nextExpectedStreamVersion) });
-    }),
-  );
-};
+        return NoContent({
+          eTag: toWeakETag(result.nextExpectedStreamVersion),
+        });
+      }),
+    );
+
+    // Cancel Shopping Cart
+    router.delete(
+      '/clients/:clientId/shopping-carts/:shoppingCartId',
+      on(async (request: Request) => {
+        const shoppingCartId = assertNotEmptyString(
+          request.params.shoppingCartId,
+        );
+
+        const result = await handle(
+          eventStore,
+          shoppingCartId,
+          {
+            type: 'CancelShoppingCart',
+            data: { shoppingCartId, now: new Date() },
+          },
+          {
+            expectedStreamVersion: assertUnsignedBigInt(
+              getETagValueFromIfMatch(request),
+            ),
+          },
+        );
+
+        return NoContent({
+          eTag: toWeakETag(result.nextExpectedStreamVersion),
+        });
+      }),
+    );
+  };
 
 // Add Product Item
 type AddProductItemRequest = Request<

--- a/src/packages/emmett-expressjs/src/testing/apiE2ESpecification.ts
+++ b/src/packages/emmett-expressjs/src/testing/apiE2ESpecification.ts
@@ -1,9 +1,6 @@
 import supertest, { type Response } from 'supertest';
 
-import type {
-  DefaultStreamVersionType,
-  EventStore,
-} from '@event-driven-io/emmett';
+import type { EventStore } from '@event-driven-io/emmett';
 import { WrapEventStore } from '@event-driven-io/emmett';
 import assert from 'assert';
 import type { Application } from 'express';
@@ -20,9 +17,9 @@ export type ApiE2ESpecification = (...givenRequests: TestRequest[]) => {
 };
 
 export const ApiE2ESpecification = {
-  for: <StreamVersion = DefaultStreamVersionType>(
-    getEventStore: () => EventStore<StreamVersion>,
-    getApplication: (eventStore: EventStore<StreamVersion>) => Application,
+  for: (
+    getEventStore: () => EventStore,
+    getApplication: (eventStore: EventStore) => Application,
   ): ApiE2ESpecification => {
     {
       return (...givenRequests: TestRequest[]) => {

--- a/src/packages/emmett-expressjs/src/testing/apiSpecification.ts
+++ b/src/packages/emmett-expressjs/src/testing/apiSpecification.ts
@@ -3,7 +3,6 @@ import {
   assertEqual,
   assertFails,
   assertMatches,
-  type DefaultStreamVersionType,
   type Event,
   type EventStore,
   type TestEventStream,
@@ -86,12 +85,9 @@ export type ApiSpecification<EventType extends Event = Event> = (
 };
 
 export const ApiSpecification = {
-  for: <
-    EventType extends Event = Event,
-    StreamVersion = DefaultStreamVersionType,
-  >(
-    getEventStore: () => EventStore<StreamVersion>,
-    getApplication: (eventStore: EventStore<StreamVersion>) => Application,
+  for: <EventType extends Event = Event>(
+    getEventStore: () => EventStore,
+    getApplication: (eventStore: EventStore) => Application,
   ): ApiSpecification<EventType> => {
     {
       return (...givenStreams: TestEventStream<EventType>[]) => {

--- a/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.ts
@@ -13,7 +13,7 @@ import {
   type AggregateStreamOptions,
   type AggregateStreamResult,
   type AppendToStreamOptions,
-  type AppendToStreamResult,
+  type AppendToStreamResultWithGlobalPosition,
   type Event,
   type EventStore,
   type EventStoreSession,
@@ -238,7 +238,7 @@ export const getPostgreSQLEventStore = (
       streamName: string,
       events: EventType[],
       options?: AppendToStreamOptions,
-    ): Promise<AppendToStreamResult> => {
+    ): Promise<AppendToStreamResultWithGlobalPosition> => {
       await ensureSchemaExists();
       // TODO: This has to be smarter when we introduce urn-based resolution
       const [firstPart, ...rest] = streamName.split('-');
@@ -265,6 +265,7 @@ export const getPostgreSQLEventStore = (
 
       return {
         nextExpectedStreamVersion: appendResult.nextStreamPosition,
+        lastEventGlobalPosition: appendResult.lastGlobalPosition,
         createdNewStream:
           appendResult.nextStreamPosition >= BigInt(events.length),
       };

--- a/src/packages/emmett-postgresql/src/eventStore/projections/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/index.ts
@@ -11,9 +11,9 @@ import {
   type EventMetaDataOf,
   type ProjectionHandler,
   type ReadEvent,
-  type ReadEventMetadata,
   type TypedProjectionDefinition,
 } from '@event-driven-io/emmett';
+import type { PostgresReadEventMetadata } from '../postgreSQLEventStore';
 
 export type PostgreSQLProjectionHandlerContext = {
   connectionString: string;
@@ -25,7 +25,8 @@ export type PostgreSQLProjectionHandlerContext = {
 export type PostgreSQLProjectionHandler<
   EventType extends Event = Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
+    PostgresReadEventMetadata,
 > = ProjectionHandler<
   EventType,
   EventMetaDataType,
@@ -35,7 +36,8 @@ export type PostgreSQLProjectionHandler<
 export type PostgreSQLProjectionDefinition<
   EventType extends Event = Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
+    PostgresReadEventMetadata,
 > = TypedProjectionDefinition<
   EventType,
   EventMetaDataType,
@@ -45,10 +47,11 @@ export type PostgreSQLProjectionDefinition<
 export type ProjectionHandlerOptions<
   EventType extends Event = Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
+    PostgresReadEventMetadata,
 > = {
   events: ReadEvent<EventType, EventMetaDataType>[];
-  projections: PostgreSQLProjectionDefinition<EventType>[];
+  projections: PostgreSQLProjectionDefinition<EventType, EventMetaDataType>[];
   connection: {
     connectionString: string;
     transaction: NodePostgresTransaction;
@@ -58,7 +61,8 @@ export type ProjectionHandlerOptions<
 export const handleProjections = async <
   EventType extends Event = Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
+    PostgresReadEventMetadata,
 >(
   options: ProjectionHandlerOptions<EventType, EventMetaDataType>,
 ): Promise<void> => {
@@ -89,15 +93,16 @@ export const handleProjections = async <
 export const postgreSQLProjection = <
   EventType extends Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
+    PostgresReadEventMetadata,
 >(
-  definition: PostgreSQLProjectionDefinition<EventType>,
+  definition: PostgreSQLProjectionDefinition<EventType, EventMetaDataType>,
 ): PostgreSQLProjectionDefinition =>
   projection<
     EventType,
     EventMetaDataType,
     PostgreSQLProjectionHandlerContext,
-    PostgreSQLProjectionDefinition<EventType>
+    PostgreSQLProjectionDefinition<EventType, EventMetaDataType>
   >(definition) as PostgreSQLProjectionDefinition;
 
 export const postgreSQLRawBatchSQLProjection = <EventType extends Event>(

--- a/src/packages/emmett-postgresql/src/eventStore/projections/pongo/projections.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/pongo/projections.ts
@@ -3,7 +3,6 @@ import {
   type Event,
   type EventMetaDataOf,
   type ReadEvent,
-  type ReadEventMetadataWithGlobalPosition,
 } from '@event-driven-io/emmett';
 import {
   pongoClient,
@@ -15,6 +14,7 @@ import {
   type PostgreSQLProjectionDefinition,
   type PostgreSQLProjectionHandlerContext,
 } from '..';
+import type { PostgresReadEventMetadata } from '../../postgreSQLEventStore';
 
 export type PongoProjectionHandlerContext =
   PostgreSQLProjectionHandlerContext & {
@@ -25,8 +25,8 @@ export type PongoWithNotNullDocumentEvolve<
   Document extends PongoDocument,
   EventType extends Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition,
+    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
+    PostgresReadEventMetadata,
 > =
   | ((
       document: Document,
@@ -41,8 +41,8 @@ export type PongoWithNullableDocumentEvolve<
   Document extends PongoDocument,
   EventType extends Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition,
+    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
+    PostgresReadEventMetadata,
 > =
   | ((
       document: Document | null,
@@ -57,8 +57,8 @@ export type PongoDocumentEvolve<
   Document extends PongoDocument,
   EventType extends Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition,
+    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
+    PostgresReadEventMetadata,
 > =
   | PongoWithNotNullDocumentEvolve<Document, EventType, EventMetaDataType>
   | PongoWithNullableDocumentEvolve<Document, EventType, EventMetaDataType>;
@@ -66,8 +66,8 @@ export type PongoDocumentEvolve<
 export type PongoProjectionOptions<
   EventType extends Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition,
+    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
+    PostgresReadEventMetadata,
 > = {
   handle: (
     events: ReadEvent<EventType, EventMetaDataType>[],
@@ -79,8 +79,8 @@ export type PongoProjectionOptions<
 export const pongoProjection = <
   EventType extends Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition,
+    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
+    PostgresReadEventMetadata,
 >({
   handle,
   canHandle,
@@ -95,7 +95,7 @@ export const pongoProjection = <
       const pongo = pongoClient(connectionString, {
         connectionOptions: { client },
       });
-      await handle(events as ReadEvent<EventType, EventMetaDataType>[], {
+      await handle(events, {
         ...context,
         pongo,
       });
@@ -106,8 +106,8 @@ export type PongoMultiStreamProjectionOptions<
   Document extends PongoDocument,
   EventType extends Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition,
+    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
+    PostgresReadEventMetadata,
 > = {
   canHandle: CanHandle<EventType>;
 
@@ -135,8 +135,8 @@ export const pongoMultiStreamProjection = <
   Document extends PongoDocument,
   EventType extends Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition,
+    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
+    PostgresReadEventMetadata,
 >(
   options: PongoMultiStreamProjectionOptions<
     Document,
@@ -172,8 +172,8 @@ export type PongoSingleStreamProjectionOptions<
   Document extends PongoDocument,
   EventType extends Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition,
+    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
+    PostgresReadEventMetadata,
 > = {
   canHandle: CanHandle<EventType>;
 
@@ -200,8 +200,8 @@ export const pongoSingleStreamProjection = <
   Document extends PongoDocument,
   EventType extends Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition,
+    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
+    PostgresReadEventMetadata,
 >(
   options: PongoSingleStreamProjectionOptions<
     Document,

--- a/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjectionSpec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjectionSpec.ts
@@ -14,17 +14,17 @@ import {
   type Event,
   type EventMetaDataOf,
   type ReadEvent,
-  type ReadEventMetadataWithGlobalPosition,
   type ThenThrows,
 } from '@event-driven-io/emmett';
 import { v4 as uuid } from 'uuid';
 import { handleProjections, type PostgreSQLProjectionDefinition } from '.';
+import type { PostgresReadEventMetadata } from '../postgreSQLEventStore';
 
 export type PostgreSQLProjectionSpecEvent<
   EventType extends Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition,
+    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
+    PostgresReadEventMetadata,
 > = EventType & {
   metadata?: Partial<EventMetaDataType>;
 };
@@ -71,10 +71,8 @@ export const PostgreSQLProjectionSpec = {
             events: PostgreSQLProjectionSpecEvent<EventType>[],
             options?: PostgreSQLProjectionSpecWhenOptions,
           ) => {
-            const allEvents: ReadEvent<
-              EventType,
-              ReadEventMetadataWithGlobalPosition
-            >[] = [];
+            const allEvents: ReadEvent<EventType, PostgresReadEventMetadata>[] =
+              [];
 
             const run = async (pool: Dumbo) => {
               let globalPosition = 0n;
@@ -176,8 +174,8 @@ export const PostgreSQLProjectionSpec = {
 export const eventInStream = <
   EventType extends Event = Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition,
+    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
+    PostgresReadEventMetadata,
 >(
   streamName: string,
   event: PostgreSQLProjectionSpecEvent<EventType, EventMetaDataType>,
@@ -194,8 +192,8 @@ export const eventInStream = <
 export const eventsInStream = <
   EventType extends Event = Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition = EventMetaDataOf<EventType> &
-    ReadEventMetadataWithGlobalPosition,
+    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
+    PostgresReadEventMetadata,
 >(
   streamName: string,
   events: PostgreSQLProjectionSpecEvent<EventType, EventMetaDataType>[],

--- a/src/packages/emmett-postgresql/src/eventStore/schema/readStream.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/readStream.ts
@@ -1,7 +1,6 @@
 import { mapRows, sql, type SQLExecutor } from '@event-driven-io/dumbo';
 import {
   event,
-  type DefaultStreamVersionType,
   type Event,
   type EventDataOf,
   type EventMetaDataOf,
@@ -11,8 +10,8 @@ import {
   type ReadStreamOptions,
   type ReadStreamResult,
 } from '@event-driven-io/emmett';
-import { defaultTag, eventsTable } from './typing';
 import { PostgreSQLEventStoreDefaultStreamVersion } from '../postgreSQLEventStore';
+import { defaultTag, eventsTable } from './typing';
 
 type ReadStreamSqlResult<EventType extends Event> = {
   stream_position: string;
@@ -31,11 +30,7 @@ export const readStream = async <EventType extends Event>(
   streamId: string,
   options?: ReadStreamOptions & { partition?: string },
 ): Promise<
-  ReadStreamResult<
-    EventType,
-    DefaultStreamVersionType,
-    ReadEventMetadataWithGlobalPosition
-  >
+  ReadStreamResult<EventType, ReadEventMetadataWithGlobalPosition>
 > => {
   const fromCondition: string =
     options && 'from' in options

--- a/src/packages/emmett-tests/src/eventStore/features.ts
+++ b/src/packages/emmett-tests/src/eventStore/features.ts
@@ -19,7 +19,7 @@ type TestOptions = {
   teardownHook?: () => Promise<void>;
 };
 
-export type EventStoreFactory = () => Promise<EventStore<bigint>>;
+export type EventStoreFactory = () => Promise<EventStore>;
 
 export async function testAggregateStream(
   eventStoreFactory: EventStoreFactory,
@@ -28,7 +28,7 @@ export async function testAggregateStream(
   },
 ) {
   return describe('aggregateStream', async () => {
-    let eventStore: EventStore<bigint>;
+    let eventStore: EventStore;
     const evolveTestCases = [
       {
         evolve,

--- a/src/packages/emmett/src/commandHandling/handleCommand.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.ts
@@ -123,9 +123,14 @@ export const CommandHandler =
           });
 
           // 2. Use the aggregate state
-          const state = aggregationResult.state;
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          const currentStreamVersion = aggregationResult.currentStreamVersion;
+
+          const {
+            state,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            currentStreamVersion,
+            streamExists: _streamExists,
+            ...restOfAggregationResult
+          } = aggregationResult;
 
           // 3. Run business logic
           const result = await handle(state);
@@ -134,6 +139,7 @@ export const CommandHandler =
 
           if (newEvents.length === 0) {
             return {
+              ...restOfAggregationResult,
               newEvents: [],
               newState: state,
               // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/src/packages/emmett/src/commandHandling/handleCommandWithDecider.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommandWithDecider.ts
@@ -1,4 +1,4 @@
-import type { DefaultStreamVersionType, EventStore } from '../eventStore';
+import type { EventStore } from '../eventStore';
 import type { Command, Event } from '../typing';
 import type { Decider } from '../typing/decider';
 import {
@@ -17,23 +17,18 @@ export type DeciderCommandHandlerOptions<
   Decider<State, CommandType, StreamEvent>;
 
 export const DeciderCommandHandler =
-  <
-    State,
-    CommandType extends Command,
-    StreamEvent extends Event,
-    StreamVersion = DefaultStreamVersionType,
-  >(
+  <State, CommandType extends Command, StreamEvent extends Event>(
     options: DeciderCommandHandlerOptions<State, CommandType, StreamEvent>,
   ) =>
-  async (
-    eventStore: EventStore<StreamVersion>,
+  async <Store extends EventStore>(
+    eventStore: Store,
     id: string,
     command: CommandType,
-    handleOptions?: HandleOptions<StreamVersion, EventStore<StreamVersion>>,
+    handleOptions?: HandleOptions<Store>,
   ) => {
     const { decide, ...rest } = options;
 
-    return CommandHandler<State, StreamEvent, StreamVersion>(rest)(
+    return CommandHandler<State, StreamEvent>(rest)(
       eventStore,
       id,
       (state) => decide(command, state),

--- a/src/packages/emmett/src/eventStore/eventStore.ts
+++ b/src/packages/emmett/src/eventStore/eventStore.ts
@@ -196,3 +196,9 @@ export type AppendToStreamResult<StreamVersion = BigIntStreamPosition> = {
   nextExpectedStreamVersion: StreamVersion;
   createdNewStream: boolean;
 };
+
+export type AppendToStreamResultWithGlobalPosition<
+  StreamVersion = BigIntStreamPosition,
+> = AppendToStreamResult<StreamVersion> & {
+  lastEventGlobalPosition: StreamVersion;
+};

--- a/src/packages/emmett/src/eventStore/eventStore.ts
+++ b/src/packages/emmett/src/eventStore/eventStore.ts
@@ -77,6 +77,12 @@ export type GlobalPositionTypeOfEventStore<Store extends EventStore> =
 export type StreamPositionTypeOfEventStore<Store extends EventStore> =
   StreamPositionTypeOfReadEventMetadata<EventStoreReadEventMetadata<Store>>;
 
+export type AppendStreamResultOfEventStore<Store extends EventStore> =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Store['appendToStream'] extends (...args: any[]) => Promise<infer R>
+    ? R
+    : never;
+
 export type EventStoreSession<EventStoreType extends EventStore> = {
   eventStore: EventStoreType;
   close: () => Promise<void>;

--- a/src/packages/emmett/src/eventStore/eventStore.ts
+++ b/src/packages/emmett/src/eventStore/eventStore.ts
@@ -1,5 +1,6 @@
 //import type { ReadableStream } from 'web-streams-polyfill';
 import type {
+  BigIntGlobalPosition,
   BigIntStreamPosition,
   Event,
   EventMetaDataOf,
@@ -76,12 +77,6 @@ export type GlobalPositionTypeOfEventStore<Store extends EventStore> =
 
 export type StreamPositionTypeOfEventStore<Store extends EventStore> =
   StreamPositionTypeOfReadEventMetadata<EventStoreReadEventMetadata<Store>>;
-
-export type AppendStreamResultOfEventStore<Store extends EventStore> =
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Store['appendToStream'] extends (...args: any[]) => Promise<infer R>
-    ? R
-    : never;
 
 export type EventStoreSession<EventStoreType extends EventStore> = {
   eventStore: EventStoreType;
@@ -190,6 +185,25 @@ export type AggregateStreamResult<
   streamExists: boolean;
 };
 
+export type AggregateStreamResultWithGlobalPosition<
+  State,
+  StreamPosition = BigIntStreamPosition,
+  GlobalPosition = BigIntGlobalPosition,
+> =
+  | (AggregateStreamResult<State, StreamPosition> & {
+      streamExists: true;
+      lastEventGlobalPosition: GlobalPosition;
+    })
+  | (AggregateStreamResult<State, StreamPosition> & {
+      streamExists: false;
+    });
+
+export type AggregateStreamResultOfEventStore<Store extends EventStore> =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Store['aggregateStream'] extends (...args: any[]) => Promise<infer R>
+    ? R
+    : never;
+
 ////////////////////////////////////////////////////////////////////
 /// AppendToStream types
 ////////////////////////////////////////////////////////////////////
@@ -205,6 +219,13 @@ export type AppendToStreamResult<StreamVersion = BigIntStreamPosition> = {
 
 export type AppendToStreamResultWithGlobalPosition<
   StreamVersion = BigIntStreamPosition,
+  GlobalPosition = BigIntGlobalPosition,
 > = AppendToStreamResult<StreamVersion> & {
-  lastEventGlobalPosition: StreamVersion;
+  lastEventGlobalPosition: GlobalPosition;
 };
+
+export type AppendStreamResultOfEventStore<Store extends EventStore> =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Store['appendToStream'] extends (...args: any[]) => Promise<infer R>
+    ? R
+    : never;

--- a/src/packages/emmett/src/eventStore/expectedVersion.ts
+++ b/src/packages/emmett/src/eventStore/expectedVersion.ts
@@ -1,14 +1,12 @@
 import { ConcurrencyError } from '../errors';
-import type { Flavour } from '../typing';
-import type { DefaultStreamVersionType } from './eventStore';
+import type { BigIntStreamPosition, Flavour } from '../typing';
 
-export type ExpectedStreamVersion<VersionType = DefaultStreamVersionType> =
+export type ExpectedStreamVersion<VersionType = BigIntStreamPosition> =
   | ExpectedStreamVersionWithValue<VersionType>
   | ExpectedStreamVersionGeneral;
 
-export type ExpectedStreamVersionWithValue<
-  VersionType = DefaultStreamVersionType,
-> = Flavour<VersionType, 'StreamVersion'>;
+export type ExpectedStreamVersionWithValue<VersionType = BigIntStreamPosition> =
+  Flavour<VersionType, 'StreamVersion'>;
 
 export type ExpectedStreamVersionGeneral = Flavour<
   'STREAM_EXISTS' | 'STREAM_DOES_NOT_EXIST' | 'NO_CONCURRENCY_CHECK',
@@ -21,9 +19,7 @@ export const STREAM_DOES_NOT_EXIST =
 export const NO_CONCURRENCY_CHECK =
   'NO_CONCURRENCY_CHECK' as ExpectedStreamVersionGeneral;
 
-export const matchesExpectedVersion = <
-  StreamVersion = DefaultStreamVersionType,
->(
+export const matchesExpectedVersion = <StreamVersion = BigIntStreamPosition>(
   current: StreamVersion | undefined,
   expected: ExpectedStreamVersion<StreamVersion>,
   defaultVersion: StreamVersion,
@@ -38,7 +34,7 @@ export const matchesExpectedVersion = <
 };
 
 export const assertExpectedVersionMatchesCurrent = <
-  StreamVersion = DefaultStreamVersionType,
+  StreamVersion = BigIntStreamPosition,
 >(
   current: StreamVersion,
   expected: ExpectedStreamVersion<StreamVersion> | undefined,
@@ -51,7 +47,7 @@ export const assertExpectedVersionMatchesCurrent = <
 };
 
 export class ExpectedVersionConflictError<
-  VersionType = DefaultStreamVersionType,
+  VersionType = BigIntStreamPosition,
 > extends ConcurrencyError {
   constructor(
     current: VersionType,

--- a/src/packages/emmett/src/projections/index.ts
+++ b/src/packages/emmett/src/projections/index.ts
@@ -12,7 +12,10 @@ export type ProjectionHandlingType = 'inline' | 'async';
 export type ProjectionHandler<
   EventType extends Event = Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ReadEventMetadata<any, any> = EventMetaDataOf<EventType> &
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ReadEventMetadata<any, any>,
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
 > = (
   events: ReadEvent<EventType, EventMetaDataType>[],
@@ -20,17 +23,31 @@ export type ProjectionHandler<
 ) => Promise<void> | void;
 
 export interface ProjectionDefinition<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ReadEventMetadataType extends ReadEventMetadata<any, any> = ReadEventMetadata<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any
+  >,
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
 > {
   name?: string;
   canHandle: CanHandle<Event>;
-  handle: ProjectionHandler<Event, ReadEventMetadata, ProjectionHandlerContext>;
+  handle: ProjectionHandler<
+    Event,
+    ReadEventMetadataType,
+    ProjectionHandlerContext
+  >;
 }
 
 export interface TypedProjectionDefinition<
   EventType extends Event = Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ReadEventMetadata<any, any> = EventMetaDataOf<EventType> &
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ReadEventMetadata<any, any>,
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
 > {
   name?: string;
@@ -44,43 +61,84 @@ export interface TypedProjectionDefinition<
 
 export type ProjectionRegistration<
   HandlingType extends ProjectionHandlingType,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ReadEventMetadataType extends ReadEventMetadata<any, any> = ReadEventMetadata<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any
+  >,
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
 > = {
   type: HandlingType;
-  projection: ProjectionDefinition<ProjectionHandlerContext>;
+  projection: ProjectionDefinition<
+    ReadEventMetadataType,
+    ProjectionHandlerContext
+  >;
 };
 
 export const projection = <
   EventType extends Event = Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ReadEventMetadata<any, any> = EventMetaDataOf<EventType> &
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ReadEventMetadata<any, any>,
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
   ProjectionDefintionType extends TypedProjectionDefinition<
     EventType,
     EventMetaDataType,
     ProjectionHandlerContext
-  > = ProjectionDefinition<ProjectionHandlerContext>,
+  > = TypedProjectionDefinition<
+    EventType,
+    EventMetaDataType,
+    ProjectionHandlerContext
+  >,
 >(
   definition: ProjectionDefintionType,
 ): ProjectionDefintionType => definition;
 
 export const inlineProjections = <
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ReadEventMetadataType extends ReadEventMetadata<any, any> = ReadEventMetadata<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any
+  >,
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
-  ProjectionDefintionType extends
-    ProjectionDefinition<ProjectionHandlerContext> = ProjectionDefinition<ProjectionHandlerContext>,
+  ProjectionDefintionType extends ProjectionDefinition<
+    ReadEventMetadataType,
+    ProjectionHandlerContext
+  > = ProjectionDefinition<ReadEventMetadataType, ProjectionHandlerContext>,
 >(
   definitions: ProjectionDefintionType[],
-): ProjectionRegistration<'inline', ProjectionHandlerContext>[] =>
-  definitions.map((projection) => ({ type: 'inline', projection }));
+): ProjectionRegistration<
+  'inline',
+  ReadEventMetadataType,
+  ProjectionHandlerContext
+>[] => definitions.map((projection) => ({ type: 'inline', projection }));
 
 export const asyncProjections = <
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ReadEventMetadataType extends ReadEventMetadata<any, any> = ReadEventMetadata<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any
+  >,
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
-  ProjectionDefintionType extends
-    ProjectionDefinition<ProjectionHandlerContext> = ProjectionDefinition<ProjectionHandlerContext>,
+  ProjectionDefintionType extends ProjectionDefinition<
+    ReadEventMetadataType,
+    ProjectionHandlerContext
+  > = ProjectionDefinition<ReadEventMetadataType, ProjectionHandlerContext>,
 >(
   definitions: ProjectionDefintionType[],
-): ProjectionRegistration<'async', ProjectionHandlerContext>[] =>
-  definitions.map((projection) => ({ type: 'async', projection }));
+): ProjectionRegistration<
+  'async',
+  ReadEventMetadataType,
+  ProjectionHandlerContext
+>[] => definitions.map((projection) => ({ type: 'async', projection }));
 
 export const projections = {
   inline: inlineProjections,

--- a/src/packages/emmett/src/testing/assertions.ts
+++ b/src/packages/emmett/src/testing/assertions.ts
@@ -33,12 +33,12 @@ export const assertThrowsAsync = async <TError extends Error>(
 ): Promise<TError> => {
   try {
     await fun();
-    throw new AssertionError("Function didn't throw expected error");
   } catch (error) {
     const typedError = error as TError;
     if (errorCheck) assertTrue(errorCheck(typedError));
     return typedError;
   }
+  throw new AssertionError("Function didn't throw expected error");
 };
 
 export const assertThrows = <TError extends Error>(
@@ -47,12 +47,12 @@ export const assertThrows = <TError extends Error>(
 ): TError => {
   try {
     fun();
-    throw new AssertionError("Function didn't throw expected error");
   } catch (error) {
     const typedError = error as TError;
     if (errorCheck) assertTrue(errorCheck(typedError));
     return typedError;
   }
+  throw new AssertionError("Function didn't throw expected error");
 };
 
 export const assertRejects = async <T, TError extends Error = Error>(

--- a/src/packages/emmett/src/typing/event.ts
+++ b/src/packages/emmett/src/typing/event.ts
@@ -1,5 +1,8 @@
 import type { DefaultRecord, Flavour } from './';
 
+export type BigIntStreamPosition = bigint;
+export type BigIntGlobalPosition = bigint;
+
 export type Event<
   EventType extends string = string,
   EventData extends DefaultRecord = DefaultRecord,
@@ -48,7 +51,10 @@ export const event = <EventType extends Event>(
 export type ReadEvent<
   EventType extends Event = Event,
   EventMetaDataType extends EventMetaDataOf<EventType> &
-    ReadEventMetadata = EventMetaDataOf<EventType> & ReadEventMetadata,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ReadEventMetadata<any, any> = EventMetaDataOf<EventType> &
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ReadEventMetadata<any, any>,
 > = CreateEventType<
   EventTypeOf<EventType>,
   EventDataOf<EventType>,
@@ -56,12 +62,30 @@ export type ReadEvent<
 > &
   EventType & { metadata: EventMetaDataType };
 
-export type ReadEventMetadata = Readonly<{
+export type ReadEventMetadata<
+  GlobalPosition = undefined,
+  StreamPosition = BigIntStreamPosition,
+> = Readonly<{
   eventId: string;
-  streamPosition: bigint;
+  streamPosition: StreamPosition;
   streamName: string;
-}>;
+}> &
+  (GlobalPosition extends undefined
+    ? object
+    : { globalPosition: GlobalPosition });
 
-export type ReadEventMetadataWithGlobalPosition = ReadEventMetadata & {
-  globalPosition: bigint;
-};
+export type ReadEventMetadataWithGlobalPosition<
+  GlobalPosition = BigIntGlobalPosition,
+> = ReadEventMetadata<GlobalPosition>;
+
+export type ReadEventMetadataWithoutGlobalPosition<
+  StreamPosition = BigIntStreamPosition,
+> = ReadEventMetadata<undefined, StreamPosition>;
+
+export type GlobalPositionTypeOfReadEventMetadata<ReadEventMetadataType> =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ReadEventMetadataType extends ReadEventMetadata<infer GP, any> ? GP : never;
+
+export type StreamPositionTypeOfReadEventMetadata<ReadEventMetadataType> =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ReadEventMetadataType extends ReadEventMetadata<any, infer SV> ? SV : never;


### PR DESCRIPTION
Added some [TypeScript VooDoo](https://www.youtube.com/watch?v=YV78vobCyIo) to make it possible to extend the Append and Aggregation result from the `EventStore` interface. And further in `CommandHandler`.

Thanks to that, it'll be possible to, e.g. return global position from stores that support it and similar adjustments.

By adding this VooDoo, metadata like stream position and global position types are derived from stored event (`ReadEvent` ) metadata passed to EventStore.

![Voodoo](https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/b1499d0f-0e69-449c-af15-10c441e94130/dhb2fdo-f2efb3d5-9ac7-41e4-8826-a7612b3994f5.gif?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7InBhdGgiOiJcL2ZcL2IxNDk5ZDBmLTBlNjktNDQ5Yy1hZjE1LTEwYzQ0MWU5NDEzMFwvZGhiMmZkby1mMmVmYjNkNS05YWM3LTQxZTQtODgyNi1hNzYxMmIzOTk0ZjUuZ2lmIn1dXSwiYXVkIjpbInVybjpzZXJ2aWNlOmZpbGUuZG93bmxvYWQiXX0.k5Cyw9UL-356_AWEt61UbRTuTMuRMGbh3EU1IjkxxVc)

I'm not sure, but my guess is that this is a breaking change. 🤷‍♂️