### PR TITLE
Added onAfterCommit hook for in-process notifications after events were appended

### DIFF
--- a/src/packages/emmett/src/eventStore/afterCommit/afterEventStoreCommitHandler.ts
+++ b/src/packages/emmett/src/eventStore/afterCommit/afterEventStoreCommitHandler.ts
@@ -1,9 +1,5 @@
 import { type Event, type ReadEvent } from '../../typing';
-import type {
-  DefaultEventStoreOptions,
-  EventStore,
-  EventStoreReadEventMetadata,
-} from '../eventStore';
+import type { EventStore, EventStoreReadEventMetadata } from '../eventStore';
 
 type AfterEventStoreCommitHandlerWithoutContext<Store extends EventStore> = (
   messages: ReadEvent<Event, EventStoreReadEventMetadata<Store>>[],
@@ -30,8 +26,8 @@ type TryPublishMessagesAfterCommitOptions<
 
 export async function tryPublishMessagesAfterCommit<Store extends EventStore>(
   messages: ReadEvent<Event, EventStoreReadEventMetadata<Store>>[],
-  options: DefaultEventStoreOptions<Store, undefined> | undefined,
-): Promise<void>;
+  options: TryPublishMessagesAfterCommitOptions<Store, undefined> | undefined,
+): Promise<boolean>;
 export async function tryPublishMessagesAfterCommit<
   Store extends EventStore,
   HandlerContext,
@@ -41,7 +37,7 @@ export async function tryPublishMessagesAfterCommit<
     | TryPublishMessagesAfterCommitOptions<Store, HandlerContext>
     | undefined,
   context: HandlerContext,
-): Promise<void>;
+): Promise<boolean>;
 export async function tryPublishMessagesAfterCommit<
   Store extends EventStore,
   HandlerContext = never,
@@ -51,13 +47,15 @@ export async function tryPublishMessagesAfterCommit<
     | TryPublishMessagesAfterCommitOptions<Store, HandlerContext>
     | undefined,
   context?: HandlerContext,
-): Promise<void> {
-  if (options?.onAfterCommit === undefined) return;
+): Promise<boolean> {
+  if (options?.onAfterCommit === undefined) return false;
 
   try {
     await options?.onAfterCommit(messages, context!);
+    return true;
   } catch (error) {
     // TODO: enhance with tracing
     console.error(`Error in on after commit hook`, error);
+    return false;
   }
 }

