### PR TITLE
Renamed consumer subscriptions to processors

### DIFF
--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.handling.int.spec.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.handling.int.spec.ts
@@ -14,7 +14,7 @@ import {
   eventStoreDBEventStoreConsumer,
   type EventStoreDBEventStoreConsumerType,
 } from './eventStoreDBEventStoreConsumer';
-import type { EventStoreDBEventStoreSubscriptionOptions } from './eventStoreDBEventStoreSubscription';
+import type { EventStoreDBEventStoreProcessorOptions } from './eventStoreDBEventStoreProcessor';
 
 void describe('EventStoreDB event store started consumer', () => {
   let eventStoreDB: StartedEventStoreDBContainer;
@@ -45,7 +45,7 @@ void describe('EventStoreDB event store started consumer', () => {
 
   consumeFrom.forEach(([displayName, from]) => {
     void describe('eachMessage', () => {
-      void it(`handles all events from ${displayName} appended to event store BEFORE subscription was started`, async () => {
+      void it(`handles all events from ${displayName} appended to event store BEFORE processor was started`, async () => {
         // Given
         const guestId = uuid();
         const streamName = `guestStay-${guestId}`;
@@ -65,8 +65,8 @@ void describe('EventStoreDB event store started consumer', () => {
           connectionString,
           from: from(streamName),
         });
-        consumer.subscribe<GuestStayEvent>({
-          subscriptionId: uuid(),
+        consumer.processor<GuestStayEvent>({
+          processorId: uuid(),
           stopAfter: (event) =>
             event.metadata.globalPosition ===
             appendResult.lastEventGlobalPosition,
@@ -84,7 +84,7 @@ void describe('EventStoreDB event store started consumer', () => {
         }
       });
 
-      void it(`handles all events from ${displayName} appended to event store AFTER subscription was started`, async () => {
+      void it(`handles all events from ${displayName} appended to event store AFTER processor was started`, async () => {
         // Given
 
         const result: GuestStayEvent[] = [];
@@ -98,8 +98,8 @@ void describe('EventStoreDB event store started consumer', () => {
           connectionString,
           from: from(streamName),
         });
-        consumer.subscribe<GuestStayEvent>({
-          subscriptionId: uuid(),
+        consumer.processor<GuestStayEvent>({
+          processorId: uuid(),
           stopAfter: (event) =>
             event.metadata.globalPosition === stopAfterPosition,
           eachMessage: (event) => {
@@ -155,8 +155,8 @@ void describe('EventStoreDB event store started consumer', () => {
           connectionString,
           from: from(streamName),
         });
-        consumer.subscribe<GuestStayEvent>({
-          subscriptionId: uuid(),
+        consumer.processor<GuestStayEvent>({
+          processorId: uuid(),
           startFrom: { position: startPosition },
           stopAfter: (event) =>
             event.metadata.globalPosition === stopAfterPosition,
@@ -208,8 +208,8 @@ void describe('EventStoreDB event store started consumer', () => {
           connectionString,
           from: from(streamName),
         });
-        consumer.subscribe<GuestStayEvent>({
-          subscriptionId: uuid(),
+        consumer.processor<GuestStayEvent>({
+          processorId: uuid(),
           startFrom: 'CURRENT',
           stopAfter: (event) =>
             event.metadata.globalPosition === stopAfterPosition,
@@ -266,8 +266,8 @@ void describe('EventStoreDB event store started consumer', () => {
           connectionString,
           from: from(streamName),
         });
-        consumer.subscribe<GuestStayEvent>({
-          subscriptionId: uuid(),
+        consumer.processor<GuestStayEvent>({
+          processorId: uuid(),
           startFrom: 'CURRENT',
           stopAfter: (event) =>
             event.metadata.globalPosition === stopAfterPosition,
@@ -323,9 +323,9 @@ void describe('EventStoreDB event store started consumer', () => {
         let result: GuestStayEvent[] = [];
         let stopAfterPosition: bigint | undefined = lastEventGlobalPosition;
 
-        const subscriptionOptions: EventStoreDBEventStoreSubscriptionOptions<GuestStayEvent> =
+        const processorOptions: EventStoreDBEventStoreProcessorOptions<GuestStayEvent> =
           {
-            subscriptionId: uuid(),
+            processorId: uuid(),
             startFrom: 'CURRENT',
             stopAfter: (event) =>
               event.metadata.globalPosition === stopAfterPosition,
@@ -340,7 +340,7 @@ void describe('EventStoreDB event store started consumer', () => {
           from: from(streamName),
         });
         try {
-          consumer.subscribe<GuestStayEvent>(subscriptionOptions);
+          consumer.processor<GuestStayEvent>(processorOptions);
 
           await consumer.start();
         } finally {
@@ -355,7 +355,7 @@ void describe('EventStoreDB event store started consumer', () => {
           connectionString,
           from: from(streamName),
         });
-        newConsumer.subscribe<GuestStayEvent>(subscriptionOptions);
+        newConsumer.processor<GuestStayEvent>(processorOptions);
 
         try {
           const consumerPromise = newConsumer.start();

--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.int.spec.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.int.spec.ts
@@ -15,12 +15,12 @@ import {
   eventStoreDBEventStoreConsumer,
   type EventStoreDBEventStoreConsumer,
 } from './eventStoreDBEventStoreConsumer';
-import type { EventStoreDBEventStoreSubscription } from './eventStoreDBEventStoreSubscription';
+import type { EventStoreDBEventStoreProcessor } from './eventStoreDBEventStoreProcessor';
 
 void describe('EventStoreDB event store consumer', () => {
   let eventStoreDB: StartedEventStoreDBContainer;
   let connectionString: string;
-  const dummySubscription: EventStoreDBEventStoreSubscription = {
+  const dummyProcessor: EventStoreDBEventStoreProcessor = {
     id: uuid(),
     start: () => Promise.resolve('BEGINNING'),
     handle: () => Promise.resolve(),
@@ -43,7 +43,7 @@ void describe('EventStoreDB event store consumer', () => {
   void it('creates not-started consumer for the specified connection string', () => {
     const consumer = eventStoreDBEventStoreConsumer({
       connectionString,
-      subscriptions: [dummySubscription],
+      processors: [dummyProcessor],
     });
 
     assertFalse(consumer.isRunning);
@@ -54,7 +54,7 @@ void describe('EventStoreDB event store consumer', () => {
       'esdb://not-existing:2113?tls=false';
     const consumer = eventStoreDBEventStoreConsumer({
       connectionString: connectionStringToNotExistingDB,
-      subscriptions: [dummySubscription],
+      processors: [dummyProcessor],
     });
 
     assertFalse(consumer.isRunning);
@@ -66,7 +66,7 @@ void describe('EventStoreDB event store consumer', () => {
     beforeEach(() => {
       consumer = eventStoreDBEventStoreConsumer({
         connectionString,
-        subscriptions: [dummySubscription],
+        processors: [dummyProcessor],
       });
     });
     afterEach(() => consumer.stop());
@@ -82,7 +82,7 @@ void describe('EventStoreDB event store consumer', () => {
         'esdb://not-existing:2113?tls=false';
       const consumerToNotExistingServer = eventStoreDBEventStoreConsumer({
         connectionString: connectionStringToNotExistingDB,
-        subscriptions: [dummySubscription],
+        processors: [dummyProcessor],
       });
       await assertThrowsAsync(
         () => consumerToNotExistingServer.start(),
@@ -92,17 +92,17 @@ void describe('EventStoreDB event store consumer', () => {
       );
     });
 
-    void it('fails to start if there are no subscriptions', async () => {
+    void it('fails to start if there are no processors', async () => {
       const consumerToNotExistingServer = eventStoreDBEventStoreConsumer({
         connectionString,
-        subscriptions: [],
+        processors: [],
       });
       await assertThrowsAsync<EmmettError>(
         () => consumerToNotExistingServer.start(),
         (error) => {
           return (
             error.message ===
-            'Cannot start consumer without at least a single subscription'
+            'Cannot start consumer without at least a single processor'
           );
         },
       );
@@ -128,7 +128,7 @@ void describe('EventStoreDB event store consumer', () => {
     beforeEach(() => {
       consumer = eventStoreDBEventStoreConsumer({
         connectionString,
-        subscriptions: [dummySubscription],
+        processors: [dummyProcessor],
       });
     });
     afterEach(() => consumer.stop());

--- a/src/packages/emmett-esdb/src/eventStore/consumers/index.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/index.ts
@@ -1,0 +1,3 @@
+export * from './eventStoreDBEventStoreConsumer';
+export * from './eventStoreDBEventStoreProcessor';
+export * from './subscriptions';

--- a/src/packages/emmett-esdb/src/eventStore/index.ts
+++ b/src/packages/emmett-esdb/src/eventStore/index.ts
@@ -1,1 +1,2 @@
+export * from './consumers';
 export * from './eventstoreDBEventStore';

--- a/src/packages/emmett-esdb/src/eventStore/subscriptions/index.ts
+++ b/src/packages/emmett-esdb/src/eventStore/subscriptions/index.ts
@@ -1,3 +1,0 @@
-export * from './eventStoreDBEventStoreConsumer';
-export * from './eventStoreDBEventStoreSubscription';
-export * from './messageBatchProcessing';

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/index.ts
@@ -1,3 +1,3 @@
 export * from './messageBatchProcessing';
 export * from './postgreSQLEventStoreConsumer';
-export * from './postgreSQLEventStoreSubscription';
+export * from './postgreSQLProcessor';

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/messageBatchProcessing/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/messageBatchProcessing/index.ts
@@ -11,8 +11,8 @@ import {
   type ReadMessagesBatchOptions,
 } from '../../schema/readMessagesBatch';
 
-export const DefaultPostgreSQLEventStoreSubscriptionBatchSize = 100;
-export const DefaultPostgreSQLEventStoreSubscriptionPullingFrequencyInMs = 50;
+export const DefaultPostgreSQLEventStoreProcessorBatchSize = 100;
+export const DefaultPostgreSQLEventStoreProcessorPullingFrequencyInMs = 50;
 
 export type PostgreSQLEventStoreMessagesBatch<EventType extends Event = Event> =
   {

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.int.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.int.ts
@@ -19,13 +19,13 @@ import {
   postgreSQLEventStoreConsumer,
   type PostgreSQLEventStoreConsumer,
 } from './postgreSQLEventStoreConsumer';
-import type { PostgreSQLEventStoreSubscription } from './postgreSQLEventStoreSubscription';
+import type { PostgreSQLProcessor } from './postgreSQLProcessor';
 
 void describe('PostgreSQL event store consumer', () => {
   let postgres: StartedPostgreSqlContainer;
   let connectionString: string;
   let eventStore: PostgresEventStore;
-  const dummySubscription: PostgreSQLEventStoreSubscription = {
+  const dummyProcessor: PostgreSQLProcessor = {
     id: uuid(),
     start: () => Promise.resolve('BEGINNING'),
     handle: () => Promise.resolve(),
@@ -51,7 +51,7 @@ void describe('PostgreSQL event store consumer', () => {
   void it('creates not-started consumer for the specified connection string', () => {
     const consumer = postgreSQLEventStoreConsumer({
       connectionString,
-      subscriptions: [dummySubscription],
+      processors: [dummyProcessor],
     });
 
     assertFalse(consumer.isRunning);
@@ -62,7 +62,7 @@ void describe('PostgreSQL event store consumer', () => {
       'postgresql://postgres:postgres@not-existing-database:5432/postgres';
     const consumer = postgreSQLEventStoreConsumer({
       connectionString: connectionStringToNotExistingDB,
-      subscriptions: [dummySubscription],
+      processors: [dummyProcessor],
     });
 
     assertFalse(consumer.isRunning);
@@ -74,7 +74,7 @@ void describe('PostgreSQL event store consumer', () => {
     beforeEach(() => {
       consumer = postgreSQLEventStoreConsumer({
         connectionString,
-        subscriptions: [dummySubscription],
+        processors: [dummyProcessor],
       });
     });
     afterEach(() => consumer.stop());
@@ -90,7 +90,7 @@ void describe('PostgreSQL event store consumer', () => {
         'postgresql://postgres:postgres@not-existing-database:5432/postgres';
       const consumerToNotExistingServer = postgreSQLEventStoreConsumer({
         connectionString: connectionStringToNotExistingDB,
-        subscriptions: [dummySubscription],
+        processors: [dummyProcessor],
       });
       await assertThrowsAsync(
         () => consumerToNotExistingServer.start(),
@@ -100,17 +100,17 @@ void describe('PostgreSQL event store consumer', () => {
       );
     });
 
-    void it('fails to start if there are no subscriptions', async () => {
+    void it('fails to start if there are no processors', async () => {
       const consumerToNotExistingServer = postgreSQLEventStoreConsumer({
         connectionString,
-        subscriptions: [],
+        processors: [],
       });
       await assertThrowsAsync<EmmettError>(
         () => consumerToNotExistingServer.start(),
         (error) => {
           return (
             error.message ===
-            'Cannot start consumer without at least a single subscription'
+            'Cannot start consumer without at least a single processor'
           );
         },
       );
@@ -136,7 +136,7 @@ void describe('PostgreSQL event store consumer', () => {
     beforeEach(() => {
       consumer = postgreSQLEventStoreConsumer({
         connectionString,
-        subscriptions: [dummySubscription],
+        processors: [dummyProcessor],
       });
     });
     afterEach(() => consumer.stop());

--- a/src/packages/emmett-postgresql/src/eventStore/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/index.ts
@@ -1,4 +1,4 @@
 export * from './postgreSQLEventStore';
 export * from './projections';
 export * from './schema';
-export * from './subscriptions';
+export * from './consumers';

--- a/src/packages/emmett-postgresql/src/eventStore/schema/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/index.ts
@@ -1,6 +1,6 @@
 import { type NodePostgresPool, type SQL } from '@event-driven-io/dumbo';
 import { appendEventsSQL } from './appendToStream';
-import { storeSubscriptionCheckpointSQL } from './storeSubscriptionCheckpoint';
+import { storeSubscriptionCheckpointSQL } from './storeProcessorCheckpoint';
 import {
   addDefaultPartition,
   addEventsPartitions,
@@ -19,8 +19,8 @@ export * from './appendToStream';
 export * from './readLastMessageGlobalPosition';
 export * from './readMessagesBatch';
 export * from './readStream';
-export * from './readSubscriptionCheckpoint';
-export * from './storeSubscriptionCheckpoint';
+export * from './readProcessorCheckpoint';
+export * from './storeProcessorCheckpoint';
 export * from './tables';
 export * from './typing';
 

--- a/src/packages/emmett-postgresql/src/eventStore/schema/readProcessorCheckpoint.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/readProcessorCheckpoint.ts
@@ -1,27 +1,27 @@
 import { singleOrNull, sql, type SQLExecutor } from '@event-driven-io/dumbo';
 import { defaultTag, subscriptionsTable } from './typing';
 
-type ReadSubscriptionCheckpointSqlResult = {
+type ReadProcessorCheckpointSqlResult = {
   last_processed_position: string;
 };
 
-export type ReadSubscriptionCheckpointResult = {
+export type ReadProcessorCheckpointResult = {
   lastProcessedPosition: bigint | null;
 };
 
-export const readSubscriptionCheckpoint = async (
+export const readProcessorCheckpoint = async (
   execute: SQLExecutor,
-  options: { subscriptionId: string; partition?: string },
-): Promise<ReadSubscriptionCheckpointResult> => {
+  options: { processorId: string; partition?: string },
+): Promise<ReadProcessorCheckpointResult> => {
   const result = await singleOrNull(
-    execute.query<ReadSubscriptionCheckpointSqlResult>(
+    execute.query<ReadProcessorCheckpointSqlResult>(
       sql(
         `SELECT last_processed_position
            FROM ${subscriptionsTable.name}
            WHERE partition = %L AND subscription_id = %L
            LIMIT 1`,
         options?.partition ?? defaultTag,
-        options.subscriptionId,
+        options.processorId,
       ),
     ),
   );

--- a/src/packages/emmett-postgresql/src/eventStore/schema/storeProcessorCheckpoint.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/storeProcessorCheckpoint.ts
@@ -62,7 +62,7 @@ END;
 $$ LANGUAGE plpgsql;
 `);
 
-export type StoreLastProcessedSubscriptionPositionResult<
+export type StoreLastProcessedProcessorPositionResult<
   Position extends bigint | null = bigint,
 > =
   | {
@@ -71,42 +71,42 @@ export type StoreLastProcessedSubscriptionPositionResult<
     }
   | { success: false; reason: 'IGNORED' | 'MISMATCH' };
 
-export function storeSubscriptionCheckpoint(
+export function storeProcessorCheckpoint(
   execute: SQLExecutor,
   options: {
-    subscriptionId: string;
+    processorId: string;
     version: number | undefined;
     newPosition: bigint | null;
     lastProcessedPosition: bigint | null;
     partition?: string;
   },
-): Promise<StoreLastProcessedSubscriptionPositionResult<bigint | null>>;
-export function storeSubscriptionCheckpoint(
+): Promise<StoreLastProcessedProcessorPositionResult<bigint | null>>;
+export function storeProcessorCheckpoint(
   execute: SQLExecutor,
   options: {
-    subscriptionId: string;
+    processorId: string;
     version: number | undefined;
     newPosition: bigint;
     lastProcessedPosition: bigint | null;
     partition?: string;
   },
-): Promise<StoreLastProcessedSubscriptionPositionResult<bigint>>;
-export async function storeSubscriptionCheckpoint(
+): Promise<StoreLastProcessedProcessorPositionResult<bigint>>;
+export async function storeProcessorCheckpoint(
   execute: SQLExecutor,
   options: {
-    subscriptionId: string;
+    processorId: string;
     version: number | undefined;
     newPosition: bigint | null;
     lastProcessedPosition: bigint | null;
     partition?: string;
   },
-): Promise<StoreLastProcessedSubscriptionPositionResult<bigint | null>> {
+): Promise<StoreLastProcessedProcessorPositionResult<bigint | null>> {
   try {
     const { result } = await single(
       execute.command<{ result: 0 | 1 | 2 }>(
         sql(
           `SELECT store_subscription_checkpoint(%L, %s, %L, %L, pg_current_xact_id(), %L) as result;`,
-          options.subscriptionId,
+          options.processorId,
           options.version ?? 1,
           options.newPosition,
           options.lastProcessedPosition,


### PR DESCRIPTION
Initially, I came up with the following split:
- **Consumers** - primarily responsible for pushing messages to multiple handlers/subscribers.
- **Subscribers** -  diverse roles: Some store data, some trigger workflows, and some forward to other systems. Checkpointing is subscriber-specific, meaning each subscriber manages its own message state independently.

Still, after discussion, it appeared that Subscription in this context may be wrong or confusing. This could work to describe the relationship between the consumer and its individual subscribers. However, "subscription" often implies pub/sub semantics, where the subscriber initiates the relationship, which might not match your push-based model. 

Subscription is a widely understood term for entities that receive and process messages. However, since Emmetts’s subscribers also checkpoint and process messages independently, I decided to name them Processors.

Processor term is also common in event-processing frameworks, especially when the focus is on message handling or transformation. Processor is an independent unit that receives messages and performs an action (e.g., running a workflow, updating projections, forwarding to another service).