### PR TITLE
Added explicit storage type selection for MongoDB Event Store

### DIFF
--- a/src/packages/emmett-mongodb/src/eventStore/index.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/index.ts
@@ -1,2 +1,3 @@
 export * from './mongoDBEventStore';
 export * from './projections';
+export * from './storage';

--- a/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.connection.e2e.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.connection.e2e.spec.ts
@@ -48,6 +48,7 @@ void describe('MongoDBEventStore connection', () => {
 
   void it('connects using connection string', async () => {
     const eventStore = getMongoDBEventStore({
+      storage: { type: 'COLLECTION_PER_STREAM_TYPE' },
       connectionString: mongodb.getConnectionString(),
       clientOptions: { directConnection: true },
       projections: projections.inline([
@@ -68,6 +69,7 @@ void describe('MongoDBEventStore connection', () => {
   void it('disconnects on close', async () => {
     // given
     const eventStore = getMongoDBEventStore({
+      storage: { type: 'COLLECTION_PER_STREAM_TYPE' },
       connectionString: mongodb.getConnectionString(),
       clientOptions: { directConnection: true },
       projections: projections.inline([
@@ -97,6 +99,7 @@ void describe('MongoDBEventStore connection', () => {
     });
     try {
       const eventStore = getMongoDBEventStore({
+        storage: { type: 'COLLECTION_PER_STREAM_TYPE' },
         client,
         projections: projections.inline([
           mongoDBInlineProjection({
@@ -128,6 +131,7 @@ void describe('MongoDBEventStore connection', () => {
     await client.connect();
     try {
       const eventStore = getMongoDBEventStore({
+        storage: { type: 'COLLECTION_PER_STREAM_TYPE' },
         client,
         projections: projections.inline([
           mongoDBInlineProjection({
@@ -153,8 +157,8 @@ void describe('MongoDBEventStore connection', () => {
 
     try {
       const eventStore = getMongoDBEventStore({
+        storage: { type: 'COLLECTION_PER_STREAM_TYPE', database },
         client,
-        database,
         projections: projections.inline([
           mongoDBInlineProjection({
             name: SHOPPING_CART_PROJECTION_NAME,
@@ -179,6 +183,7 @@ void describe('MongoDBEventStore connection', () => {
 
   void it('connects using connection string', async () => {
     const eventStore = getMongoDBEventStore({
+      storage: { type: 'COLLECTION_PER_STREAM_TYPE' },
       connectionString: mongodb.getConnectionString(),
       clientOptions: { directConnection: true },
       projections: projections.inline([

--- a/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.connection.e2e.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.connection.e2e.spec.ts
@@ -157,7 +157,7 @@ void describe('MongoDBEventStore connection', () => {
 
     try {
       const eventStore = getMongoDBEventStore({
-        storage: { type: 'COLLECTION_PER_STREAM_TYPE', database },
+        storage: { type: 'COLLECTION_PER_STREAM_TYPE', databaseName: database },
         client,
         projections: projections.inline([
           mongoDBInlineProjection({

--- a/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.e2e.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.e2e.spec.ts
@@ -11,10 +11,7 @@ import {
 import { MongoClient, type Collection } from 'mongodb';
 import { after, before, describe, it } from 'node:test';
 import { v4 as uuid } from 'uuid';
-import {
-  type PricedProductItem,
-  type ShoppingCartEvent,
-} from '../testing/shoppingCart.domain';
+import { type PricedProductItem, type ShoppingCartEvent } from '../testing';
 import {
   getMongoDBEventStore,
   toStreamCollectionName,

--- a/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.e2e.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.e2e.spec.ts
@@ -42,7 +42,6 @@ void describe('MongoDBEventStore', () => {
     );
 
     eventStore = getMongoDBEventStore({
-      storage: { type: 'COLLECTION_PER_STREAM_TYPE' },
       client,
     });
     return eventStore;

--- a/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.e2e.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.e2e.spec.ts
@@ -42,6 +42,7 @@ void describe('MongoDBEventStore', () => {
     );
 
     eventStore = getMongoDBEventStore({
+      storage: { type: 'COLLECTION_PER_STREAM_TYPE' },
       client,
     });
     return eventStore;

--- a/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.ts
@@ -16,7 +16,6 @@ import {
   type ReadStreamResult,
 } from '@event-driven-io/emmett';
 import {
-  Db,
   MongoClient,
   type Collection,
   type Document,
@@ -189,7 +188,6 @@ export type MongoDBEventStore = EventStore<MongoDBReadEventMetadata> & {
 class MongoDBEventStoreImplementation implements MongoDBEventStore, Closeable {
   private readonly client: MongoClient;
   private shouldManageClientLifetime: boolean;
-  private db: Db | undefined;
   private readonly inlineProjections: MongoDBInlineProjectionDefinition[];
   private isClosed: boolean = false;
   public projections: ProjectionQueries<StreamType>;

--- a/src/packages/emmett-mongodb/src/eventStore/projections/mongoDBEventStore.projections.e2e.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/projections/mongoDBEventStore.projections.e2e.spec.ts
@@ -14,12 +14,6 @@ import { MongoClient, type Collection } from 'mongodb';
 import { after, before, describe, it } from 'node:test';
 import { v4 as uuid } from 'uuid';
 import {
-  type DiscountApplied,
-  type PricedProductItem,
-  type ProductItemAdded,
-  type ShoppingCartEvent,
-} from '../../testing/shoppingCart.domain';
-import {
   getMongoDBEventStore,
   mongoDBInlineProjection,
   toStreamCollectionName,
@@ -27,6 +21,12 @@ import {
   type EventStream,
   type MongoDBEventStore,
 } from '../';
+import {
+  type DiscountApplied,
+  type PricedProductItem,
+  type ProductItemAdded,
+  type ShoppingCartEvent,
+} from '../../testing/shoppingCart.domain';
 
 void describe('MongoDBEventStore', () => {
   let mongodb: StartedMongoDBContainer;
@@ -55,6 +55,7 @@ void describe('MongoDBEventStore', () => {
     );
 
     eventStore = getMongoDBEventStore({
+      storage: { type: 'COLLECTION_PER_STREAM_TYPE' },
       client,
       projections: projections.inline([
         mongoDBInlineProjection({

--- a/src/packages/emmett-mongodb/src/eventStore/projections/mongoDBEventStore.projections.e2e.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/projections/mongoDBEventStore.projections.e2e.spec.ts
@@ -26,7 +26,7 @@ import {
   type PricedProductItem,
   type ProductItemAdded,
   type ShoppingCartEvent,
-} from '../../testing/shoppingCart.domain';
+} from '../../testing';
 
 void describe('MongoDBEventStore', () => {
   let mongodb: StartedMongoDBContainer;

--- a/src/packages/emmett-mongodb/src/eventStore/projections/mongoDBEventStore.projections.e2e.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/projections/mongoDBEventStore.projections.e2e.spec.ts
@@ -55,7 +55,6 @@ void describe('MongoDBEventStore', () => {
     );
 
     eventStore = getMongoDBEventStore({
-      storage: { type: 'COLLECTION_PER_STREAM_TYPE' },
       client,
       projections: projections.inline([
         mongoDBInlineProjection({

--- a/src/packages/emmett-mongodb/src/eventStore/storage/index.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/storage/index.ts
@@ -1,0 +1,1 @@
+export * from './mongoDBEventStoreStorage';

--- a/src/packages/emmett-mongodb/src/eventStore/storage/mongoDBEventStoreStorage.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/storage/mongoDBEventStoreStorage.ts
@@ -146,7 +146,7 @@ const collectionFor = async <EventType extends Event = Event>(options: {
 };
 
 export const mongoDBEventStoreStorage = (options: {
-  storage: MongoDBEventStoreStorageOptions | undefined;
+  storage?: MongoDBEventStoreStorageOptions | undefined;
   getConnectedClient: () => Promise<MongoClient>;
 }): MongoDBEventStoreStorage => {
   const dbsCache: Map<string, Db> = new Map();

--- a/src/packages/emmett-mongodb/src/eventStore/storage/mongoDBEventStoreStorage.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/storage/mongoDBEventStoreStorage.ts
@@ -1,0 +1,187 @@
+import { type Event } from '@event-driven-io/emmett';
+import type { Collection, Db, MongoClient } from 'mongodb';
+import {
+  toStreamCollectionName,
+  type EventStream,
+  type StreamType,
+} from '../mongoDBEventStore';
+
+export type MongoDBEventStoreCollectionPerStreamTypeStorageOptions = {
+  /**
+   * The recommended setting where each stream type will be kept
+   * in a separate collection type using the format: `emt_${streamType}`.
+   */
+  type: 'COLLECTION_PER_STREAM_TYPE';
+  databaseName?: string;
+};
+
+export type MongoDBEventStoreSingleCollectionStorageOptions = {
+  /**
+   * All streams will be kept withing a single MongDB collection
+   * It'll either use default collection name ("emt_streams")
+   * or provided name through 'collection' param.
+   */
+  type: 'SINGLE_COLLECTION';
+  collectionName?: string;
+  databaseName?: string;
+};
+
+export type MongoDBEventStoreCollectionResolution = {
+  databaseName?: string;
+  collectionName: string;
+};
+
+export type MongoDBEventStoreCustomStorageOptions = {
+  /**
+   * This is advanced option, where you specify your own collection
+   * resolution function. You can do that by specifying the `collectionFor` function.
+   */
+  type: 'CUSTOM';
+  databaseName?: string;
+  collectionFor: <T extends StreamType>(
+    streamType: T,
+  ) => string | MongoDBEventStoreCollectionResolution;
+};
+
+export type MongoDBEventStoreStorageOptions =
+  | 'COLLECTION_PER_STREAM_TYPE'
+  | 'SINGLE_COLLECTION'
+  | MongoDBEventStoreSingleCollectionStorageOptions
+  | MongoDBEventStoreCollectionPerStreamTypeStorageOptions
+  | MongoDBEventStoreCustomStorageOptions;
+
+export const DefaultMongoDBEventStoreStorageOptions =
+  'COLLECTION_PER_STREAM_TYPE';
+
+export type MongoDBEventStoreStorage = {
+  collectionFor: <T extends StreamType, EventType extends Event = Event>(
+    streamType: T,
+  ) => Promise<Collection<EventStream<EventType>>>;
+};
+
+export const DefaultMongoDBEventStoreCollectionName = 'emt:streams';
+
+const resolveCollectionAndDatabase = <T extends StreamType>(
+  streamType: T,
+  options: MongoDBEventStoreStorageOptions,
+): MongoDBEventStoreCollectionResolution => {
+  if (
+    options === 'SINGLE_COLLECTION' ||
+    (typeof options === 'object' && options.type === 'SINGLE_COLLECTION')
+  ) {
+    return {
+      collectionName:
+        typeof options === 'object'
+          ? (options.collectionName ?? DefaultMongoDBEventStoreCollectionName)
+          : DefaultMongoDBEventStoreCollectionName,
+      databaseName:
+        typeof options === 'object' ? options.databaseName : undefined,
+    };
+  } else if (
+    options === 'COLLECTION_PER_STREAM_TYPE' ||
+    (typeof options === 'object' &&
+      options.type === 'COLLECTION_PER_STREAM_TYPE')
+  ) {
+    return {
+      collectionName: toStreamCollectionName(streamType),
+      databaseName:
+        typeof options === 'object' ? options.databaseName : undefined,
+    };
+  } else {
+    const result = options.collectionFor(streamType);
+    return {
+      collectionName:
+        typeof result === 'object' ? result.collectionName : result,
+      databaseName:
+        typeof result === 'object'
+          ? (result.databaseName ?? options.databaseName)
+          : options.databaseName,
+    };
+  }
+};
+
+const getDB = async (options: {
+  databaseName: string | undefined;
+  dbsCache: Map<string, Db>;
+  getConnectedClient: () => Promise<MongoClient>;
+}): Promise<Db> => {
+  const { dbsCache, databaseName, getConnectedClient } = options;
+  const safeDbName = databaseName ?? '___default';
+
+  let db = dbsCache.get(safeDbName);
+
+  if (!db) {
+    const connectedClient = await getConnectedClient();
+
+    db = connectedClient.db(databaseName);
+
+    dbsCache.set(safeDbName, db);
+  }
+
+  return db;
+};
+
+const collectionFor = async <EventType extends Event = Event>(options: {
+  collectionName: string;
+  streamCollections: Map<string, Collection<EventStream>>;
+  db: Db;
+}): Promise<Collection<EventStream<EventType>>> => {
+  const { collectionName, db, streamCollections } = options;
+
+  let collection = streamCollections.get(collectionName) as
+    | Collection<EventStream<EventType>>
+    | undefined;
+
+  if (!collection) {
+    collection = db.collection<EventStream<EventType>>(collectionName);
+    await collection.createIndex({ streamName: 1 }, { unique: true });
+
+    streamCollections.set(
+      collectionName,
+      collection as Collection<EventStream>,
+    );
+  }
+
+  return collection;
+};
+
+export const mongoDBEventStoreStorage = (options: {
+  storage: MongoDBEventStoreStorageOptions | undefined;
+  getConnectedClient: () => Promise<MongoClient>;
+}): MongoDBEventStoreStorage => {
+  const dbsCache: Map<string, Db> = new Map();
+  const streamCollections: Map<string, Collection<EventStream>> = new Map();
+  const storageOptions =
+    options.storage ?? DefaultMongoDBEventStoreStorageOptions;
+
+  const { getConnectedClient } = options;
+
+  return {
+    collectionFor: async <
+      T extends StreamType,
+      EventType extends Event = Event,
+    >(
+      streamType: T,
+    ): Promise<Collection<EventStream<EventType>>> => {
+      const { collectionName, databaseName } = resolveCollectionAndDatabase(
+        streamType,
+        storageOptions,
+      );
+
+      let collection = streamCollections.get(collectionName) as
+        | Collection<EventStream<EventType>>
+        | undefined;
+
+      if (!collection) {
+        const db = await getDB({ databaseName, dbsCache, getConnectedClient });
+        collection = await collectionFor<EventType>({
+          collectionName,
+          streamCollections,
+          db,
+        });
+      }
+
+      return collection;
+    },
+  };
+};

--- a/src/packages/emmett-mongodb/src/eventStore/storage/mongoDBEventStoreStorage.unit.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/storage/mongoDBEventStoreStorage.unit.spec.ts
@@ -51,6 +51,20 @@ void describe('mongoDBEventStoreStorage', () => {
     assertEqual(collection.dbName, defaultDBName);
   });
 
+  void it('resolves the same instance of collection for multiple calls for the same stream type resolution', async () => {
+    // Given
+    const storage = mongoDBEventStoreStorage({
+      getConnectedClient,
+    });
+
+    // When
+    const firstResolution = await storage.collectionFor(testStreamTypeName);
+    const nextResolution = await storage.collectionFor(testStreamTypeName);
+
+    // Then
+    assertEqual(firstResolution, nextResolution);
+  });
+
   void describe('Single Collection storage', () => {
     void it('handles SINGLE_COLLECTION passed as string with default collection name and no db', async () => {
       // Given

--- a/src/packages/emmett-mongodb/src/eventStore/storage/mongoDBEventStoreStorage.unit.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/storage/mongoDBEventStoreStorage.unit.spec.ts
@@ -1,0 +1,432 @@
+import { assertEqual, assertNotEqual } from '@event-driven-io/emmett';
+import type { MongoClient } from 'mongodb';
+import { beforeEach, describe, it } from 'node:test';
+import { v7 as uuid } from 'uuid';
+import { getDummyClient } from '../../testing';
+import { toStreamCollectionName, type StreamType } from '../mongoDBEventStore';
+import {
+  DefaultMongoDBEventStoreCollectionName,
+  mongoDBEventStoreStorage,
+  type MongoDBEventStoreCollectionResolution,
+} from './mongoDBEventStoreStorage';
+
+type TestStreamType = StreamType;
+type OtherTestStreamType = StreamType;
+
+void describe('mongoDBEventStoreStorage', () => {
+  let testStreamTypeName: TestStreamType;
+  let otherStreamTypeName: OtherTestStreamType;
+  let defaultDBName: string;
+  let getConnectedClient: () => Promise<MongoClient>;
+
+  beforeEach(() => {
+    testStreamTypeName = uuid();
+    otherStreamTypeName = uuid();
+    defaultDBName = uuid();
+    getConnectedClient = () =>
+      Promise.resolve(getDummyClient({ defaultDBName }));
+  });
+
+  void it('uses COLLECTION_PER_STREAM_TYPE storage option if none provided with default db', async () => {
+    // Given
+    const storage = mongoDBEventStoreStorage({
+      getConnectedClient,
+    });
+
+    // When
+    const collection = await storage.collectionFor(testStreamTypeName);
+    const otherCollection = await storage.collectionFor(otherStreamTypeName);
+
+    // Then
+    assertNotEqual(collection.collectionName, otherCollection.collectionName);
+    assertEqual(
+      collection.collectionName,
+      toStreamCollectionName(testStreamTypeName),
+    );
+    assertEqual(
+      otherCollection.collectionName,
+      toStreamCollectionName(otherStreamTypeName),
+    );
+    assertEqual(collection.dbName, defaultDBName);
+    assertEqual(collection.dbName, defaultDBName);
+  });
+
+  void describe('Single Collection storage', () => {
+    void it('handles SINGLE_COLLECTION passed as string with default collection name and no db', async () => {
+      // Given
+      const storage = mongoDBEventStoreStorage({
+        storage: 'SINGLE_COLLECTION',
+        getConnectedClient,
+      });
+
+      // When
+      const collection = await storage.collectionFor(testStreamTypeName);
+      const otherCollection = await storage.collectionFor(otherStreamTypeName);
+
+      // Then
+      assertEqual(collection.collectionName, otherCollection.collectionName);
+      assertEqual(
+        collection.collectionName,
+        DefaultMongoDBEventStoreCollectionName,
+      );
+      assertEqual(
+        otherCollection.collectionName,
+        DefaultMongoDBEventStoreCollectionName,
+      );
+      assertEqual(collection.dbName, defaultDBName);
+      assertEqual(collection.dbName, defaultDBName);
+    });
+
+    void it('handles SINGLE_COLLECTION passed as object with default collection name and no db', async () => {
+      // Given
+      const storage = mongoDBEventStoreStorage({
+        storage: { type: 'SINGLE_COLLECTION' },
+        getConnectedClient,
+      });
+
+      // When
+      const collection = await storage.collectionFor(testStreamTypeName);
+      const otherCollection = await storage.collectionFor(otherStreamTypeName);
+
+      // Then
+      assertEqual(collection.collectionName, otherCollection.collectionName);
+      assertEqual(
+        collection.collectionName,
+        DefaultMongoDBEventStoreCollectionName,
+      );
+      assertEqual(
+        otherCollection.collectionName,
+        DefaultMongoDBEventStoreCollectionName,
+      );
+      assertEqual(collection.dbName, defaultDBName);
+      assertEqual(collection.dbName, defaultDBName);
+    });
+
+    void it('handles SINGLE_COLLECTION passed as object with custom collection name and no db', async () => {
+      // Given
+      const customCollectionName = uuid();
+      const storage = mongoDBEventStoreStorage({
+        storage: {
+          type: 'SINGLE_COLLECTION',
+          collectionName: customCollectionName,
+        },
+        getConnectedClient,
+      });
+
+      // When
+      const collection = await storage.collectionFor(testStreamTypeName);
+      const otherCollection = await storage.collectionFor(otherStreamTypeName);
+
+      // Then
+      assertEqual(collection.collectionName, otherCollection.collectionName);
+      assertEqual(collection.collectionName, customCollectionName);
+      assertEqual(otherCollection.collectionName, customCollectionName);
+      assertEqual(collection.dbName, defaultDBName);
+      assertEqual(collection.dbName, defaultDBName);
+    });
+
+    void it('handles SINGLE_COLLECTION passed as object with no collection name and custom db', async () => {
+      // Given
+      const customDatabaseName = uuid();
+      const storage = mongoDBEventStoreStorage({
+        storage: {
+          type: 'SINGLE_COLLECTION',
+          databaseName: customDatabaseName,
+        },
+        getConnectedClient,
+      });
+
+      // When
+      const collection = await storage.collectionFor(testStreamTypeName);
+      const otherCollection = await storage.collectionFor(otherStreamTypeName);
+
+      // Then
+      assertEqual(collection.collectionName, otherCollection.collectionName);
+      assertEqual(
+        collection.collectionName,
+        DefaultMongoDBEventStoreCollectionName,
+      );
+      assertEqual(
+        otherCollection.collectionName,
+        DefaultMongoDBEventStoreCollectionName,
+      );
+      assertEqual(collection.dbName, customDatabaseName);
+      assertEqual(collection.dbName, customDatabaseName);
+    });
+
+    void it('handles SINGLE_COLLECTION passed as object with custom collection name and custom db', async () => {
+      // Given
+      const customCollectionName = uuid();
+      const customDatabaseName = uuid();
+      const storage = mongoDBEventStoreStorage({
+        storage: {
+          type: 'SINGLE_COLLECTION',
+          collectionName: customCollectionName,
+          databaseName: customDatabaseName,
+        },
+        getConnectedClient,
+      });
+
+      // When
+      const collection = await storage.collectionFor(testStreamTypeName);
+      const otherCollection = await storage.collectionFor(otherStreamTypeName);
+
+      // Then
+      assertEqual(collection.collectionName, otherCollection.collectionName);
+      assertEqual(collection.collectionName, customCollectionName);
+      assertEqual(otherCollection.collectionName, customCollectionName);
+      assertEqual(collection.dbName, customDatabaseName);
+      assertEqual(collection.dbName, customDatabaseName);
+    });
+  });
+
+  void describe('Collection per stream type storage', () => {
+    void it('handles COLLECTION_PER_STREAM_TYPE passed as string', async () => {
+      // Given
+      const storage = mongoDBEventStoreStorage({
+        storage: 'COLLECTION_PER_STREAM_TYPE',
+        getConnectedClient,
+      });
+
+      // When
+      const collection = await storage.collectionFor(testStreamTypeName);
+      const otherCollection = await storage.collectionFor(otherStreamTypeName);
+
+      // Then
+      assertNotEqual(collection.collectionName, otherCollection.collectionName);
+      assertEqual(
+        collection.collectionName,
+        toStreamCollectionName(testStreamTypeName),
+      );
+      assertEqual(
+        otherCollection.collectionName,
+        toStreamCollectionName(otherStreamTypeName),
+      );
+      assertEqual(collection.dbName, defaultDBName);
+      assertEqual(collection.dbName, defaultDBName);
+    });
+
+    void it('handles COLLECTION_PER_STREAM_TYPE passed as object with no db', async () => {
+      // Given
+      const storage = mongoDBEventStoreStorage({
+        storage: { type: 'COLLECTION_PER_STREAM_TYPE' },
+        getConnectedClient,
+      });
+
+      // When
+      const collection = await storage.collectionFor(testStreamTypeName);
+      const otherCollection = await storage.collectionFor(otherStreamTypeName);
+
+      // Then
+      assertNotEqual(collection.collectionName, otherCollection.collectionName);
+      assertEqual(
+        collection.collectionName,
+        toStreamCollectionName(testStreamTypeName),
+      );
+      assertEqual(
+        otherCollection.collectionName,
+        toStreamCollectionName(otherStreamTypeName),
+      );
+      assertEqual(collection.dbName, defaultDBName);
+      assertEqual(collection.dbName, defaultDBName);
+    });
+
+    void it('handles COLLECTION_PER_STREAM_TYPE passed as object and custom db', async () => {
+      // Given
+      const customDatabaseName = uuid();
+      const storage = mongoDBEventStoreStorage({
+        storage: {
+          type: 'COLLECTION_PER_STREAM_TYPE',
+          databaseName: customDatabaseName,
+        },
+        getConnectedClient,
+      });
+
+      // When
+      const collection = await storage.collectionFor(testStreamTypeName);
+      const otherCollection = await storage.collectionFor(otherStreamTypeName);
+
+      // Then
+      assertNotEqual(collection.collectionName, otherCollection.collectionName);
+      assertEqual(
+        collection.collectionName,
+        toStreamCollectionName(testStreamTypeName),
+      );
+      assertEqual(
+        otherCollection.collectionName,
+        toStreamCollectionName(otherStreamTypeName),
+      );
+      assertEqual(collection.dbName, customDatabaseName);
+      assertEqual(collection.dbName, customDatabaseName);
+    });
+  });
+
+  void describe('Custom collection resolution storage', () => {
+    const customSuffix = uuid();
+    const collectionFor = (streamType: string) =>
+      `${streamType}:${customSuffix}`;
+
+    void it('handles CUSTOM with collectionFor returning string and no db', async () => {
+      // Given
+      const storage = mongoDBEventStoreStorage({
+        storage: { type: 'CUSTOM', collectionFor },
+        getConnectedClient,
+      });
+
+      // When
+      const collection = await storage.collectionFor(testStreamTypeName);
+      const otherCollection = await storage.collectionFor(otherStreamTypeName);
+
+      // Then
+      assertNotEqual(collection.collectionName, otherCollection.collectionName);
+      assertEqual(
+        collection.collectionName,
+        `${testStreamTypeName}:${customSuffix}`,
+      );
+      assertEqual(
+        otherCollection.collectionName,
+        `${otherStreamTypeName}:${customSuffix}`,
+      );
+      assertEqual(collection.dbName, defaultDBName);
+      assertEqual(collection.dbName, defaultDBName);
+    });
+
+    void it('handles CUSTOM with collectionFor returning object with collection name and no db', async () => {
+      // Given
+      const collectionForWithDb = (
+        streamType: string,
+      ): MongoDBEventStoreCollectionResolution => ({
+        collectionName: collectionFor(streamType),
+      });
+
+      const storage = mongoDBEventStoreStorage({
+        storage: {
+          type: 'CUSTOM',
+          collectionFor: collectionForWithDb,
+        },
+        getConnectedClient,
+      });
+
+      // When
+      const collection = await storage.collectionFor(testStreamTypeName);
+      const otherCollection = await storage.collectionFor(otherStreamTypeName);
+
+      // Then
+      assertNotEqual(collection.collectionName, otherCollection.collectionName);
+      assertEqual(
+        collection.collectionName,
+        `${testStreamTypeName}:${customSuffix}`,
+      );
+      assertEqual(
+        otherCollection.collectionName,
+        `${otherStreamTypeName}:${customSuffix}`,
+      );
+      assertEqual(collection.dbName, defaultDBName);
+      assertEqual(collection.dbName, defaultDBName);
+    });
+
+    void it('handles CUSTOM with collectionFor returning string and using custom db from options', async () => {
+      // Given
+      const customDatabaseName = uuid();
+      const storage = mongoDBEventStoreStorage({
+        storage: {
+          type: 'CUSTOM',
+          collectionFor,
+          databaseName: customDatabaseName,
+        },
+        getConnectedClient,
+      });
+
+      // When
+      const collection = await storage.collectionFor(testStreamTypeName);
+      const otherCollection = await storage.collectionFor(otherStreamTypeName);
+
+      // Then
+      assertNotEqual(collection.collectionName, otherCollection.collectionName);
+      assertEqual(
+        collection.collectionName,
+        `${testStreamTypeName}:${customSuffix}`,
+      );
+      assertEqual(
+        otherCollection.collectionName,
+        `${otherStreamTypeName}:${customSuffix}`,
+      );
+      assertEqual(collection.dbName, customDatabaseName);
+      assertEqual(collection.dbName, customDatabaseName);
+    });
+
+    void it('handles CUSTOM with collectionFor returning object with collection name and using custom db from options', async () => {
+      // Given
+      const customDefaultDatabaseName = uuid();
+      const collectionForWithDb = (
+        streamType: string,
+      ): MongoDBEventStoreCollectionResolution => ({
+        collectionName: collectionFor(streamType),
+      });
+
+      const storage = mongoDBEventStoreStorage({
+        storage: {
+          type: 'CUSTOM',
+          collectionFor: collectionForWithDb,
+          databaseName: customDefaultDatabaseName,
+        },
+        getConnectedClient,
+      });
+
+      // When
+      const collection = await storage.collectionFor(testStreamTypeName);
+      const otherCollection = await storage.collectionFor(otherStreamTypeName);
+
+      // Then
+      assertNotEqual(collection.collectionName, otherCollection.collectionName);
+      assertEqual(
+        collection.collectionName,
+        `${testStreamTypeName}:${customSuffix}`,
+      );
+      assertEqual(
+        otherCollection.collectionName,
+        `${otherStreamTypeName}:${customSuffix}`,
+      );
+      assertEqual(collection.dbName, customDefaultDatabaseName);
+      assertEqual(collection.dbName, customDefaultDatabaseName);
+    });
+
+    void it('handles CUSTOM with collectionFor returning string and custom db', async () => {
+      // Given
+      const customDatabaseName = uuid();
+      const customDefaultDatabaseName = uuid();
+      const collectionForWithDb = (
+        streamType: string,
+      ): MongoDBEventStoreCollectionResolution => ({
+        collectionName: collectionFor(streamType),
+        databaseName: customDatabaseName,
+      });
+
+      const storage = mongoDBEventStoreStorage({
+        storage: {
+          type: 'CUSTOM',
+          collectionFor: collectionForWithDb,
+          databaseName: customDefaultDatabaseName,
+        },
+        getConnectedClient,
+      });
+
+      // When
+      const collection = await storage.collectionFor(testStreamTypeName);
+      const otherCollection = await storage.collectionFor(otherStreamTypeName);
+
+      // Then
+      assertNotEqual(collection.collectionName, otherCollection.collectionName);
+      assertEqual(
+        collection.collectionName,
+        `${testStreamTypeName}:${customSuffix}`,
+      );
+      assertEqual(
+        otherCollection.collectionName,
+        `${otherStreamTypeName}:${customSuffix}`,
+      );
+      assertEqual(collection.dbName, customDatabaseName);
+      assertEqual(collection.dbName, customDatabaseName);
+    });
+  });
+});

--- a/src/packages/emmett-mongodb/src/testing/index.ts
+++ b/src/packages/emmett-mongodb/src/testing/index.ts
@@ -1,2 +1,2 @@
-export * from './mongoMocks';
+export * from './mongoDummies';
 export * from './shoppingCart.domain';

--- a/src/packages/emmett-mongodb/src/testing/index.ts
+++ b/src/packages/emmett-mongodb/src/testing/index.ts
@@ -1,0 +1,2 @@
+export * from './mongoMocks';
+export * from './shoppingCart.domain';

--- a/src/packages/emmett-mongodb/src/testing/mongoDummies.ts
+++ b/src/packages/emmett-mongodb/src/testing/mongoDummies.ts
@@ -7,6 +7,13 @@ import type {
   MongoClient,
 } from 'mongodb';
 
+/**
+ * Creates a dummy MongoDB collection. It should not be used as in-memory version,
+ * but just a dummy replacement for the basic structure and calls test.
+ * @param name collection name
+ * @param options collection setup options
+ * @returns Dummmy collection that has name, dbName and createIndex method
+ */
 export const getDummyCollection = <TSchema extends Document = Document>(
   name: string,
   options?: CollectionOptions & { dbName?: string },
@@ -20,6 +27,13 @@ export const getDummyCollection = <TSchema extends Document = Document>(
   return dummyCollection;
 };
 
+/**
+ * Creates a dummy MongoDB database. It should not be used as in-memory version,
+ * but just a dummy replacement for the basic structure and calls test.
+ * @param dbName database name
+ * @param options database setup options
+ * @returns Dummmy database that has name and can setup dummy collection
+ */
 export const getDummyDb = (dbName?: string, options?: DbOptions): Db => {
   const dummyDB: Db = {
     databaseName: dbName!,
@@ -30,6 +44,12 @@ export const getDummyDb = (dbName?: string, options?: DbOptions): Db => {
   return dummyDB;
 };
 
+/**
+ * Creates a dummy MongoDB connection. It should not be used as in-memory version,
+ * but just a dummy replacement for the basic structure and calls test.
+ * @param options setup options allowing to pass the default database name
+ * @returns Dummmy connection that can setup a dummy database
+ */
 export const getDummyClient = (options?: {
   defaultDBName?: string;
 }): MongoClient => {

--- a/src/packages/emmett-mongodb/src/testing/mongoMocks.ts
+++ b/src/packages/emmett-mongodb/src/testing/mongoMocks.ts
@@ -1,0 +1,42 @@
+import type {
+  Collection,
+  CollectionOptions,
+  Db,
+  DbOptions,
+  Document,
+  MongoClient,
+} from 'mongodb';
+
+export const getDummyCollection = <TSchema extends Document = Document>(
+  name: string,
+  options?: CollectionOptions & { dbName?: string },
+): Collection<TSchema> => {
+  const dummyCollection: Collection<TSchema> = {
+    collectionName: name,
+    dbName: options?.dbName,
+    createIndex: (_indexSpec, _options) => {},
+    options,
+  } as Collection<TSchema>;
+  return dummyCollection;
+};
+
+export const getDummyDb = (dbName?: string, options?: DbOptions): Db => {
+  const dummyDB: Db = {
+    databaseName: dbName!,
+    options,
+    collection: (name, options) =>
+      getDummyCollection(name, { dbName, ...options }),
+  } as Db;
+  return dummyDB;
+};
+
+export const getDummyClient = (options?: {
+  defaultDBName?: string;
+}): MongoClient => {
+  const dummyClient: MongoClient = {
+    db: (name, dbOptions) =>
+      getDummyDb(name ?? options?.defaultDBName, dbOptions),
+  } as MongoClient;
+
+  return dummyClient;
+};


### PR DESCRIPTION
Exposed strongly typed storage options for MongoDB Event Store. Now they can be explicitly selected and mutually exclusive:
- `COLLECTION_PER_STREAM_TYPE` - default option, where each stream type has a dedicated storage. As we're keeping _inline_ projections in the same document as the stream, then that gives a better option for custom indexing and better storage usage.
- `SINGLE_COLLECTION` can be either custom or default to `emt:streams`. This can be a fair choice if you don't have a large number of streams or you don't need customisation per stream type.
- `CUSTOM` - you can define your own collection resolution based on the stream type. It might be that you need to route databases per tenant or handle some other more advanced stuff, so this is the choice for you.

Added the possibility of providing custom collection and database resolution.

Moved storage-related code to a dedicated file, as it got a bit too crowded in the MongoDBEventStore implementation.

Fixes #142