### PR TITLE
Added possibility to create consumers from directly from event stores

### DIFF
--- a/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.ts
+++ b/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.ts
@@ -28,6 +28,11 @@ import {
   type ReadStreamOptions as ESDBReadStreamOptions,
   type JSONRecordedEvent,
 } from '@eventstore/db-client';
+import {
+  eventStoreDBEventStoreConsumer,
+  type EventStoreDBEventStoreConsumer,
+  type EventStoreDBEventStoreConsumerConfig,
+} from './consumers';
 
 const toEventStoreDBReadOptions = (
   options: ReadStreamOptions | undefined,
@@ -61,6 +66,9 @@ export interface EventStoreDBEventStore
     events: EventType[],
     options?: AppendToStreamOptions,
   ): Promise<AppendToStreamResultWithGlobalPosition>;
+  consumer<ConsumerEventType extends Event = Event>(
+    options: EventStoreDBEventStoreConsumerConfig<ConsumerEventType>,
+  ): EventStoreDBEventStoreConsumer<ConsumerEventType>;
 }
 
 export const getEventStoreDBEventStore = (
@@ -201,6 +209,14 @@ export const getEventStoreDBEventStore = (
         throw error;
       }
     },
+
+    consumer: <ConsumerEventType extends Event = Event>(
+      options: EventStoreDBEventStoreConsumerConfig<ConsumerEventType>,
+    ): EventStoreDBEventStoreConsumer<ConsumerEventType> =>
+      eventStoreDBEventStoreConsumer<ConsumerEventType>({
+        ...options,
+        eventStoreDBClient: eventStore,
+      }),
 
     //streamEvents: streamEvents(eventStore),
   };

--- a/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.ts
@@ -26,6 +26,11 @@ import {
 } from '@event-driven-io/emmett';
 import pg from 'pg';
 import {
+  postgreSQLEventStoreConsumer,
+  type PostgreSQLEventStoreConsumer,
+  type PostgreSQLEventStoreConsumerConfig,
+} from './consumers';
+import {
   handleProjections,
   type PostgreSQLProjectionHandlerContext,
 } from './projections';
@@ -45,6 +50,9 @@ export interface PostgresEventStore
     events: EventType[],
     options?: AppendToStreamOptions,
   ): Promise<AppendToStreamResultWithGlobalPosition>;
+  consumer<ConsumerEventType extends Event = Event>(
+    options: PostgreSQLEventStoreConsumerConfig<ConsumerEventType>,
+  ): PostgreSQLEventStoreConsumer<ConsumerEventType>;
   close(): Promise<void>;
   schema: {
     sql(): string;
@@ -275,6 +283,10 @@ export const getPostgreSQLEventStore = (
           appendResult.nextStreamPosition >= BigInt(events.length),
       };
     },
+    consumer: <ConsumerEventType extends Event = Event>(
+      options: PostgreSQLEventStoreConsumerConfig<ConsumerEventType>,
+    ): PostgreSQLEventStoreConsumer<ConsumerEventType> =>
+      postgreSQLEventStoreConsumer<ConsumerEventType>({ ...options, pool }),
     close: () => pool.close(),
 
     async withSession<T = unknown>(


### PR DESCRIPTION
This will allow the PostgreSQL pool or EventStoreDB client to be reused, simplifying the potential setup and increasing performance.

@mbirkegaard fyi