### PR TITLE
Fixed the event store read event metadata inference

### DIFF
--- a/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.ts
@@ -1,6 +1,6 @@
 import {
-  ExpectedVersionConflictError,
   assertExpectedVersionMatchesCurrent,
+  ExpectedVersionConflictError,
   filterProjections,
   tryPublishMessagesAfterCommit,
   type AggregateStreamOptions,
@@ -8,6 +8,7 @@ import {
   type AppendToStreamOptions,
   type AppendToStreamResult,
   type Closeable,
+  type DefaultEventStoreOptions,
   type Event,
   type EventStore,
   type ProjectionRegistration,
@@ -15,7 +16,6 @@ import {
   type ReadEventMetadataWithoutGlobalPosition,
   type ReadStreamOptions,
   type ReadStreamResult,
-  type DefaultEventStoreOptions,
 } from '@event-driven-io/emmett';
 import {
   MongoClient,
@@ -394,7 +394,6 @@ class MongoDBEventStoreImplementation implements MongoDBEventStore, Closeable {
     }
 
     await tryPublishMessagesAfterCommit<MongoDBEventStore>(
-      // @ts-expect-error Issues with `globalPosition` not being present causing the type for metadata to expect `never`
       eventsToAppend,
       this.options.hooks,
       // {

--- a/src/packages/emmett/src/eventStore/eventStore.ts
+++ b/src/packages/emmett/src/eventStore/eventStore.ts
@@ -3,11 +3,13 @@ import type {
   AnyReadEventMetadata,
   BigIntGlobalPosition,
   BigIntStreamPosition,
+  CommonReadEventMetadata,
   Event,
   GlobalPositionTypeOfReadEventMetadata,
   ReadEvent,
   ReadEventMetadata,
   StreamPositionTypeOfReadEventMetadata,
+  WithGlobalPosition,
 } from '../typing';
 import type { AfterEventStoreCommitHandler } from './afterCommit';
 //import type { GlobalSubscriptionEvent } from './events';
@@ -52,9 +54,11 @@ export interface EventStore<
 }
 
 export type EventStoreReadEventMetadata<Store extends EventStore> =
-  Store extends EventStore<infer ReadEventMetadataType>
-    ? ReadEventMetadataType extends ReadEventMetadata<infer GV, infer SV>
-      ? ReadEventMetadata<GV, SV> & ReadEventMetadataType
+  Store extends EventStore<infer T>
+    ? T extends CommonReadEventMetadata<infer SP>
+      ? T extends WithGlobalPosition<infer GP>
+        ? ReadEventMetadata<GP, SP> & T
+        : ReadEventMetadata<undefined, SP> & T
       : never
     : never;
 

--- a/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
+++ b/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
@@ -173,7 +173,10 @@ export const getInMemoryEventStore = (
           currentStreamVersion === InMemoryEventStoreDefaultStreamVersion,
       };
 
-      await tryPublishMessagesAfterCommit(newEvents, eventStoreOptions?.hooks);
+      await tryPublishMessagesAfterCommit<InMemoryEventStore>(
+        newEvents,
+        eventStoreOptions?.hooks,
+      );
 
       return result;
     },

--- a/src/packages/emmett/src/typing/event.ts
+++ b/src/packages/emmett/src/typing/event.ts
@@ -80,17 +80,23 @@ export type ReadEvent<
   metadata: CombinedReadEventMetadata<EventType, EventMetaDataType>;
 };
 
+export type CommonReadEventMetadata<StreamPosition = BigIntStreamPosition> =
+  Readonly<{
+    eventId: string;
+    streamPosition: StreamPosition;
+    streamName: string;
+  }>;
+
+export type WithGlobalPosition<GlobalPosition> = Readonly<{
+  globalPosition: GlobalPosition;
+}>;
+
 export type ReadEventMetadata<
   GlobalPosition = undefined,
   StreamPosition = BigIntStreamPosition,
-> = Readonly<{
-  eventId: string;
-  streamPosition: StreamPosition;
-  streamName: string;
-}> &
-  (GlobalPosition extends undefined
-    ? object
-    : { globalPosition: GlobalPosition });
+> = CommonReadEventMetadata<StreamPosition> &
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  (GlobalPosition extends undefined ? {} : WithGlobalPosition<GlobalPosition>);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyReadEventMetadata = ReadEventMetadata<any, any>;


### PR DESCRIPTION
Now, it'll be possible to use tryPublishMessagesAfterCommit method without type errors.

@alex-laycalvert FYI, that should fix the type error you had in the MongoDB event store

Relates #169 #170 