### PR TITLE
Added idempotence check for Decider Specification

### DIFF
--- a/src/packages/emmett-postgresql/src/eventStore/projections/pongo/pongoProjectionSpec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/pongo/pongoProjectionSpec.ts
@@ -61,7 +61,7 @@ const assertDocumentsEqual = <
       expected._id,
       actual._id,
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      `Document ids are not matching! Expected: ${expected._id}, actual: ${actual._id}`,
+      `Document ids are not matching! Expected: ${expected._id}, Actual: ${actual._id}`,
     );
 
   return assertDeepEqual(

--- a/src/packages/emmett/src/testing/deciderSpecification.ts
+++ b/src/packages/emmett/src/testing/deciderSpecification.ts
@@ -1,5 +1,5 @@
 import { isErrorConstructor, type ErrorConstructor } from '../errors';
-import { AssertionError, assertMatches, assertTrue } from './assertions';
+import { AssertionError, assertThatArray, assertTrue } from './assertions';
 
 type ErrorCheck<ErrorType> = (error: ErrorType) => boolean;
 
@@ -17,6 +17,7 @@ export type DeciderSpecfication<Command, Event> = (
 ) => {
   when: (command: Command) => {
     then: (expectedEvents: Event | Event[]) => void;
+    thenDoesNothing: () => void;
     thenThrows: <ErrorType extends Error = Error>(
       ...args: Parameters<ThenThrows<ErrorType>>
     ) => void;
@@ -58,7 +59,18 @@ export const DeciderSpecification = {
                   ? expectedEvents
                   : [expectedEvents];
 
-                assertMatches(resultEventsArray, expectedEventsArray);
+                assertThatArray(resultEventsArray).containsOnlyElementsMatching(
+                  expectedEventsArray,
+                );
+              },
+              thenDoesNothing: (): void => {
+                const resultEvents = handle();
+
+                const resultEventsArray = Array.isArray(resultEvents)
+                  ? resultEvents
+                  : [resultEvents];
+
+                assertThatArray(resultEventsArray).isEmpty();
               },
               thenThrows: <ErrorType extends Error>(
                 ...args: Parameters<ThenThrows<ErrorType>>


### PR DESCRIPTION
Now, you can either pass an empty array or call `thenDoesNothing` to verify whether the business logic handled idempotency correctly.