### PR TITLE
Adjusted command metadata definition to have metadata required if provided

### DIFF
--- a/src/packages/emmett/src/typing/event.ts
+++ b/src/packages/emmett/src/typing/event.ts
@@ -49,19 +49,20 @@ export type CreateEventType<
 >;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const event = <T extends Event<string, any, any>>(
-  ...args: EventMetaDataOf<T> extends undefined
-    ? [type: EventTypeOf<T>, data: EventDataOf<T>]
-    : [type: EventTypeOf<T>, data: EventDataOf<T>, metadata: EventMetaDataOf<T>]
-): T => {
-  const [type, data, metadata] = args as [
-    EventTypeOf<T>,
-    EventDataOf<T>,
-    EventMetaDataOf<T> | undefined,
-  ];
+export const event = <EventType extends Event<string, any, any>>(
+  ...args: EventMetaDataOf<EventType> extends undefined
+    ? [type: EventTypeOf<EventType>, data: EventDataOf<EventType>]
+    : [
+        type: EventTypeOf<EventType>,
+        data: EventDataOf<EventType>,
+        metadata: EventMetaDataOf<EventType>,
+      ]
+): EventType => {
+  const [type, data, metadata] = args;
+
   return metadata !== undefined
-    ? ({ type, data, metadata } as T)
-    : ({ type, data } as T);
+    ? ({ type, data, metadata } as EventType)
+    : ({ type, data } as EventType);
 };
 
 export type CombinedReadEventMetadata<


### PR DESCRIPTION
It's a follow-up to the changes for the event: https://github.com/event-driven-io/emmett/pull/162.

The difference here is that if metadata is not provided for a command, it will use an optional default command metadata type. The reasoning is to allow the full overriding of metadata but benefit from the common metadata. In the future, default metadata handling can be changed when the command handler context is added.