### PR TITLE
Updated API tests to use strongly-typed Event Store type

### DIFF
--- a/src/docs/snippets/gettingStarted/webApi/apiBDD.e2e.spec.ts
+++ b/src/docs/snippets/gettingStarted/webApi/apiBDD.e2e.spec.ts
@@ -4,7 +4,6 @@ import { ShoppingCartStatus } from './shoppingCart';
 import { shoppingCartApi } from './simpleApi';
 
 // #region getting-started-e2e-tests
-import { type EventStore } from '@event-driven-io/emmett';
 import { getEventStoreDBEventStore } from '@event-driven-io/emmett-esdb';
 import {
   ApiE2ESpecification,
@@ -29,8 +28,8 @@ void describe('ShoppingCart E2E', () => {
     esdbContainer = await new EventStoreDBContainer().start();
 
     given = ApiE2ESpecification.for(
-      (): EventStore => getEventStoreDBEventStore(esdbContainer.getClient()),
-      (eventStore: EventStore) =>
+      () => getEventStoreDBEventStore(esdbContainer.getClient()),
+      (eventStore) =>
         getApplication({
           apis: [
             shoppingCartApi(

--- a/src/docs/snippets/gettingStarted/webApi/apiBDD.int.spec.ts
+++ b/src/docs/snippets/gettingStarted/webApi/apiBDD.int.spec.ts
@@ -2,10 +2,7 @@ import { beforeEach, describe, it } from 'node:test';
 import type { PricedProductItem, ShoppingCartEvent } from '../events';
 import { shoppingCartApi } from './simpleApi';
 // #region getting-started-integration-tests
-import {
-  getInMemoryEventStore,
-  type EventStore,
-} from '@event-driven-io/emmett';
+import { getInMemoryEventStore } from '@event-driven-io/emmett';
 import {
   ApiSpecification,
   existingStream,
@@ -119,8 +116,8 @@ void describe('ShoppingCart', () => {
   const unitPrice = Math.random() * 10;
 
   const given = ApiSpecification.for<ShoppingCartEvent>(
-    (): EventStore => getInMemoryEventStore(),
-    (eventStore: EventStore) =>
+    () => getInMemoryEventStore(),
+    (eventStore) =>
       getApplication({
         apis: [
           shoppingCartApi(

--- a/src/docs/snippets/gettingStarted/webApi/apiBDDE2EGiven.ts
+++ b/src/docs/snippets/gettingStarted/webApi/apiBDDE2EGiven.ts
@@ -27,7 +27,6 @@ void describe('ShoppingCart E2E', () => {
 // #endregion test-container
 
 // #region given
-import { type EventStore } from '@event-driven-io/emmett';
 import { getEventStoreDBEventStore } from '@event-driven-io/emmett-esdb';
 import {
   ApiE2ESpecification,
@@ -35,8 +34,8 @@ import {
 } from '@event-driven-io/emmett-expressjs';
 
 const given = ApiE2ESpecification.for(
-  (): EventStore => getEventStoreDBEventStore(esdbContainer.getClient()),
-  (eventStore: EventStore) =>
+  () => getEventStoreDBEventStore(esdbContainer.getClient()),
+  (eventStore) =>
     getApplication({
       apis: [
         shoppingCartApi(

--- a/src/docs/snippets/gettingStarted/webApi/apiBDDE2ETest.ts
+++ b/src/docs/snippets/gettingStarted/webApi/apiBDDE2ETest.ts
@@ -1,4 +1,3 @@
-import { type EventStore } from '@event-driven-io/emmett';
 import {
   ApiE2ESpecification,
   getApplication,
@@ -15,8 +14,8 @@ const now = new Date();
 const unitPrice = Math.random() * 10;
 
 const given = ApiE2ESpecification.for(
-  (): EventStore => getEventStoreDBEventStore(esdbContainer.getClient()),
-  (eventStore: EventStore) =>
+  () => getEventStoreDBEventStore(esdbContainer.getClient()),
+  (eventStore) =>
     getApplication({
       apis: [
         shoppingCartApi(

--- a/src/docs/snippets/gettingStarted/webApi/apiBDDIntGiven.ts
+++ b/src/docs/snippets/gettingStarted/webApi/apiBDDIntGiven.ts
@@ -3,10 +3,7 @@ import type { ShoppingCartEvent } from '../events';
 import { shoppingCartApi } from './simpleApi';
 
 // #region given
-import {
-  getInMemoryEventStore,
-  type EventStore,
-} from '@event-driven-io/emmett';
+import { getInMemoryEventStore } from '@event-driven-io/emmett';
 import {
   ApiSpecification,
   getApplication,
@@ -16,8 +13,8 @@ const unitPrice = 100;
 const now = new Date();
 
 const given = ApiSpecification.for<ShoppingCartEvent>(
-  (): EventStore => getInMemoryEventStore(),
-  (eventStore: EventStore) =>
+  () => getInMemoryEventStore(),
+  (eventStore) =>
     getApplication({
       apis: [
         shoppingCartApi(

--- a/src/docs/snippets/gettingStarted/webApi/apiBDDIntTest.ts
+++ b/src/docs/snippets/gettingStarted/webApi/apiBDDIntTest.ts
@@ -1,7 +1,4 @@
-import {
-  getInMemoryEventStore,
-  type EventStore,
-} from '@event-driven-io/emmett';
+import { getInMemoryEventStore } from '@event-driven-io/emmett';
 import {
   ApiSpecification,
   getApplication,
@@ -18,8 +15,8 @@ const now = new Date();
 const unitPrice = Math.random() * 10;
 
 const given = ApiSpecification.for<ShoppingCartEvent>(
-  (): EventStore => getInMemoryEventStore(),
-  (eventStore: EventStore) =>
+  () => getInMemoryEventStore(),
+  (eventStore) =>
     getApplication({
       apis: [
         shoppingCartApi(

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@event-driven-io/core",
-  "version": "0.23.0-alpha.7",
+  "version": "0.23.0-alpha.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@event-driven-io/core",
-      "version": "0.23.0-alpha.7",
+      "version": "0.23.0-alpha.8",
       "workspaces": [
         "packages/emmett-shims",
         "packages/emmett",
@@ -10627,7 +10627,7 @@
     },
     "packages/emmett": {
       "name": "@event-driven-io/emmett",
-      "version": "0.23.0-alpha.7",
+      "version": "0.23.0-alpha.8",
       "bin": {
         "emmett": "dist/cli.js"
       },
@@ -10643,21 +10643,21 @@
     },
     "packages/emmett-esdb": {
       "name": "@event-driven-io/emmett-esdb",
-      "version": "0.23.0-alpha.7",
+      "version": "0.23.0-alpha.8",
       "devDependencies": {
-        "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.7"
+        "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.8"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.23.0-alpha.7",
+        "@event-driven-io/emmett": "0.23.0-alpha.8",
         "@eventstore/db-client": "^6.2.1"
       }
     },
     "packages/emmett-expressjs": {
       "name": "@event-driven-io/emmett-expressjs",
-      "version": "0.23.0-alpha.7",
+      "version": "0.23.0-alpha.8",
       "devDependencies": {},
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.23.0-alpha.7",
+        "@event-driven-io/emmett": "0.23.0-alpha.8",
         "@types/express": "^4.17.21",
         "@types/supertest": "^6.0.2",
         "express": "^4.19.2",
@@ -10668,10 +10668,10 @@
     },
     "packages/emmett-fastify": {
       "name": "@event-driven-io/emmett-fastify",
-      "version": "0.23.0-alpha.7",
+      "version": "0.23.0-alpha.8",
       "devDependencies": {},
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.23.0-alpha.7",
+        "@event-driven-io/emmett": "0.23.0-alpha.8",
         "@fastify/compress": "^7.0.3",
         "@fastify/etag": "^5.2.0",
         "@fastify/formbody": "^7.4.0",
@@ -10681,31 +10681,31 @@
     },
     "packages/emmett-mongodb": {
       "name": "@event-driven-io/emmett-mongodb",
-      "version": "0.23.0-alpha.7",
+      "version": "0.23.0-alpha.8",
       "devDependencies": {
-        "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.7",
+        "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.8",
         "@testcontainers/mongodb": "^10.13.2"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.23.0-alpha.7",
+        "@event-driven-io/emmett": "0.23.0-alpha.8",
         "mongodb": "^6.10.0"
       }
     },
     "packages/emmett-postgresql": {
       "name": "@event-driven-io/emmett-postgresql",
-      "version": "0.23.0-alpha.7",
+      "version": "0.23.0-alpha.8",
       "devDependencies": {
-        "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.7",
+        "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.8",
         "@testcontainers/postgresql": "^10.12.0"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.23.0-alpha.7",
+        "@event-driven-io/emmett": "0.23.0-alpha.8",
         "@event-driven-io/pongo": "0.16.4"
       }
     },
     "packages/emmett-shims": {
       "name": "@event-driven-io/emmett-shims",
-      "version": "0.23.0-alpha.7",
+      "version": "0.23.0-alpha.8",
       "devDependencies": {
         "@types/node": "^20.11.30"
       },
@@ -10723,20 +10723,20 @@
     },
     "packages/emmett-sqlite": {
       "name": "@event-driven-io/emmett-sqlite",
-      "version": "0.23.0-alpha.7",
+      "version": "0.23.0-alpha.8",
       "devDependencies": {
         "@types/sqlite3": "^3.1.11"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett": "^0.23.0-alpha.7",
+        "@event-driven-io/emmett": "0.23.0-alpha.8",
         "sqlite3": "^5.1.7"
       }
     },
     "packages/emmett-testcontainers": {
       "name": "@event-driven-io/emmett-testcontainers",
-      "version": "0.23.0-alpha.7",
+      "version": "0.23.0-alpha.8",
       "dependencies": {
-        "@event-driven-io/emmett": "0.23.0-alpha.7",
+        "@event-driven-io/emmett": "0.23.0-alpha.8",
         "testcontainers": "^10.12.0"
       },
       "devDependencies": {
@@ -10745,12 +10745,12 @@
     },
     "packages/emmett-tests": {
       "name": "@event-driven-io/emmett-tests",
-      "version": "0.23.0-alpha.7",
+      "version": "0.23.0-alpha.8",
       "devDependencies": {
-        "@event-driven-io/emmett": "0.23.0-alpha.7",
-        "@event-driven-io/emmett-esdb": "0.23.0-alpha.7",
-        "@event-driven-io/emmett-postgresql": "0.23.0-alpha.7",
-        "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.7",
+        "@event-driven-io/emmett": "0.23.0-alpha.8",
+        "@event-driven-io/emmett-esdb": "0.23.0-alpha.8",
+        "@event-driven-io/emmett-postgresql": "0.23.0-alpha.8",
+        "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.8",
         "@testcontainers/postgresql": "^10.12.0"
       }
     }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@event-driven-io/core",
-  "version": "0.23.0-alpha.6",
+  "version": "0.23.0-alpha.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@event-driven-io/core",
-      "version": "0.23.0-alpha.6",
+      "version": "0.23.0-alpha.7",
       "workspaces": [
         "packages/emmett-shims",
         "packages/emmett",
@@ -10627,7 +10627,7 @@
     },
     "packages/emmett": {
       "name": "@event-driven-io/emmett",
-      "version": "0.23.0-alpha.6",
+      "version": "0.23.0-alpha.7",
       "bin": {
         "emmett": "dist/cli.js"
       },
@@ -10643,21 +10643,21 @@
     },
     "packages/emmett-esdb": {
       "name": "@event-driven-io/emmett-esdb",
-      "version": "0.23.0-alpha.6",
+      "version": "0.23.0-alpha.7",
       "devDependencies": {
-        "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.6"
+        "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.7"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.23.0-alpha.6",
+        "@event-driven-io/emmett": "0.23.0-alpha.7",
         "@eventstore/db-client": "^6.2.1"
       }
     },
     "packages/emmett-expressjs": {
       "name": "@event-driven-io/emmett-expressjs",
-      "version": "0.23.0-alpha.6",
+      "version": "0.23.0-alpha.7",
       "devDependencies": {},
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.23.0-alpha.6",
+        "@event-driven-io/emmett": "0.23.0-alpha.7",
         "@types/express": "^4.17.21",
         "@types/supertest": "^6.0.2",
         "express": "^4.19.2",
@@ -10668,10 +10668,10 @@
     },
     "packages/emmett-fastify": {
       "name": "@event-driven-io/emmett-fastify",
-      "version": "0.23.0-alpha.6",
+      "version": "0.23.0-alpha.7",
       "devDependencies": {},
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.23.0-alpha.6",
+        "@event-driven-io/emmett": "0.23.0-alpha.7",
         "@fastify/compress": "^7.0.3",
         "@fastify/etag": "^5.2.0",
         "@fastify/formbody": "^7.4.0",
@@ -10681,31 +10681,31 @@
     },
     "packages/emmett-mongodb": {
       "name": "@event-driven-io/emmett-mongodb",
-      "version": "0.23.0-alpha.6",
+      "version": "0.23.0-alpha.7",
       "devDependencies": {
-        "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.6",
+        "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.7",
         "@testcontainers/mongodb": "^10.13.2"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.23.0-alpha.6",
+        "@event-driven-io/emmett": "0.23.0-alpha.7",
         "mongodb": "^6.10.0"
       }
     },
     "packages/emmett-postgresql": {
       "name": "@event-driven-io/emmett-postgresql",
-      "version": "0.23.0-alpha.6",
+      "version": "0.23.0-alpha.7",
       "devDependencies": {
-        "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.6",
+        "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.7",
         "@testcontainers/postgresql": "^10.12.0"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett": "0.23.0-alpha.6",
+        "@event-driven-io/emmett": "0.23.0-alpha.7",
         "@event-driven-io/pongo": "0.16.4"
       }
     },
     "packages/emmett-shims": {
       "name": "@event-driven-io/emmett-shims",
-      "version": "0.23.0-alpha.6",
+      "version": "0.23.0-alpha.7",
       "devDependencies": {
         "@types/node": "^20.11.30"
       },
@@ -10723,20 +10723,20 @@
     },
     "packages/emmett-sqlite": {
       "name": "@event-driven-io/emmett-sqlite",
-      "version": "0.23.0-alpha.6",
+      "version": "0.23.0-alpha.7",
       "devDependencies": {
         "@types/sqlite3": "^3.1.11"
       },
       "peerDependencies": {
-        "@event-driven-io/emmett": "^0.23.0-alpha.6",
+        "@event-driven-io/emmett": "^0.23.0-alpha.7",
         "sqlite3": "^5.1.7"
       }
     },
     "packages/emmett-testcontainers": {
       "name": "@event-driven-io/emmett-testcontainers",
-      "version": "0.23.0-alpha.6",
+      "version": "0.23.0-alpha.7",
       "dependencies": {
-        "@event-driven-io/emmett": "0.23.0-alpha.6",
+        "@event-driven-io/emmett": "0.23.0-alpha.7",
         "testcontainers": "^10.12.0"
       },
       "devDependencies": {
@@ -10745,12 +10745,12 @@
     },
     "packages/emmett-tests": {
       "name": "@event-driven-io/emmett-tests",
-      "version": "0.23.0-alpha.6",
+      "version": "0.23.0-alpha.7",
       "devDependencies": {
-        "@event-driven-io/emmett": "0.23.0-alpha.6",
-        "@event-driven-io/emmett-esdb": "0.23.0-alpha.6",
-        "@event-driven-io/emmett-postgresql": "0.23.0-alpha.6",
-        "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.6",
+        "@event-driven-io/emmett": "0.23.0-alpha.7",
+        "@event-driven-io/emmett-esdb": "0.23.0-alpha.7",
+        "@event-driven-io/emmett-postgresql": "0.23.0-alpha.7",
+        "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.7",
         "@testcontainers/postgresql": "^10.12.0"
       }
     }

--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@event-driven-io/core",
   "type": "module",
-  "version": "0.23.0-alpha.7",
+  "version": "0.23.0-alpha.8",
   "description": "Emmett - Event Sourcing development made simple",
   "engines": {
     "node": ">=20.11.1"

--- a/src/packages/emmett-esdb/package.json
+++ b/src/packages/emmett-esdb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@event-driven-io/emmett-esdb",
   "type": "module",
-  "version": "0.23.0-alpha.7",
+  "version": "0.23.0-alpha.8",
   "description": "Emmett - EventStoreDB - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -48,10 +48,10 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.7"
+    "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.8"
   },
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.23.0-alpha.7",
+    "@event-driven-io/emmett": "0.23.0-alpha.8",
     "@eventstore/db-client": "^6.2.1"
   }
 }

--- a/src/packages/emmett-expressjs/package.json
+++ b/src/packages/emmett-expressjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-expressjs",
-  "version": "0.23.0-alpha.7",
+  "version": "0.23.0-alpha.8",
   "type": "module",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
@@ -49,7 +49,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.23.0-alpha.7",
+    "@event-driven-io/emmett": "0.23.0-alpha.8",
     "@types/express": "^4.17.21",
     "@types/supertest": "^6.0.2",
     "express": "^4.19.2",

--- a/src/packages/emmett-expressjs/src/testing/apiE2ESpecification.ts
+++ b/src/packages/emmett-expressjs/src/testing/apiE2ESpecification.ts
@@ -1,7 +1,6 @@
 import supertest, { type Response } from 'supertest';
 
 import type { EventStore } from '@event-driven-io/emmett';
-import { WrapEventStore } from '@event-driven-io/emmett';
 import assert from 'assert';
 import type { Application } from 'express';
 import type { TestRequest } from './apiSpecification';
@@ -17,13 +16,13 @@ export type ApiE2ESpecification = (...givenRequests: TestRequest[]) => {
 };
 
 export const ApiE2ESpecification = {
-  for: (
-    getEventStore: () => EventStore,
-    getApplication: (eventStore: EventStore) => Application,
+  for: <Store extends EventStore = EventStore>(
+    getEventStore: () => Store,
+    getApplication: (eventStore: Store) => Application,
   ): ApiE2ESpecification => {
     {
       return (...givenRequests: TestRequest[]) => {
-        const eventStore = WrapEventStore(getEventStore());
+        const eventStore = getEventStore();
         const application = getApplication(eventStore);
 
         return {

--- a/src/packages/emmett-expressjs/src/testing/apiSpecification.ts
+++ b/src/packages/emmett-expressjs/src/testing/apiSpecification.ts
@@ -85,9 +85,9 @@ export type ApiSpecification<EventType extends Event = Event> = (
 };
 
 export const ApiSpecification = {
-  for: <EventType extends Event = Event>(
-    getEventStore: () => EventStore,
-    getApplication: (eventStore: EventStore) => Application,
+  for: <EventType extends Event = Event, Store extends EventStore = EventStore>(
+    getEventStore: () => Store,
+    getApplication: (eventStore: Store) => Application,
   ): ApiSpecification<EventType> => {
     {
       return (...givenStreams: TestEventStream<EventType>[]) => {

--- a/src/packages/emmett-fastify/package.json
+++ b/src/packages/emmett-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-fastify",
-  "version": "0.23.0-alpha.7",
+  "version": "0.23.0-alpha.8",
   "type": "module",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
@@ -53,7 +53,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.23.0-alpha.7",
+    "@event-driven-io/emmett": "0.23.0-alpha.8",
     "fastify": "^4.28.1",
     "@fastify/compress": "^7.0.3",
     "@fastify/etag": "^5.2.0",

--- a/src/packages/emmett-mongodb/package.json
+++ b/src/packages/emmett-mongodb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@event-driven-io/emmett-mongodb",
   "type": "module",
-  "version": "0.23.0-alpha.7",
+  "version": "0.23.0-alpha.8",
   "description": "Emmett - MongoDB - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",
@@ -47,11 +47,11 @@
     "dist"
   ],
   "devDependencies": {
-    "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.7",
+    "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.8",
     "@testcontainers/mongodb": "^10.13.2"
   },
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.23.0-alpha.7",
+    "@event-driven-io/emmett": "0.23.0-alpha.8",
     "mongodb": "^6.10.0"
   }
 }

--- a/src/packages/emmett-postgresql/package.json
+++ b/src/packages/emmett-postgresql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-postgresql",
-  "version": "0.23.0-alpha.7",
+  "version": "0.23.0-alpha.8",
   "type": "module",
   "description": "Emmett - PostgreSQL - Event Sourcing development made simple",
   "scripts": {
@@ -70,10 +70,10 @@
   ],
   "devDependencies": {
     "@testcontainers/postgresql": "^10.12.0",
-    "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.7"
+    "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.8"
   },
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.23.0-alpha.7",
+    "@event-driven-io/emmett": "0.23.0-alpha.8",
     "@event-driven-io/pongo": "0.16.4"
   }
 }

--- a/src/packages/emmett-shims/package.json
+++ b/src/packages/emmett-shims/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-shims",
-  "version": "0.23.0-alpha.7",
+  "version": "0.23.0-alpha.8",
   "type": "module",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {

--- a/src/packages/emmett-sqlite/package.json
+++ b/src/packages/emmett-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-sqlite",
-  "version": "0.23.0-alpha.7",
+  "version": "0.23.0-alpha.8",
   "type": "module",
   "private": true,
   "description": "Emmett - SQLite - Event Sourcing development made simple",
@@ -73,7 +73,7 @@
     "@types/sqlite3": "^3.1.11"
   },
   "peerDependencies": {
-    "@event-driven-io/emmett": "0.23.0-alpha.7",
+    "@event-driven-io/emmett": "0.23.0-alpha.8",
     "sqlite3": "^5.1.7"
   }
 }

--- a/src/packages/emmett-sqlite/package.json
+++ b/src/packages/emmett-sqlite/package.json
@@ -73,7 +73,7 @@
     "@types/sqlite3": "^3.1.11"
   },
   "peerDependencies": {
-    "@event-driven-io/emmett": "^0.23.0-alpha.7",
+    "@event-driven-io/emmett": "0.23.0-alpha.7",
     "sqlite3": "^5.1.7"
   }
 }

--- a/src/packages/emmett-testcontainers/package.json
+++ b/src/packages/emmett-testcontainers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/emmett-testcontainers",
-  "version": "0.23.0-alpha.7",
+  "version": "0.23.0-alpha.8",
   "type": "module",
   "description": "Emmett - TestContainers - Event Sourcing development made simple",
   "scripts": {
@@ -47,7 +47,7 @@
     "dist"
   ],
   "dependencies": {
-    "@event-driven-io/emmett": "0.23.0-alpha.7",
+    "@event-driven-io/emmett": "0.23.0-alpha.8",
     "testcontainers": "^10.12.0"
   },
   "devDependencies": {

--- a/src/packages/emmett-tests/package.json
+++ b/src/packages/emmett-tests/package.json
@@ -2,7 +2,7 @@
   "name": "@event-driven-io/emmett-tests",
   "type": "module",
   "private": true,
-  "version": "0.23.0-alpha.7",
+  "version": "0.23.0-alpha.8",
   "description": "Emmett - Internal E2E Tests",
   "scripts": {
     "build": "tsup",
@@ -55,10 +55,10 @@
     "dist"
   ],
   "devDependencies": {
-    "@event-driven-io/emmett": "0.23.0-alpha.7",
-    "@event-driven-io/emmett-esdb": "0.23.0-alpha.7",
-    "@event-driven-io/emmett-postgresql": "0.23.0-alpha.7",
-    "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.7",
+    "@event-driven-io/emmett": "0.23.0-alpha.8",
+    "@event-driven-io/emmett-esdb": "0.23.0-alpha.8",
+    "@event-driven-io/emmett-postgresql": "0.23.0-alpha.8",
+    "@event-driven-io/emmett-testcontainers": "0.23.0-alpha.8",
     "@testcontainers/postgresql": "^10.12.0"
   }
 }

--- a/src/packages/emmett/package.json
+++ b/src/packages/emmett/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@event-driven-io/emmett",
   "type": "module",
-  "version": "0.23.0-alpha.7",
+  "version": "0.23.0-alpha.8",
   "description": "Emmett - Event Sourcing development made simple",
   "scripts": {
     "build": "tsup",

--- a/src/packages/emmett/src/testing/wrapEventStore.ts
+++ b/src/packages/emmett/src/testing/wrapEventStore.ts
@@ -30,6 +30,7 @@ export const WrapEventStore = <Store extends EventStore>(
   const appendedEvents = new Map<string, TestEventStream>();
 
   const wrapped = {
+    ...eventStore,
     aggregateStream<State, EventType extends Event>(
       streamName: string,
       options: AggregateStreamOptions<State, EventType>,


### PR DESCRIPTION
Previously, it was always taking the Event Store implementation, which was forcing to do casting while setting up, which was not great.

Fixed also Event Store wrapper to just override the needed methods passing the rest as they are. Without it, even store extensions (like MongoDB projections API) wouldn't work.

Removed event store wrapper usage from E2E tests, as it was redundant: checks are only made on responses.