### PR TITLE
Made the MongoDB event store explicit on whether it can close MongoDBclient or not

### DIFF
--- a/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.connection.e2e.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.connection.e2e.spec.ts
@@ -48,6 +48,7 @@ void describe('MongoDBEventStore connection', () => {
 
   void it('connects using connection string', async () => {
     const eventStore = getMongoDBEventStore({
+      storage: { type: 'COLLECTION_PER_STREAM_TYPE' },
       connectionString: mongodb.getConnectionString(),
       clientOptions: { directConnection: true },
       projections: projections.inline([
@@ -68,6 +69,7 @@ void describe('MongoDBEventStore connection', () => {
   void it('disconnects on close', async () => {
     // given
     const eventStore = getMongoDBEventStore({
+      storage: { type: 'COLLECTION_PER_STREAM_TYPE' },
       connectionString: mongodb.getConnectionString(),
       clientOptions: { directConnection: true },
       projections: projections.inline([
@@ -97,6 +99,7 @@ void describe('MongoDBEventStore connection', () => {
     });
     try {
       const eventStore = getMongoDBEventStore({
+        storage: { type: 'COLLECTION_PER_STREAM_TYPE' },
         client,
         projections: projections.inline([
           mongoDBInlineProjection({
@@ -128,6 +131,7 @@ void describe('MongoDBEventStore connection', () => {
     await client.connect();
     try {
       const eventStore = getMongoDBEventStore({
+        storage: { type: 'COLLECTION_PER_STREAM_TYPE' },
         client,
         projections: projections.inline([
           mongoDBInlineProjection({
@@ -153,8 +157,8 @@ void describe('MongoDBEventStore connection', () => {
 
     try {
       const eventStore = getMongoDBEventStore({
+        storage: { type: 'COLLECTION_PER_STREAM_TYPE', database },
         client,
-        database,
         projections: projections.inline([
           mongoDBInlineProjection({
             name: SHOPPING_CART_PROJECTION_NAME,
@@ -179,6 +183,7 @@ void describe('MongoDBEventStore connection', () => {
 
   void it('connects using connection string', async () => {
     const eventStore = getMongoDBEventStore({
+      storage: { type: 'COLLECTION_PER_STREAM_TYPE' },
       connectionString: mongodb.getConnectionString(),
       clientOptions: { directConnection: true },
       projections: projections.inline([

--- a/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.connection.e2e.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.connection.e2e.spec.ts
@@ -2,7 +2,6 @@ import {
   assertIsNotNull,
   assertNotEqual,
   assertThrowsAsync,
-  assertTrue,
   projections,
   STREAM_DOES_NOT_EXIST,
 } from '@event-driven-io/emmett';
@@ -116,37 +115,6 @@ void describe('MongoDBEventStore connection', () => {
         .collection(toStreamCollectionName(streamType))
         .findOne();
       assertIsNotNull(stream);
-    } finally {
-      await client.close();
-    }
-  });
-
-  void it('does not disconnect connected client', async () => {
-    const client = new MongoClient(mongodb.getConnectionString(), {
-      directConnection: true,
-    });
-
-    await client.connect();
-    try {
-      const eventStore = getMongoDBEventStore({
-        client,
-        projections: projections.inline([
-          mongoDBInlineProjection({
-            name: SHOPPING_CART_PROJECTION_NAME,
-            canHandle: ['ProductItemAdded', 'DiscountApplied'],
-            evolve,
-          }),
-        ]),
-      });
-
-      await eventStore.close();
-
-      const { acknowledged } = await client
-        .db()
-        .collection('test')
-        .insertOne({ test: 'test' });
-
-      assertTrue(acknowledged);
     } finally {
       await client.close();
     }

--- a/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.e2e.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.e2e.spec.ts
@@ -42,6 +42,7 @@ void describe('MongoDBEventStore', () => {
     );
 
     eventStore = getMongoDBEventStore({
+      storage: { type: 'COLLECTION_PER_STREAM_TYPE' },
       client,
     });
     return eventStore;

--- a/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.ts
@@ -171,6 +171,18 @@ type ProjectionQueries<T extends StreamType> = {
   inline: InlineProjectionQueries<T>;
 };
 
+type MongoDBEventStoreClientOptions = {
+  client: MongoClient;
+  connectionString?: never;
+  clientOptions?: never;
+};
+
+type MongoDBEventStoreConnectionStringOptions = {
+  client?: never;
+  connectionString: string;
+  clientOptions?: MongoClientOptions;
+};
+
 export type MongoDBEventStoreOptions = {
   database?: string;
   collection?: string;
@@ -179,15 +191,7 @@ export type MongoDBEventStoreOptions = {
     MongoDBReadEventMetadata,
     MongoDBProjectionInlineHandlerContext
   >[];
-} & (
-  | {
-      client: MongoClient;
-    }
-  | {
-      connectionString: string;
-      clientOptions?: MongoClientOptions;
-    }
-);
+} & (MongoDBEventStoreClientOptions | MongoDBEventStoreConnectionStringOptions);
 
 export type MongoDBEventStore = EventStore<MongoDBReadEventMetadata> & {
   projections: ProjectionQueries<StreamType>;
@@ -211,7 +215,7 @@ class MongoDBEventStoreImplementation implements MongoDBEventStore, Closeable {
 
   constructor(options: MongoDBEventStoreOptions) {
     this.client =
-      'client' in options
+      'client' in options && options.client
         ? options.client
         : new MongoClient(options.connectionString, options.clientOptions);
     this.shouldManageClientLifetime = !('client' in options);

--- a/src/packages/emmett-mongodb/src/eventStore/projections/mongoDBEventStore.projections.e2e.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/projections/mongoDBEventStore.projections.e2e.spec.ts
@@ -14,12 +14,6 @@ import { MongoClient, type Collection } from 'mongodb';
 import { after, before, describe, it } from 'node:test';
 import { v4 as uuid } from 'uuid';
 import {
-  type DiscountApplied,
-  type PricedProductItem,
-  type ProductItemAdded,
-  type ShoppingCartEvent,
-} from '../../testing/shoppingCart.domain';
-import {
   getMongoDBEventStore,
   mongoDBInlineProjection,
   toStreamCollectionName,
@@ -27,6 +21,12 @@ import {
   type EventStream,
   type MongoDBEventStore,
 } from '../';
+import {
+  type DiscountApplied,
+  type PricedProductItem,
+  type ProductItemAdded,
+  type ShoppingCartEvent,
+} from '../../testing/shoppingCart.domain';
 
 void describe('MongoDBEventStore', () => {
   let mongodb: StartedMongoDBContainer;
@@ -55,6 +55,7 @@ void describe('MongoDBEventStore', () => {
     );
 
     eventStore = getMongoDBEventStore({
+      storage: { type: 'COLLECTION_PER_STREAM_TYPE' },
       client,
       projections: projections.inline([
         mongoDBInlineProjection({

--- a/src/packages/emmett/src/utils/closeable.ts
+++ b/src/packages/emmett/src/utils/closeable.ts
@@ -1,0 +1,8 @@
+export type Closeable = {
+  /**
+   * Gracefully cleans up managed resources
+   *
+   * @memberof Closeable
+   */
+  close: () => Promise<void>;
+};

--- a/src/packages/emmett/src/utils/index.ts
+++ b/src/packages/emmett/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './closeable';
 export * from './deepEquals';
 export * from './iterators';
 export * from './locking';


### PR DESCRIPTION
So far, the MongoDB event store has always exposed the close method. That's redundant for the case when the client is passed through options.

Now, it'll only be exposed if the store is created based on the connection string.

Following the Boy Scout rule, I also added a general Closeable interface to facilitate uniform handling of such cases in the future.

Follow up to #136

Fixes #143 