### PR TITLE
Added message type to allow store not only events but also commands and unfied message processing

### DIFF
--- a/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.ts
@@ -336,7 +336,7 @@ class MongoDBEventStoreImplementation implements MongoDBEventStore, Closeable {
     const eventsToAppend: ReadEvent<EventType, MongoDBReadEventMetadata>[] =
       events.map((event) => {
         const metadata: MongoDBReadEventMetadata = {
-          eventId: uuid(),
+          messageId: uuid(),
           streamName,
           streamPosition: ++streamOffset,
         };

--- a/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjectionSpec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjectionSpec.ts
@@ -85,11 +85,12 @@ export const PostgreSQLProjectionSpec = {
                   globalPosition: ++globalPosition,
                   streamPosition: globalPosition,
                   streamName: `test-${uuid()}`,
-                  eventId: uuid(),
+                  messageId: uuid(),
                 };
 
                 allEvents.push({
                   ...event,
+                  kind: 'Event',
                   metadata: {
                     ...metadata,
                     ...('metadata' in event ? (event.metadata ?? {}) : {}),

--- a/src/packages/emmett-postgresql/src/eventStore/schema/appendToStream.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/appendToStream.ts
@@ -146,9 +146,10 @@ export const appendToStream = (
 
       const eventsToAppend: ReadEvent[] = events.map((e, i) => ({
         ...e,
+        kind: e.kind ?? 'Event',
         metadata: {
           streamName,
-          eventId: uuid(),
+          messageId: uuid(),
           streamPosition: BigInt(i),
           ...('metadata' in e ? (e.metadata ?? {}) : {}),
         },
@@ -252,7 +253,7 @@ const appendEventsRaw = (
                   %s::bigint,
                   %L::text
               )`,
-        events.map((e) => sql('%L', e.metadata.eventId)).join(','),
+        events.map((e) => sql('%L', e.metadata.messageId)).join(','),
         events.map((e) => sql('%L', JSONParser.stringify(e.data))).join(','),
         events
           .map((e) => sql('%L', JSONParser.stringify(e.metadata ?? {})))

--- a/src/packages/emmett-postgresql/src/eventStore/schema/readMessagesBatch.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/readMessagesBatch.ts
@@ -93,7 +93,7 @@ export const readMessagesBatch = async <
 
       const metadata: ReadEventMetadataWithGlobalPosition = {
         ...('metadata' in rawEvent ? (rawEvent.metadata ?? {}) : {}),
-        eventId: row.event_id,
+        messageId: row.event_id,
         streamName: row.stream_id,
         streamPosition: BigInt(row.stream_position),
         globalPosition: BigInt(row.global_position),
@@ -101,6 +101,7 @@ export const readMessagesBatch = async <
 
       return {
         ...rawEvent,
+        kind: 'Event',
         metadata: metadata as CombinedReadEventMetadata<
           MessageType,
           ReadEventMetadataType

--- a/src/packages/emmett-postgresql/src/eventStore/schema/readStream.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/readStream.ts
@@ -67,7 +67,7 @@ export const readStream = async <EventType extends Event>(
 
         const metadata: ReadEventMetadataWithGlobalPosition = {
           ...('metadata' in rawEvent ? (rawEvent.metadata ?? {}) : {}),
-          eventId: row.event_id,
+          messageId: row.event_id,
           streamName: streamId,
           streamPosition: BigInt(row.stream_position),
           globalPosition: BigInt(row.global_position),
@@ -75,6 +75,7 @@ export const readStream = async <EventType extends Event>(
 
         return {
           ...rawEvent,
+          kind: 'Event',
           metadata: metadata as CombinedReadEventMetadata<
             EventType,
             ReadEventMetadataWithGlobalPosition

--- a/src/packages/emmett-sqlite/src/eventStore/schema/appendToStream.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/schema/appendToStream.ts
@@ -44,9 +44,10 @@ export const appendToStream = async (
   const eventsToAppend: ReadEvent[] = events.map(
     (e: Event, i: number): ReadEvent => ({
       ...e,
+      kind: e.kind ?? 'Event',
       metadata: {
         streamName,
-        eventId: uuid(),
+        messageId: uuid(),
         streamPosition: BigInt(i + 1),
         ...('metadata' in e ? (e.metadata ?? {}) : {}),
       },
@@ -268,7 +269,7 @@ const buildEventInsertQuery = (
         JSONParser.stringify(event.metadata),
         expectedStreamVersion?.toString() ?? 0,
         event.type,
-        event.metadata.eventId,
+        event.metadata.messageId,
         false,
       );
 

--- a/src/packages/emmett-sqlite/src/eventStore/schema/readStream.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/schema/readStream.ts
@@ -61,13 +61,14 @@ export const readStream = async <EventType extends Event>(
 
       const metadata: ReadEventMetadataWithGlobalPosition = {
         ...('metadata' in rawEvent ? (rawEvent.metadata ?? {}) : {}),
-        eventId: row.event_id,
+        messageId: row.event_id,
         streamName: streamId,
         streamPosition: BigInt(row.stream_position),
         globalPosition: BigInt(row.global_position),
       };
 
       return {
+        kind: 'Event',
         ...rawEvent,
         metadata: metadata as CombinedReadEventMetadata<
           EventType,

--- a/src/packages/emmett/src/eventStore/afterCommit/afterEventStoreCommitHandler.unit.spec.ts
+++ b/src/packages/emmett/src/eventStore/afterCommit/afterEventStoreCommitHandler.unit.spec.ts
@@ -31,22 +31,24 @@ void describe('InMemoryEventStore onAfterCommit', () => {
     let counter = 0;
     const events: TestReadEvent[] = [
       {
+        kind: 'Event',
         type: 'test',
         data: { counter: ++counter },
         metadata: {
           some: true,
-          eventId: uuid(),
+          messageId: uuid(),
           globalPosition: 1n,
           streamName,
           streamPosition: 1n,
         },
       },
       {
+        kind: 'Event',
         type: 'test',
         data: { counter: ++counter },
         metadata: {
           some: false,
-          eventId: uuid(),
+          messageId: uuid(),
           globalPosition: 1n,
           streamName,
           streamPosition: 1n,
@@ -76,22 +78,24 @@ void describe('InMemoryEventStore onAfterCommit', () => {
     let counter = 0;
     const events: TestReadEvent[] = [
       {
+        kind: 'Event',
         type: 'test',
         data: { counter: ++counter },
         metadata: {
           some: true,
-          eventId: uuid(),
+          messageId: uuid(),
           globalPosition: 1n,
           streamName,
           streamPosition: 1n,
         },
       },
       {
+        kind: 'Event',
         type: 'test',
         data: { counter: ++counter },
         metadata: {
           some: false,
-          eventId: uuid(),
+          messageId: uuid(),
           globalPosition: 1n,
           streamName,
           streamPosition: 1n,
@@ -100,22 +104,24 @@ void describe('InMemoryEventStore onAfterCommit', () => {
     ];
     const nextEvents: TestReadEvent[] = [
       {
+        kind: 'Event',
         type: 'test',
         data: { counter: ++counter },
         metadata: {
           some: true,
-          eventId: uuid(),
+          messageId: uuid(),
           globalPosition: 1n,
           streamName,
           streamPosition: 1n,
         },
       },
       {
+        kind: 'Event',
         type: 'test',
         data: { counter: ++counter },
         metadata: {
           some: false,
-          eventId: uuid(),
+          messageId: uuid(),
           globalPosition: 1n,
           streamName,
           streamPosition: 1n,
@@ -152,22 +158,24 @@ void describe('InMemoryEventStore onAfterCommit', () => {
     let counter = 0;
     const events: TestReadEvent[] = [
       {
+        kind: 'Event',
         type: 'test',
         data: { counter: ++counter },
         metadata: {
           some: true,
-          eventId: uuid(),
+          messageId: uuid(),
           globalPosition: 1n,
           streamName,
           streamPosition: 1n,
         },
       },
       {
+        kind: 'Event',
         type: 'test',
         data: { counter: ++counter },
         metadata: {
           some: false,
-          eventId: uuid(),
+          messageId: uuid(),
           globalPosition: 1n,
           streamName,
           streamPosition: 1n,

--- a/src/packages/emmett/src/eventStore/afterCommit/forwardToMessageBus.unit.spec.ts
+++ b/src/packages/emmett/src/eventStore/afterCommit/forwardToMessageBus.unit.spec.ts
@@ -33,22 +33,24 @@ void describe('InMemoryEventStore onAfterCommit', () => {
     let counter = 0;
     const events: TestReadEvent[] = [
       {
+        kind: 'Event',
         type: 'test',
         data: { counter: ++counter },
         metadata: {
           some: true,
-          eventId: uuid(),
+          messageId: uuid(),
           globalPosition: 1n,
           streamName,
           streamPosition: 1n,
         },
       },
       {
+        kind: 'Event',
         type: 'test',
         data: { counter: ++counter },
         metadata: {
           some: false,
-          eventId: uuid(),
+          messageId: uuid(),
           globalPosition: 1n,
           streamName,
           streamPosition: 1n,
@@ -79,22 +81,24 @@ void describe('InMemoryEventStore onAfterCommit', () => {
     let counter = 0;
     const events: TestReadEvent[] = [
       {
+        kind: 'Event',
         type: 'test',
         data: { counter: ++counter },
         metadata: {
           some: true,
-          eventId: uuid(),
+          messageId: uuid(),
           globalPosition: 1n,
           streamName,
           streamPosition: 1n,
         },
       },
       {
+        kind: 'Event',
         type: 'test',
         data: { counter: ++counter },
         metadata: {
           some: false,
-          eventId: uuid(),
+          messageId: uuid(),
           globalPosition: 1n,
           streamName,
           streamPosition: 1n,
@@ -103,22 +107,24 @@ void describe('InMemoryEventStore onAfterCommit', () => {
     ];
     const nextEvents: TestReadEvent[] = [
       {
+        kind: 'Event',
         type: 'test',
         data: { counter: ++counter },
         metadata: {
           some: true,
-          eventId: uuid(),
+          messageId: uuid(),
           globalPosition: 1n,
           streamName,
           streamPosition: 1n,
         },
       },
       {
+        kind: 'Event',
         type: 'test',
         data: { counter: ++counter },
         metadata: {
           some: false,
-          eventId: uuid(),
+          messageId: uuid(),
           globalPosition: 1n,
           streamName,
           streamPosition: 1n,
@@ -151,22 +157,24 @@ void describe('InMemoryEventStore onAfterCommit', () => {
     let counter = 0;
     const events: TestReadEvent[] = [
       {
+        kind: 'Event',
         type: 'test',
         data: { counter: ++counter },
         metadata: {
           some: true,
-          eventId: uuid(),
+          messageId: uuid(),
           globalPosition: 1n,
           streamName,
           streamPosition: 1n,
         },
       },
       {
+        kind: 'Event',
         type: 'test',
         data: { counter: ++counter },
         metadata: {
           some: false,
-          eventId: uuid(),
+          messageId: uuid(),
           globalPosition: 1n,
           streamName,
           streamPosition: 1n,

--- a/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
+++ b/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
@@ -161,12 +161,13 @@ export const getInMemoryEventStore = (
       >[] = events.map((event, index) => {
         const metadata: ReadEventMetadataWithGlobalPosition = {
           streamName,
-          eventId: uuid(),
+          messageId: uuid(),
           streamPosition: BigInt(currentEvents.length + index + 1),
           globalPosition: BigInt(getAllEventsCount() + index + 1),
         };
         return {
           ...event,
+          kind: event.kind ?? 'Event',
           metadata: {
             ...('metadata' in event ? (event.metadata ?? {}) : {}),
             ...metadata,

--- a/src/packages/emmett/src/eventStore/subscriptions/caughtUpTransformStream.unit.spec.ts
+++ b/src/packages/emmett/src/eventStore/subscriptions/caughtUpTransformStream.unit.spec.ts
@@ -22,9 +22,10 @@ void describe('CaughtUpTransformStream', () => {
     globalPosition: bigint,
   ): ReadEvent<ShoppingCartOpened, ReadEventMetadataWithGlobalPosition> => ({
     type: 'ShoppingCartOpened',
+    kind: 'Event',
     data: { cartId: 'cartId' },
     metadata: {
-      eventId: uuid(),
+      messageId: uuid(),
       globalPosition,
       streamPosition: globalPosition,
       streamName: 'test',

--- a/src/packages/emmett/src/eventStore/subscriptions/streamingCoordinator.unit.spec.ts
+++ b/src/packages/emmett/src/eventStore/subscriptions/streamingCoordinator.unit.spec.ts
@@ -159,10 +159,11 @@ const createMockEvent = (
   position: bigint,
 ): ReadEvent<MockEvent, ReadEventMetadataWithGlobalPosition> => ({
   type: 'Mocked',
+  kind: 'Event',
   data: { mocked: true },
   metadata: {
     streamName: 'testStream',
-    eventId: `event-${position}`,
+    messageId: `message-${position}`,
     streamPosition: position,
     globalPosition: position,
   },

--- a/src/packages/emmett/src/typing/command.ts
+++ b/src/packages/emmett/src/typing/command.ts
@@ -1,25 +1,22 @@
-import type { DefaultRecord, Flavour } from './';
+import type { DefaultRecord } from './';
 
 export type Command<
   CommandType extends string = string,
   CommandData extends DefaultRecord = DefaultRecord,
   CommandMetaData extends DefaultRecord | undefined = undefined,
-> = Flavour<
-  Readonly<
-    CommandMetaData extends undefined
-      ? {
-          type: CommandType;
-          data: Readonly<CommandData>;
-          metadata?: DefaultCommandMetadata | undefined;
-        }
-      : {
-          type: CommandType;
-          data: CommandData;
-          metadata: CommandMetaData;
-        }
-  >,
-  'Command'
->;
+> = Readonly<
+  CommandMetaData extends undefined
+    ? {
+        type: CommandType;
+        data: Readonly<CommandData>;
+        metadata?: DefaultCommandMetadata | undefined;
+      }
+    : {
+        type: CommandType;
+        data: CommandData;
+        metadata: CommandMetaData;
+      }
+> & { readonly kind?: 'Command' };
 
 export type CommandTypeOf<T extends Command> = T['type'];
 export type CommandDataOf<T extends Command> = T['data'];
@@ -45,7 +42,7 @@ export type CreateCommandType<
         data: CommandData;
         metadata: CommandMetaData;
       }
->;
+> & { readonly kind?: 'Command' };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const command = <CommandType extends Command<string, any, any>>(
@@ -64,8 +61,8 @@ export const command = <CommandType extends Command<string, any, any>>(
   const [type, data, metadata] = args;
 
   return metadata !== undefined
-    ? ({ type, data, metadata } as CommandType)
-    : ({ type, data } as CommandType);
+    ? ({ type, data, metadata, kind: 'Command' } as CommandType)
+    : ({ type, data, kind: 'Command' } as CommandType);
 };
 
 export type DefaultCommandMetadata = { now: Date };

--- a/src/packages/emmett/src/typing/event.ts
+++ b/src/packages/emmett/src/typing/event.ts
@@ -1,4 +1,15 @@
-import type { DefaultRecord, Flavour } from './';
+import type { DefaultRecord } from './';
+import type {
+  AnyRecordedMessageMetadata,
+  CombinedRecordedMessageMetadata,
+  CommonRecordedMessageMetadata,
+  GlobalPositionTypeOfRecordedMessageMetadata,
+  RecordedMessage,
+  RecordedMessageMetadata,
+  RecordedMessageMetadataWithGlobalPosition,
+  RecordedMessageMetadataWithoutGlobalPosition,
+  StreamPositionTypeOfRecordedMessageMetadata,
+} from './message';
 
 export type BigIntStreamPosition = bigint;
 export type BigIntGlobalPosition = bigint;
@@ -7,21 +18,18 @@ export type Event<
   EventType extends string = string,
   EventData extends DefaultRecord = DefaultRecord,
   EventMetaData extends DefaultRecord | undefined = undefined,
-> = Flavour<
-  Readonly<
-    EventMetaData extends undefined
-      ? {
-          type: EventType;
-          data: EventData;
-        }
-      : {
-          type: EventType;
-          data: EventData;
-          metadata: EventMetaData;
-        }
-  >,
-  'Event'
->;
+> = Readonly<
+  EventMetaData extends undefined
+    ? {
+        type: EventType;
+        data: EventData;
+      }
+    : {
+        type: EventType;
+        data: EventData;
+        metadata: EventMetaData;
+      }
+> & { readonly kind?: 'Event' };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyEvent = Event<any, any, any>;
@@ -31,8 +39,6 @@ export type EventDataOf<T extends Event> = T['data'];
 export type EventMetaDataOf<T extends Event> = T extends { metadata: infer M }
   ? M
   : undefined;
-
-export type CanHandle<T extends Event> = EventTypeOf<T>[];
 
 export type CreateEventType<
   EventType extends string,
@@ -49,7 +55,7 @@ export type CreateEventType<
         data: EventData;
         metadata: EventMetaData;
       }
->;
+> & { readonly kind?: 'Event' };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const event = <EventType extends Event<string, any, any>>(
@@ -64,62 +70,46 @@ export const event = <EventType extends Event<string, any, any>>(
   const [type, data, metadata] = args;
 
   return metadata !== undefined
-    ? ({ type, data, metadata } as EventType)
-    : ({ type, data } as EventType);
+    ? ({ type, data, metadata, kind: 'Event' } as EventType)
+    : ({ type, data, kind: 'Event' } as EventType);
 };
 
 export type CombinedReadEventMetadata<
   EventType extends Event = Event,
-  EventMetaDataType extends AnyReadEventMetadata = AnyReadEventMetadata,
-> =
-  EventMetaDataOf<EventType> extends undefined
-    ? EventMetaDataType
-    : EventMetaDataOf<EventType> & EventMetaDataType;
+  EventMetaDataType extends
+    AnyRecordedMessageMetadata = AnyRecordedMessageMetadata,
+> = CombinedRecordedMessageMetadata<EventType, EventMetaDataType>;
 
 export type ReadEvent<
   EventType extends Event = Event,
-  EventMetaDataType extends AnyReadEventMetadata = AnyReadEventMetadata,
-> = EventType & {
-  metadata: CombinedReadEventMetadata<EventType, EventMetaDataType>;
-};
+  EventMetaDataType extends
+    AnyRecordedMessageMetadata = AnyRecordedMessageMetadata,
+> = RecordedMessage<EventType, EventMetaDataType>;
 
 export type AnyReadEvent<
   EventMetaDataType extends AnyReadEventMetadata = AnyReadEventMetadata,
 > = ReadEvent<AnyEvent, EventMetaDataType>;
 
 export type CommonReadEventMetadata<StreamPosition = BigIntStreamPosition> =
-  Readonly<{
-    eventId: string;
-    streamPosition: StreamPosition;
-    streamName: string;
-  }>;
-
-export type WithGlobalPosition<GlobalPosition> = Readonly<{
-  globalPosition: GlobalPosition;
-}>;
+  CommonRecordedMessageMetadata<StreamPosition>;
 
 export type ReadEventMetadata<
   GlobalPosition = undefined,
   StreamPosition = BigIntStreamPosition,
-> = CommonReadEventMetadata<StreamPosition> &
-  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-  (GlobalPosition extends undefined ? {} : WithGlobalPosition<GlobalPosition>);
+> = RecordedMessageMetadata<GlobalPosition, StreamPosition>;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyReadEventMetadata = ReadEventMetadata<any, any>;
+export type AnyReadEventMetadata = AnyRecordedMessageMetadata;
 
 export type ReadEventMetadataWithGlobalPosition<
   GlobalPosition = BigIntGlobalPosition,
-> = ReadEventMetadata<GlobalPosition>;
+> = RecordedMessageMetadataWithGlobalPosition<GlobalPosition>;
 
 export type ReadEventMetadataWithoutGlobalPosition<
   StreamPosition = BigIntStreamPosition,
-> = ReadEventMetadata<undefined, StreamPosition>;
+> = RecordedMessageMetadataWithoutGlobalPosition<StreamPosition>;
 
 export type GlobalPositionTypeOfReadEventMetadata<ReadEventMetadataType> =
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ReadEventMetadataType extends ReadEventMetadata<infer GP, any> ? GP : never;
+  GlobalPositionTypeOfRecordedMessageMetadata<ReadEventMetadataType>;
 
 export type StreamPositionTypeOfReadEventMetadata<ReadEventMetadataType> =
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ReadEventMetadataType extends ReadEventMetadata<any, infer SV> ? SV : never;
+  StreamPositionTypeOfRecordedMessageMetadata<ReadEventMetadataType>;

--- a/src/packages/emmett/src/typing/index.ts
+++ b/src/packages/emmett/src/typing/index.ts
@@ -2,6 +2,7 @@ export * from './deepReadonly';
 
 export * from './command';
 export * from './event';
+export * from './message';
 
 export * from './decider';
 export * from './workflow';

--- a/src/packages/emmett/src/typing/message.ts
+++ b/src/packages/emmett/src/typing/message.ts
@@ -1,0 +1,110 @@
+import type {
+  BigIntGlobalPosition,
+  BigIntStreamPosition,
+  Command,
+  DefaultRecord,
+  Event,
+} from '.';
+
+export type Message<
+  Type extends string = string,
+  Data extends DefaultRecord = DefaultRecord,
+  MetaData extends DefaultRecord | undefined = undefined,
+> = Command<Type, Data, MetaData> | Event<Type, Data, MetaData>;
+
+export type MessageKindOf<T extends Message> = T['kind'];
+export type MessageTypeOf<T extends Message> = T['type'];
+export type MessageDataOf<T extends Message> = T['data'];
+export type MessageMetaDataOf<T extends Message> = T extends {
+  metadata: infer M;
+}
+  ? M
+  : undefined;
+
+export type CanHandle<T extends Message> = MessageTypeOf<T>[];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const message = <MessageType extends Message<string, any, any>>(
+  ...args: MessageMetaDataOf<MessageType> extends undefined
+    ? [
+        kind: MessageKindOf<MessageType>,
+        type: MessageTypeOf<MessageType>,
+        data: MessageDataOf<MessageType>,
+      ]
+    : [
+        kind: MessageKindOf<MessageType>,
+        type: MessageTypeOf<MessageType>,
+        data: MessageDataOf<MessageType>,
+        metadata: MessageMetaDataOf<MessageType>,
+      ]
+): MessageType => {
+  const [kind, type, data, metadata] = args;
+
+  return metadata !== undefined
+    ? ({ type, data, metadata, kind } as MessageType)
+    : ({ type, data, kind } as MessageType);
+};
+
+export type CombinedRecordedMessageMetadata<
+  MessageType extends Message = Message,
+  MessageMetaDataType extends
+    AnyRecordedMessageMetadata = AnyRecordedMessageMetadata,
+> =
+  MessageMetaDataOf<MessageType> extends undefined
+    ? MessageMetaDataType
+    : MessageMetaDataOf<MessageType> & MessageMetaDataType;
+
+export type RecordedMessage<
+  MessageType extends Message = Message,
+  MessageMetaDataType extends
+    AnyRecordedMessageMetadata = AnyRecordedMessageMetadata,
+> = MessageType & {
+  kind: NonNullable<MessageKindOf<Message>>;
+  metadata: CombinedRecordedMessageMetadata<MessageType, MessageMetaDataType>;
+};
+
+export type CommonRecordedMessageMetadata<
+  StreamPosition = BigIntStreamPosition,
+> = Readonly<{
+  messageId: string;
+  streamPosition: StreamPosition;
+  streamName: string;
+}>;
+
+export type WithGlobalPosition<GlobalPosition> = Readonly<{
+  globalPosition: GlobalPosition;
+}>;
+
+export type RecordedMessageMetadata<
+  GlobalPosition = undefined,
+  StreamPosition = BigIntStreamPosition,
+> = CommonRecordedMessageMetadata<StreamPosition> &
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  (GlobalPosition extends undefined ? {} : WithGlobalPosition<GlobalPosition>);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyRecordedMessageMetadata = RecordedMessageMetadata<any, any>;
+
+export type RecordedMessageMetadataWithGlobalPosition<
+  GlobalPosition = BigIntGlobalPosition,
+> = RecordedMessageMetadata<GlobalPosition>;
+
+export type RecordedMessageMetadataWithoutGlobalPosition<
+  StreamPosition = BigIntStreamPosition,
+> = RecordedMessageMetadata<undefined, StreamPosition>;
+
+export type GlobalPositionTypeOfRecordedMessageMetadata<
+  RecordedMessageMetadataType,
+> =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  RecordedMessageMetadataType extends RecordedMessageMetadata<infer GP, any>
+    ? GP
+    : never;
+
+export type StreamPositionTypeOfRecordedMessageMetadata<
+  RecordedMessageMetadataType,
+> =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  RecordedMessageMetadataType extends RecordedMessageMetadata<any, infer SV>
+    ? SV
+    : never;


### PR DESCRIPTION
This is the first step in enabling message storage and workflows.

It adds a Message type that's either a command or an event. I added an additional property called kind, which will inform you what the message actually is (so if it's an event or command).

The next step is to adjust the stores to keep that information. I will also rename tables and columns to have event in their names instead of message (e.g., message ID, message type, etc.). MongoDB event store is already adjusted to some degree to that. Eventually, event stores will become message stores. Of course, I want to keep the abstractions as we have, but probably as aliases. See this in follow up PR: https://github.com/event-driven-io/emmett/pull/184

Thanks to that, Emmett will be able to store and then handle async workflows as described in https://event-driven.io/en/how_to_have_fun_with_typescript_and_workflow/. Commands will be stored either in the stream together with events or in a dedicated "outgoing commands stream".

Thanks to having mentioned earlier kind  when building the state, we'll be able to just read the events.

As an alternative to kind I was considering renaming type property in Command and Event types to commandType and eventType. Then we could benefit from duck typing, but I didn't like that fully, as in general both Commands and Events are just Messages, so that'd be a bit too expressive imho.

Of course, the kind will not be required to be provided in the regular code. It will probably only be used in workflows to distinguish if we're sending command or storing event.

It will always be available upon reading. As it'll be stored.
