### PR TITLE
[MongoDB Event Store]: Fix metadata properties / export `emmett-mongodb/eventStore/projections`

### DIFF
--- a/src/packages/emmett-mongodb/src/eventStore/index.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/index.ts
@@ -1,1 +1,2 @@
 export * from './mongoDBEventStore';
+export * from './projections';

--- a/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.e2e.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.e2e.spec.ts
@@ -22,10 +22,10 @@ import {
 import {
   getMongoDBEventStore,
   toStreamName,
+  mongoDBInlineProjection,
   type EventStream,
   type MongoDBEventStore,
-} from './mongoDBEventStore';
-import { mongoDBInlineProjection } from './projections';
+} from './';
 
 const DB_NAME = 'mongodbeventstore_testing';
 const SHOPPING_CART_PROJECTION_NAME = 'shoppingCartShortInfo';


### PR DESCRIPTION
- Included `eventStore/projections` export in the main mongodb event store module. Was left out so the helpers in `projections` were not useable
- Several metadata properties were not being created on stream creation in the event store. Added these in in `appendToStream` with `$setOnInsert`
- Added test to ensure metadata properties are set on stream creation