### PR TITLE
Refactored Event type metadata to be explicit whether it's defined

### DIFF
--- a/src/packages/emmett-expressjs/src/e2e/decider/applicationLogicWithOC.int.spec.ts
+++ b/src/packages/emmett-expressjs/src/e2e/decider/applicationLogicWithOC.int.spec.ts
@@ -4,7 +4,7 @@ import {
   assertMatches,
   assertOk,
   getInMemoryEventStore,
-  type EventStore,
+  type InMemoryEventStore,
 } from '@event-driven-io/emmett';
 import { type Application } from 'express';
 import { randomUUID } from 'node:crypto';
@@ -24,7 +24,7 @@ import type { ShoppingCartEvent } from './shoppingCart';
 
 void describe('Application logic with optimistic concurrency', () => {
   let app: Application;
-  let eventStore: EventStore;
+  let eventStore: InMemoryEventStore;
 
   beforeEach(() => {
     eventStore = getInMemoryEventStore();

--- a/src/packages/emmett-mongodb/src/eventStore/projections/index.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/projections/index.ts
@@ -1,7 +1,6 @@
 import {
   type CanHandle,
   type Event,
-  type EventMetaDataOf,
   type ProjectionHandler,
   type ReadEvent,
   type TypedProjectionDefinition,
@@ -18,9 +17,7 @@ export const MongoDBDefaultInlineProjectionName = '_default';
 
 export type MongoDBProjectionInlineHandlerContext<
   EventType extends Event = Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    MongoDBReadEventMetadata = EventMetaDataOf<EventType> &
-    MongoDBReadEventMetadata,
+  EventMetaDataType extends MongoDBReadEventMetadata = MongoDBReadEventMetadata,
 > = {
   document: MongoDBReadModel | null;
   streamId: string;
@@ -30,9 +27,7 @@ export type MongoDBProjectionInlineHandlerContext<
 
 export type MongoDBInlineProjectionHandler<
   EventType extends Event = Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    MongoDBReadEventMetadata = EventMetaDataOf<EventType> &
-    MongoDBReadEventMetadata,
+  EventMetaDataType extends MongoDBReadEventMetadata = MongoDBReadEventMetadata,
 > = ProjectionHandler<
   EventType,
   EventMetaDataType,
@@ -41,9 +36,7 @@ export type MongoDBInlineProjectionHandler<
 
 export type MongoDBInlineProjectionDefinition<
   EventType extends Event = Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    MongoDBReadEventMetadata = EventMetaDataOf<EventType> &
-    MongoDBReadEventMetadata,
+  EventMetaDataType extends MongoDBReadEventMetadata = MongoDBReadEventMetadata,
 > = TypedProjectionDefinition<
   EventType,
   EventMetaDataType,
@@ -52,9 +45,7 @@ export type MongoDBInlineProjectionDefinition<
 
 export type InlineProjectionHandlerOptions<
   EventType extends Event = Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    MongoDBReadEventMetadata = EventMetaDataOf<EventType> &
-    MongoDBReadEventMetadata,
+  EventMetaDataType extends MongoDBReadEventMetadata = MongoDBReadEventMetadata,
 > = {
   readModels: Record<string, MongoDBReadModel>;
   events: Array<ReadEvent<EventType, EventMetaDataType>>;
@@ -73,9 +64,7 @@ export type InlineProjectionHandlerOptions<
 
 export const handleInlineProjections = async <
   EventType extends Event = Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    MongoDBReadEventMetadata = EventMetaDataOf<EventType> &
-    MongoDBReadEventMetadata,
+  EventMetaDataType extends MongoDBReadEventMetadata = MongoDBReadEventMetadata,
 >(
   options: InlineProjectionHandlerOptions<EventType, EventMetaDataType>,
 ): Promise<void> => {
@@ -107,9 +96,7 @@ export const handleInlineProjections = async <
 export type MongoDBWithNotNullDocumentEvolve<
   Doc extends Document,
   EventType extends Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    MongoDBReadEventMetadata = EventMetaDataOf<EventType> &
-    MongoDBReadEventMetadata,
+  EventMetaDataType extends MongoDBReadEventMetadata = MongoDBReadEventMetadata,
 > =
   | ((
       document: Doc,
@@ -120,9 +107,7 @@ export type MongoDBWithNotNullDocumentEvolve<
 export type MongoDBWithNullableDocumentEvolve<
   Doc extends Document,
   EventType extends Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    MongoDBReadEventMetadata = EventMetaDataOf<EventType> &
-    MongoDBReadEventMetadata,
+  EventMetaDataType extends MongoDBReadEventMetadata = MongoDBReadEventMetadata,
 > =
   | ((
       document: Doc | null,
@@ -136,9 +121,7 @@ export type MongoDBWithNullableDocumentEvolve<
 export type MongoDBInlineProjectionOptions<
   Doc extends Document,
   EventType extends Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    MongoDBReadEventMetadata = EventMetaDataOf<EventType> &
-    MongoDBReadEventMetadata,
+  EventMetaDataType extends MongoDBReadEventMetadata = MongoDBReadEventMetadata,
 > = {
   name?: string;
   schemaVersion?: number;
@@ -164,9 +147,7 @@ export type MongoDBInlineProjectionOptions<
 export const mongoDBInlineProjection = <
   Doc extends Document,
   EventType extends Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    MongoDBReadEventMetadata = EventMetaDataOf<EventType> &
-    MongoDBReadEventMetadata,
+  EventMetaDataType extends MongoDBReadEventMetadata = MongoDBReadEventMetadata,
 >(
   options: MongoDBInlineProjectionOptions<Doc, EventType, EventMetaDataType>,
 ): MongoDBInlineProjectionDefinition => {

--- a/src/packages/emmett-postgresql/src/eventStore/projections/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/index.ts
@@ -8,7 +8,6 @@ import {
   projection,
   type CanHandle,
   type Event,
-  type EventMetaDataOf,
   type ProjectionHandler,
   type ReadEvent,
   type TypedProjectionDefinition,
@@ -24,9 +23,8 @@ export type PostgreSQLProjectionHandlerContext = {
 
 export type PostgreSQLProjectionHandler<
   EventType extends Event = Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata,
+  EventMetaDataType extends
+    PostgresReadEventMetadata = PostgresReadEventMetadata,
 > = ProjectionHandler<
   EventType,
   EventMetaDataType,
@@ -35,9 +33,8 @@ export type PostgreSQLProjectionHandler<
 
 export type PostgreSQLProjectionDefinition<
   EventType extends Event = Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata,
+  EventMetaDataType extends
+    PostgresReadEventMetadata = PostgresReadEventMetadata,
 > = TypedProjectionDefinition<
   EventType,
   EventMetaDataType,
@@ -46,9 +43,8 @@ export type PostgreSQLProjectionDefinition<
 
 export type ProjectionHandlerOptions<
   EventType extends Event = Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata,
+  EventMetaDataType extends
+    PostgresReadEventMetadata = PostgresReadEventMetadata,
 > = {
   events: ReadEvent<EventType, EventMetaDataType>[];
   projections: PostgreSQLProjectionDefinition<EventType, EventMetaDataType>[];
@@ -60,9 +56,8 @@ export type ProjectionHandlerOptions<
 
 export const handleProjections = async <
   EventType extends Event = Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata,
+  EventMetaDataType extends
+    PostgresReadEventMetadata = PostgresReadEventMetadata,
 >(
   options: ProjectionHandlerOptions<EventType, EventMetaDataType>,
 ): Promise<void> => {
@@ -92,9 +87,8 @@ export const handleProjections = async <
 
 export const postgreSQLProjection = <
   EventType extends Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata,
+  EventMetaDataType extends
+    PostgresReadEventMetadata = PostgresReadEventMetadata,
 >(
   definition: PostgreSQLProjectionDefinition<EventType, EventMetaDataType>,
 ): PostgreSQLProjectionDefinition =>

--- a/src/packages/emmett-postgresql/src/eventStore/projections/pongo/projections.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/pongo/projections.ts
@@ -1,7 +1,6 @@
 import {
   type CanHandle,
   type Event,
-  type EventMetaDataOf,
   type ReadEvent,
 } from '@event-driven-io/emmett';
 import {
@@ -24,9 +23,8 @@ export type PongoProjectionHandlerContext =
 export type PongoWithNotNullDocumentEvolve<
   Document extends PongoDocument,
   EventType extends Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata,
+  EventMetaDataType extends
+    PostgresReadEventMetadata = PostgresReadEventMetadata,
 > =
   | ((
       document: Document,
@@ -40,9 +38,8 @@ export type PongoWithNotNullDocumentEvolve<
 export type PongoWithNullableDocumentEvolve<
   Document extends PongoDocument,
   EventType extends Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata,
+  EventMetaDataType extends
+    PostgresReadEventMetadata = PostgresReadEventMetadata,
 > =
   | ((
       document: Document | null,
@@ -56,18 +53,16 @@ export type PongoWithNullableDocumentEvolve<
 export type PongoDocumentEvolve<
   Document extends PongoDocument,
   EventType extends Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata,
+  EventMetaDataType extends
+    PostgresReadEventMetadata = PostgresReadEventMetadata,
 > =
   | PongoWithNotNullDocumentEvolve<Document, EventType, EventMetaDataType>
   | PongoWithNullableDocumentEvolve<Document, EventType, EventMetaDataType>;
 
 export type PongoProjectionOptions<
   EventType extends Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata,
+  EventMetaDataType extends
+    PostgresReadEventMetadata = PostgresReadEventMetadata,
 > = {
   handle: (
     events: ReadEvent<EventType, EventMetaDataType>[],
@@ -78,9 +73,8 @@ export type PongoProjectionOptions<
 
 export const pongoProjection = <
   EventType extends Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata,
+  EventMetaDataType extends
+    PostgresReadEventMetadata = PostgresReadEventMetadata,
 >({
   handle,
   canHandle,
@@ -105,9 +99,8 @@ export const pongoProjection = <
 export type PongoMultiStreamProjectionOptions<
   Document extends PongoDocument,
   EventType extends Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata,
+  EventMetaDataType extends
+    PostgresReadEventMetadata = PostgresReadEventMetadata,
 > = {
   canHandle: CanHandle<EventType>;
 
@@ -134,9 +127,8 @@ export type PongoMultiStreamProjectionOptions<
 export const pongoMultiStreamProjection = <
   Document extends PongoDocument,
   EventType extends Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata,
+  EventMetaDataType extends
+    PostgresReadEventMetadata = PostgresReadEventMetadata,
 >(
   options: PongoMultiStreamProjectionOptions<
     Document,
@@ -171,9 +163,8 @@ export const pongoMultiStreamProjection = <
 export type PongoSingleStreamProjectionOptions<
   Document extends PongoDocument,
   EventType extends Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata,
+  EventMetaDataType extends
+    PostgresReadEventMetadata = PostgresReadEventMetadata,
 > = {
   canHandle: CanHandle<EventType>;
 
@@ -199,9 +190,8 @@ export type PongoSingleStreamProjectionOptions<
 export const pongoSingleStreamProjection = <
   Document extends PongoDocument,
   EventType extends Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata = EventMetaDataOf<EventType> &
-    PostgresReadEventMetadata,
+  EventMetaDataType extends
+    PostgresReadEventMetadata = PostgresReadEventMetadata,
 >(
   options: PongoSingleStreamProjectionOptions<
     Document,

--- a/src/packages/emmett-postgresql/src/eventStore/schema/appendToStream.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/appendToStream.int.spec.ts
@@ -29,9 +29,14 @@ export type ShoppingCart = {
 
 export type ProductItemAdded = Event<
   'ProductItemAdded',
-  { productItem: PricedProductItem }
+  { productItem: PricedProductItem },
+  { meta: string }
 >;
-export type DiscountApplied = Event<'DiscountApplied', { percent: number }>;
+export type DiscountApplied = Event<
+  'DiscountApplied',
+  { percent: number },
+  { meta: string }
+>;
 
 export type ShoppingCartEvent = ProductItemAdded | DiscountApplied;
 

--- a/src/packages/emmett-postgresql/src/eventStore/schema/appendToStream.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/appendToStream.ts
@@ -150,7 +150,7 @@ export const appendToStream = (
           streamName,
           eventId: uuid(),
           streamPosition: BigInt(i),
-          ...e.metadata,
+          ...('metadata' in e ? (e.metadata ?? {}) : {}),
         },
       }));
 

--- a/src/packages/emmett-postgresql/src/eventStore/schema/readMessagesBatch.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/readMessagesBatch.ts
@@ -1,6 +1,5 @@
 import { mapRows, sql, type SQLExecutor } from '@event-driven-io/dumbo';
 import {
-  event,
   type CombinedReadEventMetadata,
   type Event,
   type EventDataOf,
@@ -86,11 +85,11 @@ export const readMessagesBatch = async <
       ),
     ),
     (row) => {
-      const rawEvent = event<MessageType>(
-        row.event_type,
-        row.event_data,
-        row.event_metadata,
-      );
+      const rawEvent = {
+        type: row.event_type,
+        data: row.event_data,
+        metadata: row.event_metadata,
+      } as unknown as MessageType;
 
       const metadata: ReadEventMetadataWithGlobalPosition = {
         ...('metadata' in rawEvent ? (rawEvent.metadata ?? {}) : {}),

--- a/src/packages/emmett-postgresql/src/eventStore/schema/readMessagesBatch.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/readMessagesBatch.ts
@@ -1,6 +1,7 @@
 import { mapRows, sql, type SQLExecutor } from '@event-driven-io/dumbo';
 import {
   event,
+  type CombinedReadEventMetadata,
   type Event,
   type EventDataOf,
   type EventMetaDataOf,
@@ -89,10 +90,10 @@ export const readMessagesBatch = async <
         row.event_type,
         row.event_data,
         row.event_metadata,
-      ) as MessageType;
+      );
 
       const metadata: ReadEventMetadataWithGlobalPosition = {
-        ...rawEvent.metadata,
+        ...('metadata' in rawEvent ? (rawEvent.metadata ?? {}) : {}),
         eventId: row.event_id,
         streamName: row.stream_id,
         streamPosition: BigInt(row.stream_position),
@@ -101,7 +102,10 @@ export const readMessagesBatch = async <
 
       return {
         ...rawEvent,
-        metadata: metadata as ReadEventMetadataType,
+        metadata: metadata as CombinedReadEventMetadata<
+          MessageType,
+          ReadEventMetadataType
+        >,
       };
     },
   );

--- a/src/packages/emmett-postgresql/src/eventStore/schema/readStream.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/readStream.int.spec.ts
@@ -32,9 +32,14 @@ export type ShoppingCart = {
 
 export type ProductItemAdded = Event<
   'ProductItemAdded',
-  { productItem: PricedProductItem }
+  { productItem: PricedProductItem },
+  { meta: string }
 >;
-export type DiscountApplied = Event<'DiscountApplied', { percent: number }>;
+export type DiscountApplied = Event<
+  'DiscountApplied',
+  { percent: number },
+  { meta: string }
+>;
 
 export type ShoppingCartEvent = ProductItemAdded | DiscountApplied;
 

--- a/src/packages/emmett-postgresql/src/eventStore/schema/readStream.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/readStream.ts
@@ -1,6 +1,5 @@
 import { mapRows, sql, type SQLExecutor } from '@event-driven-io/dumbo';
 import {
-  event,
   type CombinedReadEventMetadata,
   type Event,
   type EventDataOf,
@@ -60,11 +59,11 @@ export const readStream = async <EventType extends Event>(
         ),
       ),
       (row) => {
-        const rawEvent = event<EventType>(
-          row.event_type,
-          row.event_data,
-          row.event_metadata,
-        );
+        const rawEvent = {
+          type: row.event_type,
+          data: row.event_data,
+          metadata: row.event_metadata,
+        } as unknown as EventType;
 
         const metadata: ReadEventMetadataWithGlobalPosition = {
           ...('metadata' in rawEvent ? (rawEvent.metadata ?? {}) : {}),

--- a/src/packages/emmett/src/eventStore/eventStore.ts
+++ b/src/packages/emmett/src/eventStore/eventStore.ts
@@ -1,9 +1,9 @@
 //import type { ReadableStream } from 'web-streams-polyfill';
 import type {
+  AnyReadEventMetadata,
   BigIntGlobalPosition,
   BigIntStreamPosition,
   Event,
-  EventMetaDataOf,
   GlobalPositionTypeOfReadEventMetadata,
   ReadEvent,
   ReadEventMetadata,
@@ -15,21 +15,11 @@ import type { ExpectedStreamVersion } from './expectedVersion';
 
 // #region event-store
 export interface EventStore<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ReadEventMetadataType extends ReadEventMetadata<any, any> = ReadEventMetadata<
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    any,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    any
-  >,
+  ReadEventMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
 > {
   aggregateStream<State, EventType extends Event>(
     streamName: string,
-    options: AggregateStreamOptions<
-      State,
-      EventType,
-      ReadEventMetadataType & EventMetaDataOf<EventType>
-    >,
+    options: AggregateStreamOptions<State, EventType, ReadEventMetadataType>,
   ): Promise<
     AggregateStreamResult<
       State,
@@ -42,12 +32,7 @@ export interface EventStore<
     options?: ReadStreamOptions<
       StreamPositionTypeOfReadEventMetadata<ReadEventMetadataType>
     >,
-  ): Promise<
-    ReadStreamResult<
-      EventType,
-      ReadEventMetadataType & EventMetaDataOf<EventType>
-    >
-  >;
+  ): Promise<ReadStreamResult<EventType, ReadEventMetadataType>>;
 
   appendToStream<EventType extends Event>(
     streamName: string,
@@ -127,17 +112,10 @@ export type ReadStreamOptions<StreamVersion = BigIntStreamPosition> = (
 
 export type ReadStreamResult<
   EventType extends Event,
-  ReadEventMetadataType extends EventMetaDataOf<EventType> &
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ReadEventMetadata<any, any> = EventMetaDataOf<EventType> &
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ReadEventMetadata<any, bigint>,
+  ReadEventMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
 > = {
   currentStreamVersion: StreamPositionTypeOfReadEventMetadata<ReadEventMetadataType>;
-  events: ReadEvent<
-    EventType,
-    ReadEventMetadataType & EventMetaDataOf<EventType>
-  >[];
+  events: ReadEvent<EventType, ReadEventMetadataType>[];
   streamExists: boolean;
 };
 
@@ -148,11 +126,7 @@ export type ReadStreamResult<
 type Evolve<
   State,
   EventType extends Event,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ReadEventMetadataType extends ReadEventMetadata<any, any> &
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    EventMetaDataOf<EventType> = ReadEventMetadata<any, any> &
-    EventMetaDataOf<EventType>,
+  ReadEventMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
 > =
   | ((currentState: State, event: EventType) => State)
   | ((
@@ -164,11 +138,7 @@ type Evolve<
 export type AggregateStreamOptions<
   State,
   EventType extends Event,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ReadEventMetadataType extends ReadEventMetadata<any, any> &
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    EventMetaDataOf<EventType> = ReadEventMetadata<any, any> &
-    EventMetaDataOf<EventType>,
+  ReadEventMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
 > = {
   evolve: Evolve<State, EventType, ReadEventMetadataType>;
   initialState: () => State;

--- a/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
+++ b/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
@@ -1,6 +1,7 @@
 import { v4 as uuid } from 'uuid';
 import type {
   BigIntStreamPosition,
+  CombinedReadEventMetadata,
   Event,
   ReadEvent,
   ReadEventMetadataWithGlobalPosition,
@@ -141,15 +142,21 @@ export const getInMemoryEventStore = (
         EventType,
         ReadEventMetadataWithGlobalPosition
       >[] = events.map((event, index) => {
+        const metadata: ReadEventMetadataWithGlobalPosition = {
+          streamName,
+          eventId: uuid(),
+          streamPosition: BigInt(currentEvents.length + index + 1),
+          globalPosition: BigInt(getAllEventsCount() + index + 1),
+        };
         return {
           ...event,
           metadata: {
-            ...(event.metadata ?? {}),
-            streamName,
-            eventId: uuid(),
-            streamPosition: BigInt(currentEvents.length + index + 1),
-            globalPosition: BigInt(getAllEventsCount() + index + 1),
-          },
+            ...('metadata' in event ? (event.metadata ?? {}) : {}),
+            ...metadata,
+          } as CombinedReadEventMetadata<
+            EventType,
+            ReadEventMetadataWithGlobalPosition
+          >,
         };
       });
 

--- a/src/packages/emmett/src/projections/index.ts
+++ b/src/packages/emmett/src/projections/index.ts
@@ -1,21 +1,16 @@
 import type {
+  AnyReadEventMetadata,
   CanHandle,
   DefaultRecord,
   Event,
-  EventMetaDataOf,
   ReadEvent,
-  ReadEventMetadata,
 } from '../typing';
 
 export type ProjectionHandlingType = 'inline' | 'async';
 
 export type ProjectionHandler<
   EventType extends Event = Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ReadEventMetadata<any, any> = EventMetaDataOf<EventType> &
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ReadEventMetadata<any, any>,
+  EventMetaDataType extends AnyReadEventMetadata = AnyReadEventMetadata,
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
 > = (
   events: ReadEvent<EventType, EventMetaDataType>[],
@@ -23,13 +18,7 @@ export type ProjectionHandler<
 ) => Promise<void> | void;
 
 export interface ProjectionDefinition<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ReadEventMetadataType extends ReadEventMetadata<any, any> = ReadEventMetadata<
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    any,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    any
-  >,
+  ReadEventMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
 > {
   name?: string;
@@ -43,11 +32,7 @@ export interface ProjectionDefinition<
 
 export interface TypedProjectionDefinition<
   EventType extends Event = Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ReadEventMetadata<any, any> = EventMetaDataOf<EventType> &
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ReadEventMetadata<any, any>,
+  EventMetaDataType extends AnyReadEventMetadata = AnyReadEventMetadata,
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
 > {
   name?: string;
@@ -61,13 +46,7 @@ export interface TypedProjectionDefinition<
 
 export type ProjectionRegistration<
   HandlingType extends ProjectionHandlingType,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ReadEventMetadataType extends ReadEventMetadata<any, any> = ReadEventMetadata<
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    any,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    any
-  >,
+  ReadEventMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
 > = {
   type: HandlingType;
@@ -79,11 +58,7 @@ export type ProjectionRegistration<
 
 export const projection = <
   EventType extends Event = Event,
-  EventMetaDataType extends EventMetaDataOf<EventType> &
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ReadEventMetadata<any, any> = EventMetaDataOf<EventType> &
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ReadEventMetadata<any, any>,
+  EventMetaDataType extends AnyReadEventMetadata = AnyReadEventMetadata,
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
   ProjectionDefintionType extends TypedProjectionDefinition<
     EventType,
@@ -99,13 +74,7 @@ export const projection = <
 ): ProjectionDefintionType => definition;
 
 export const inlineProjections = <
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ReadEventMetadataType extends ReadEventMetadata<any, any> = ReadEventMetadata<
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    any,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    any
-  >,
+  ReadEventMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
   ProjectionDefintionType extends ProjectionDefinition<
     ReadEventMetadataType,
@@ -120,13 +89,7 @@ export const inlineProjections = <
 >[] => definitions.map((projection) => ({ type: 'inline', projection }));
 
 export const asyncProjections = <
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ReadEventMetadataType extends ReadEventMetadata<any, any> = ReadEventMetadata<
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    any,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    any
-  >,
+  ReadEventMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
   ProjectionHandlerContext extends DefaultRecord = DefaultRecord,
   ProjectionDefintionType extends ProjectionDefinition<
     ReadEventMetadataType,

--- a/src/packages/emmett/src/typing/event.ts
+++ b/src/packages/emmett/src/typing/event.ts
@@ -47,13 +47,21 @@ export type CreateEventType<
         metadata: EventMetaData;
       }
 >;
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const event = <T extends Event<string, any, any>>(
-  type: EventTypeOf<T>,
-  data: EventDataOf<T>,
-  metadata?: EventMetaDataOf<T>,
+  ...args: EventMetaDataOf<T> extends undefined
+    ? [type: EventTypeOf<T>, data: EventDataOf<T>]
+    : [type: EventTypeOf<T>, data: EventDataOf<T>, metadata: EventMetaDataOf<T>]
 ): T => {
-  return metadata ? ({ type, data, metadata } as T) : ({ type, data } as T);
+  const [type, data, metadata] = args as [
+    EventTypeOf<T>,
+    EventDataOf<T>,
+    EventMetaDataOf<T> | undefined,
+  ];
+  return metadata !== undefined
+    ? ({ type, data, metadata } as T)
+    : ({ type, data } as T);
 };
 
 export type CombinedReadEventMetadata<


### PR DESCRIPTION
Reshaped and simplified also related typing to combine metadata from event type and store metadata.

Previously, providing metadata wasn't required, even if it was defined on type. Now it is.

Also introduced the `AnyReadEventMetadata` type wrapper to reduce the linter warnings.