--- a/src/packages/emmett/src/eventStore/afterCommit/afterEventStoreCommitHandler.ts
+++ b/src/packages/emmett/src/eventStore/afterCommit/afterEventStoreCommitHandler.ts
@@ -8,14 +8,12 @@ type AfterEventStoreCommitHandlerWithoutContext<Store extends EventStore> = (
 export type AfterEventStoreCommitHandler<
   Store extends EventStore,
   HandlerContext = never,
-> = [HandlerContext] extends [never] // Exact check for never
+> = [HandlerContext] extends [never]
   ? AfterEventStoreCommitHandlerWithoutContext<Store>
-  :
-      | ((
-          messages: ReadEvent<Event, EventStoreReadEventMetadata<Store>>[],
-          context: HandlerContext,
-        ) => Promise<void> | void)
-      | AfterEventStoreCommitHandlerWithoutContext<Store>;
+  : (
+      messages: ReadEvent<Event, EventStoreReadEventMetadata<Store>>[],
+      context: HandlerContext,
+    ) => Promise<void> | void;
 
 type TryPublishMessagesAfterCommitOptions<
   Store extends EventStore,

--- a/src/packages/emmett/src/eventStore/afterCommit/afterEventStoreCommitHandler.ts
+++ b/src/packages/emmett/src/eventStore/afterCommit/afterEventStoreCommitHandler.ts
@@ -1,0 +1,63 @@
+import { type Event, type ReadEvent } from '../../typing';
+import type {
+  DefaultEventStoreOptions,
+  EventStore,
+  EventStoreReadEventMetadata,
+} from '../eventStore';
+
+type AfterEventStoreCommitHandlerWithoutContext<Store extends EventStore> = (
+  messages: ReadEvent<Event, EventStoreReadEventMetadata<Store>>[],
+) => Promise<void> | void;
+
+export type AfterEventStoreCommitHandler<
+  Store extends EventStore,
+  HandlerContext = never,
+> = [HandlerContext] extends [never] // Exact check for never
+  ? AfterEventStoreCommitHandlerWithoutContext<Store>
+  :
+      | ((
+          messages: ReadEvent<Event, EventStoreReadEventMetadata<Store>>[],
+          context: HandlerContext,
+        ) => Promise<void> | void)
+      | AfterEventStoreCommitHandlerWithoutContext<Store>;
+
+type TryPublishMessagesAfterCommitOptions<
+  Store extends EventStore,
+  HandlerContext = never,
+> = {
+  onAfterCommit?: AfterEventStoreCommitHandler<Store, HandlerContext>;
+};
+
+export async function tryPublishMessagesAfterCommit<Store extends EventStore>(
+  messages: ReadEvent<Event, EventStoreReadEventMetadata<Store>>[],
+  options: DefaultEventStoreOptions<Store, undefined> | undefined,
+): Promise<void>;
+export async function tryPublishMessagesAfterCommit<
+  Store extends EventStore,
+  HandlerContext,
+>(
+  messages: ReadEvent<Event, EventStoreReadEventMetadata<Store>>[],
+  options:
+    | TryPublishMessagesAfterCommitOptions<Store, HandlerContext>
+    | undefined,
+  context: HandlerContext,
+): Promise<void>;
+export async function tryPublishMessagesAfterCommit<
+  Store extends EventStore,
+  HandlerContext = never,
+>(
+  messages: ReadEvent<Event, EventStoreReadEventMetadata<Store>>[],
+  options:
+    | TryPublishMessagesAfterCommitOptions<Store, HandlerContext>
+    | undefined,
+  context?: HandlerContext,
+): Promise<void> {
+  if (options?.onAfterCommit === undefined) return;
+
+  try {
+    await options?.onAfterCommit(messages, context!);
+  } catch (error) {
+    // TODO: enhance with tracing
+    console.error(`Error in on after commit hook`, error);
+  }
+}

--- a/src/packages/emmett/src/eventStore/afterCommit/afterEventStoreCommitHandler.unit.spec.ts
+++ b/src/packages/emmett/src/eventStore/afterCommit/afterEventStoreCommitHandler.unit.spec.ts
@@ -1,0 +1,187 @@
+import { describe, it } from 'node:test';
+import { v7 as uuid } from 'uuid';
+import { assertDeepEqual, assertEqual } from '../../testing';
+import type {
+  Event,
+  ReadEvent,
+  ReadEventMetadataWithGlobalPosition,
+} from '../../typing';
+import type { EventStore } from '../eventStore';
+import { type InMemoryReadEvent } from '../inMemoryEventStore';
+import { tryPublishMessagesAfterCommit } from './afterEventStoreCommitHandler';
+
+type TestEvent = Event<'test', { counter: number }, { some: boolean }>;
+
+type TestEventStore = EventStore<ReadEventMetadataWithGlobalPosition>;
+
+void describe('InMemoryEventStore onAfterCommit', () => {
+  void it('calls onAfterCommit hook after events append', async () => {
+    // Given
+    const appendedEvents: ReadEvent<
+      Event,
+      ReadEventMetadataWithGlobalPosition
+    >[] = [];
+
+    const streamName = `test:${uuid()}`;
+    let counter = 0;
+    const events: ReadEvent<Event, ReadEventMetadataWithGlobalPosition>[] = [
+      {
+        type: 'test',
+        data: { counter: ++counter },
+        metadata: {
+          some: true,
+          eventId: uuid(),
+          globalPosition: 1n,
+          streamName,
+          streamPosition: 1n,
+        },
+      },
+      {
+        type: 'test',
+        data: { counter: ++counter },
+        metadata: {
+          some: false,
+          eventId: uuid(),
+          globalPosition: 1n,
+          streamName,
+          streamPosition: 1n,
+        },
+      },
+    ];
+
+    // When
+    await tryPublishMessagesAfterCommit<TestEventStore>(events, {
+      onAfterCommit: (
+        events: ReadEvent<Event, ReadEventMetadataWithGlobalPosition>[],
+      ) => {
+        appendedEvents.push(...events);
+      },
+    });
+
+    // Then
+    assertEqual(2, appendedEvents.length);
+    assertDeepEqual(appendedEvents, events);
+  });
+
+  void it('calls onAfterCommit hook exactly once for each events append', async () => {
+    // Given
+    const appendedEvents: InMemoryReadEvent[] = [];
+
+    const streamName = `test:${uuid()}`;
+    let counter = 0;
+    const events: ReadEvent<Event, ReadEventMetadataWithGlobalPosition>[] = [
+      {
+        type: 'test',
+        data: { counter: ++counter },
+        metadata: {
+          some: true,
+          eventId: uuid(),
+          globalPosition: 1n,
+          streamName,
+          streamPosition: 1n,
+        },
+      },
+      {
+        type: 'test',
+        data: { counter: ++counter },
+        metadata: {
+          some: false,
+          eventId: uuid(),
+          globalPosition: 1n,
+          streamName,
+          streamPosition: 1n,
+        },
+      },
+    ];
+    const nextEvents: ReadEvent<Event, ReadEventMetadataWithGlobalPosition>[] =
+      [
+        {
+          type: 'test',
+          data: { counter: ++counter },
+          metadata: {
+            some: true,
+            eventId: uuid(),
+            globalPosition: 1n,
+            streamName,
+            streamPosition: 1n,
+          },
+        },
+        {
+          type: 'test',
+          data: { counter: ++counter },
+          metadata: {
+            some: false,
+            eventId: uuid(),
+            globalPosition: 1n,
+            streamName,
+            streamPosition: 1n,
+          },
+        },
+      ];
+
+    // When
+    await tryPublishMessagesAfterCommit<TestEventStore>(events, {
+      onAfterCommit: (
+        events: ReadEvent<Event, ReadEventMetadataWithGlobalPosition>[],
+      ) => {
+        appendedEvents.push(...events);
+      },
+    });
+    await tryPublishMessagesAfterCommit<TestEventStore>(nextEvents, {
+      onAfterCommit: (
+        events: ReadEvent<Event, ReadEventMetadataWithGlobalPosition>[],
+      ) => {
+        appendedEvents.push(...events);
+      },
+    });
+
+    // Then
+    assertEqual(4, appendedEvents.length);
+    assertDeepEqual(appendedEvents, [...events, ...nextEvents]);
+  });
+
+  void it('silently fails when onAfterCommit hook failed but still keeps events', async () => {
+    // Given
+    const appendedEvents: InMemoryReadEvent[] = [];
+
+    const streamName = `test:${uuid()}`;
+    let counter = 0;
+    const events: ReadEvent<Event, ReadEventMetadataWithGlobalPosition>[] = [
+      {
+        type: 'test',
+        data: { counter: ++counter },
+        metadata: {
+          some: true,
+          eventId: uuid(),
+          globalPosition: 1n,
+          streamName,
+          streamPosition: 1n,
+        },
+      },
+      {
+        type: 'test',
+        data: { counter: ++counter },
+        metadata: {
+          some: false,
+          eventId: uuid(),
+          globalPosition: 1n,
+          streamName,
+          streamPosition: 1n,
+        },
+      },
+    ];
+
+    // When
+    await tryPublishMessagesAfterCommit<TestEventStore>(events, {
+      onAfterCommit: (
+        events: ReadEvent<Event, ReadEventMetadataWithGlobalPosition>[],
+      ) => {
+        appendedEvents.push(...events);
+      },
+    });
+
+    // Then
+    assertEqual(2, appendedEvents.length);
+    assertDeepEqual(appendedEvents, events);
+  });
+});

--- a/src/packages/emmett/src/eventStore/afterCommit/forwardToMessageBus.ts
+++ b/src/packages/emmett/src/eventStore/afterCommit/forwardToMessageBus.ts
@@ -1,0 +1,16 @@
+import type { EventsPublisher } from '../../messageBus';
+import type { Event, ReadEvent } from '../../typing';
+import type { EventStore, EventStoreReadEventMetadata } from '../eventStore';
+import type { AfterEventStoreCommitHandler } from './afterEventStoreCommitHandler';
+
+export const forwardToMessageBus =
+  <Store extends EventStore, HandlerContext = never>(
+    eventPublisher: EventsPublisher,
+  ): AfterEventStoreCommitHandler<Store, HandlerContext> =>
+  async (
+    messages: ReadEvent<Event, EventStoreReadEventMetadata<Store>>[],
+  ): Promise<void> => {
+    for (const message of messages) {
+      await eventPublisher.publish(message);
+    }
+  };

--- a/src/packages/emmett/src/eventStore/afterCommit/index.ts
+++ b/src/packages/emmett/src/eventStore/afterCommit/index.ts
@@ -1,0 +1,1 @@
+export * from './afterEventStoreCommitHandler';

--- a/src/packages/emmett/src/eventStore/afterCommit/index.ts
+++ b/src/packages/emmett/src/eventStore/afterCommit/index.ts
@@ -1,1 +1,2 @@
 export * from './afterEventStoreCommitHandler';
+export * from './forwardToMessageBus';

--- a/src/packages/emmett/src/eventStore/eventStore.ts
+++ b/src/packages/emmett/src/eventStore/eventStore.ts
@@ -239,5 +239,7 @@ export type DefaultEventStoreOptions<
   Store extends EventStore,
   HandlerContext = never,
 > = {
-  onAfterCommit?: AfterEventStoreCommitHandler<Store, HandlerContext>;
+  hooks?: {
+    onAfterCommit?: AfterEventStoreCommitHandler<Store, HandlerContext>;
+  };
 };

--- a/src/packages/emmett/src/eventStore/eventStore.ts
+++ b/src/packages/emmett/src/eventStore/eventStore.ts
@@ -239,7 +239,25 @@ export type DefaultEventStoreOptions<
   Store extends EventStore,
   HandlerContext = never,
 > = {
+  /**
+   * Pluggable set of hooks informing about the event store internal behaviour.
+   */
   hooks?: {
+    /**
+     * This hook will be called **AFTER** events were stored in the event store.
+     * It's designed to handle scenarios where delivery and ordering guarantees do not matter much.
+     *
+     * **WARNINGS:**
+     *
+     *  1. It will be called **EXACTLY ONCE** if append succeded.
+     *  2. If the hook fails, its append **will still silently succeed**, and no error will be thrown.
+     *  3. Wen process crashes after events were committed, but before the hook was called, delivery won't be retried.
+     * That can lead to state inconsistencies.
+     *  4. In the case of high concurrent traffic, **race conditions may cause ordering issues**.
+     * For instance, where the second hook takes longer to process than the first one, ordering won't be guaranteed.
+     *
+     * @type {AfterEventStoreCommitHandler<Store, HandlerContext>}
+     */
     onAfterCommit?: AfterEventStoreCommitHandler<Store, HandlerContext>;
   };
 };

--- a/src/packages/emmett/src/eventStore/eventStore.ts
+++ b/src/packages/emmett/src/eventStore/eventStore.ts
@@ -229,3 +229,36 @@ export type AppendStreamResultOfEventStore<Store extends EventStore> =
   Store['appendToStream'] extends (...args: any[]) => Promise<infer R>
     ? R
     : never;
+
+////////////////////////////////////////////////////////////////////
+/// DefaultEventStoreOptions
+////////////////////////////////////////////////////////////////////
+
+export type DefaultEventStoreOptions<
+  Store extends EventStore,
+  HandlerContext = never,
+> = {
+  onAfterCommit?: AfterEventStoreCommitHandler<Store, HandlerContext>;
+};
+
+export type AfterEventStoreCommitHandler<
+  Store extends EventStore,
+  HandlerContext = never,
+> = HandlerContext extends never
+  ? <
+      EventType extends Event = Event,
+      EventMetaDataType extends EventMetaDataOf<EventType> &
+        EventStoreReadEventMetadata<Store> = EventMetaDataOf<EventType> &
+        EventStoreReadEventMetadata<Store>,
+    >(
+      messages: ReadEvent<EventType, EventMetaDataType>[],
+    ) => Promise<void>
+  : <
+      EventType extends Event = Event,
+      EventMetaDataType extends EventMetaDataOf<EventType> &
+        EventStoreReadEventMetadata<Store> = EventMetaDataOf<EventType> &
+        EventStoreReadEventMetadata<Store>,
+    >(
+      messages: ReadEvent<EventType, EventMetaDataType>[],
+      context?: HandlerContext,
+    ) => Promise<void>;

--- a/src/packages/emmett/src/eventStore/inMemoryEventStore.afterCommit.unit.spec.ts
+++ b/src/packages/emmett/src/eventStore/inMemoryEventStore.afterCommit.unit.spec.ts
@@ -14,8 +14,10 @@ void describe('InMemoryEventStore onAfterCommit', () => {
     // Given
     const appendedEvents: InMemoryReadEvent[] = [];
     const eventStore = getInMemoryEventStore({
-      onAfterCommit: (events) => {
-        appendedEvents.push(...events);
+      hooks: {
+        onAfterCommit: (events) => {
+          appendedEvents.push(...events);
+        },
       },
     });
     const streamName = `test:${uuid()}`;
@@ -44,8 +46,10 @@ void describe('InMemoryEventStore onAfterCommit', () => {
     // Given
     const appendedEvents: InMemoryReadEvent[] = [];
     const eventStore = getInMemoryEventStore({
-      onAfterCommit: (events) => {
-        appendedEvents.push(...events);
+      hooks: {
+        onAfterCommit: (events) => {
+          appendedEvents.push(...events);
+        },
       },
     });
     const streamName = `test:${uuid()}`;
@@ -87,9 +91,11 @@ void describe('InMemoryEventStore onAfterCommit', () => {
     // Given
     const appendedEvents: InMemoryReadEvent[] = [];
     const eventStore = getInMemoryEventStore({
-      onAfterCommit: (events) => {
-        appendedEvents.push(...events);
-        throw new Error('onAfterCommit failed!');
+      hooks: {
+        onAfterCommit: (events) => {
+          appendedEvents.push(...events);
+          throw new Error('onAfterCommit failed!');
+        },
       },
     });
 

--- a/src/packages/emmett/src/eventStore/inMemoryEventStore.afterCommit.unit.spec.ts
+++ b/src/packages/emmett/src/eventStore/inMemoryEventStore.afterCommit.unit.spec.ts
@@ -1,0 +1,118 @@
+import { describe, it } from 'node:test';
+import { v7 as uuid } from 'uuid';
+import { assertEqual } from '../testing';
+import type { Event } from '../typing';
+import {
+  getInMemoryEventStore,
+  type InMemoryReadEvent,
+} from './inMemoryEventStore';
+
+type TestEvent = Event<'test', { counter: number }, { some: boolean }>;
+
+void describe('InMemoryEventStore onAfterCommit', () => {
+  void it('calls onAfterCommit hook after events append', async () => {
+    // Given
+    const appendedEvents: InMemoryReadEvent[] = [];
+    const eventStore = getInMemoryEventStore({
+      onAfterCommit: (events) => {
+        appendedEvents.push(...events);
+      },
+    });
+    const streamName = `test:${uuid()}`;
+    let counter = 0;
+    const events: TestEvent[] = [
+      {
+        type: 'test',
+        data: { counter: ++counter },
+        metadata: { some: true },
+      },
+      {
+        type: 'test',
+        data: { counter: ++counter },
+        metadata: { some: false },
+      },
+    ];
+
+    // When
+    await eventStore.appendToStream(streamName, events);
+
+    // Then
+    assertEqual(2, appendedEvents.length);
+  });
+
+  void it('calls onAfterCommit hook exactly once for each events append', async () => {
+    // Given
+    const appendedEvents: InMemoryReadEvent[] = [];
+    const eventStore = getInMemoryEventStore({
+      onAfterCommit: (events) => {
+        appendedEvents.push(...events);
+      },
+    });
+    const streamName = `test:${uuid()}`;
+    let counter = 0;
+    const events: TestEvent[] = [
+      {
+        type: 'test',
+        data: { counter: ++counter },
+        metadata: { some: true },
+      },
+      {
+        type: 'test',
+        data: { counter: ++counter },
+        metadata: { some: false },
+      },
+    ];
+    const nextEvents: TestEvent[] = [
+      {
+        type: 'test',
+        data: { counter: ++counter },
+        metadata: { some: true },
+      },
+      {
+        type: 'test',
+        data: { counter: ++counter },
+        metadata: { some: false },
+      },
+    ];
+
+    // When
+    await eventStore.appendToStream(streamName, events);
+    await eventStore.appendToStream(streamName, nextEvents);
+
+    // Then
+    assertEqual(4, appendedEvents.length);
+  });
+
+  void it('silently fails when onAfterCommit hook failed but still keeps events', async () => {
+    // Given
+    const appendedEvents: InMemoryReadEvent[] = [];
+    const eventStore = getInMemoryEventStore({
+      onAfterCommit: (events) => {
+        appendedEvents.push(...events);
+        throw new Error('onAfterCommit failed!');
+      },
+    });
+    const streamName = `test:${uuid()}`;
+    let counter = 0;
+    const events: TestEvent[] = [
+      {
+        type: 'test',
+        data: { counter: ++counter },
+        metadata: { some: true },
+      },
+      {
+        type: 'test',
+        data: { counter: ++counter },
+        metadata: { some: false },
+      },
+    ];
+
+    // When
+    await eventStore.appendToStream(streamName, events);
+
+    // Then
+    assertEqual(2, appendedEvents.length);
+    const { events: eventsInStore } = await eventStore.readStream(streamName);
+    assertEqual(2, eventsInStore.length);
+  });
+});

--- a/src/packages/emmett/src/eventStore/inMemoryEventStore.afterCommit.unit.spec.ts
+++ b/src/packages/emmett/src/eventStore/inMemoryEventStore.afterCommit.unit.spec.ts
@@ -92,6 +92,7 @@ void describe('InMemoryEventStore onAfterCommit', () => {
         throw new Error('onAfterCommit failed!');
       },
     });
+
     const streamName = `test:${uuid()}`;
     let counter = 0;
     const events: TestEvent[] = [

--- a/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
+++ b/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
@@ -5,6 +5,7 @@ import type {
   ReadEvent,
   ReadEventMetadataWithGlobalPosition,
 } from '../typing';
+import { tryPublishMessagesAfterCommit } from './afterCommit';
 import {
   type AggregateStreamOptions,
   type AggregateStreamResult,
@@ -17,7 +18,6 @@ import {
 } from './eventStore';
 import { assertExpectedVersionMatchesCurrent } from './expectedVersion';
 import { StreamingCoordinator } from './subscriptions';
-import { tryPublishMessagesAfterCommit } from './afterCommit';
 
 export const InMemoryEventStoreDefaultStreamVersion = 0n;
 
@@ -166,7 +166,7 @@ export const getInMemoryEventStore = (
           currentStreamVersion === InMemoryEventStoreDefaultStreamVersion,
       };
 
-      await tryPublishMessagesAfterCommit(newEvents, eventStoreOptions);
+      await tryPublishMessagesAfterCommit(newEvents, eventStoreOptions?.hooks);
 
       return result;
     },

--- a/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
+++ b/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
@@ -6,7 +6,6 @@ import type {
   ReadEventMetadataWithGlobalPosition,
 } from '../typing';
 import {
-  tryPublishMessagesAfterCommit,
   type AggregateStreamOptions,
   type AggregateStreamResult,
   type AppendToStreamOptions,
@@ -18,6 +17,7 @@ import {
 } from './eventStore';
 import { assertExpectedVersionMatchesCurrent } from './expectedVersion';
 import { StreamingCoordinator } from './subscriptions';
+import { tryPublishMessagesAfterCommit } from './afterCommit';
 
 export const InMemoryEventStoreDefaultStreamVersion = 0n;
 

--- a/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
+++ b/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
@@ -10,6 +10,7 @@ import {
   type AggregateStreamResult,
   type AppendToStreamOptions,
   type AppendToStreamResult,
+  type DefaultEventStoreOptions,
   type EventStore,
   type ReadStreamOptions,
   type ReadStreamResult,
@@ -26,7 +27,12 @@ export const InMemoryEventStoreDefaultStreamVersion = 0n;
 export type InMemoryEventStore =
   EventStore<ReadEventMetadataWithGlobalPosition>;
 
-export const getInMemoryEventStore = (): InMemoryEventStore => {
+export type InMemoryEventStoreOptions =
+  DefaultEventStoreOptions<InMemoryEventStore>;
+
+export const getInMemoryEventStore = (
+  _options?: InMemoryEventStoreOptions,
+): InMemoryEventStore => {
   const streams = new Map<
     string,
     ReadEvent<Event, ReadEventMetadataWithGlobalPosition>[]

--- a/src/packages/emmett/src/eventStore/index.ts
+++ b/src/packages/emmett/src/eventStore/index.ts
@@ -1,5 +1,6 @@
-export * from './eventStore';
+export * from './afterCommit';
 export * from './events';
+export * from './eventStore';
 export * from './expectedVersion';
 export * from './inMemoryEventStore';
 export * from './subscriptions';


### PR DESCRIPTION
Added `DefaultEventStoreOptions` with `onAfterCommit` hook for in-process notifications after events were appended. All stores will eventually have to apply them.

 The `onAfterCommit` hook will be called **AFTER** events were stored in the event store.
It's designed to handle scenarios where delivery and ordering guarantees do not matter much.

## WARNINGS

1. It will be called **EXACTLY ONCE** if append succeded.
2. If the hook fails, its append **will still silently succeed**, and no error will be thrown.
3. Wen process crashes after events were committed, but before the hook was called, delivery won't be retried. That can lead to state inconsistencies.
4. In the case of high concurrent traffic, race conditions may cause ordering issues. For instance, where the second hook takes longer to process than the first one, ordering won't be guaranteed.

This PR adds implementation to InMemoryEventStore, and provides basic capabilities like `tryPublishMessagesAfterCommit` helper and `forwardToMessageBus` method to make easier integration with in-process message bus.

## Example Usage

You can now use:

```ts
const eventStore = getInMemoryEventStore({
  hooks: {
    onAfterCommit: (events) => {
      // bring your own handling
      console.log(JSON.stringify(events));
    },
  },
});
```

Or integrate with [InMemoryMessageBus](https://event-driven.io/en/inmemory_message_bus_in_typescript/).

```ts
const messageBus = getInMemoryMessageBus();
messageBus.subscribe((event: TestEvent) => {
  // bring your own handling
  console.log(JSON.stringify(event));
}, 'test');

const eventStore = getInMemoryEventStore({
  hooks: {
    onAfterCommit: forwardToMessageBus(messageBus),
  },
});
```

