### PR TITLE
Made consumer options really optional when creating it from event stores

### DIFF
--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreProcessor.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreProcessor.ts
@@ -17,12 +17,12 @@ export type EventStoreDBEventStoreProcessorEventsBatch<
 export type EventStoreDBEventStoreProcessor<EventType extends Event = Event> = {
   id: string;
   start: (
-    eventStoreDBClient: EventStoreDBClient,
+    client: EventStoreDBClient,
   ) => Promise<EventStoreDBSubscriptionStartFrom | undefined>;
   isActive: boolean;
   handle: (
     messagesBatch: EventStoreDBEventStoreProcessorEventsBatch<EventType>,
-    context: { eventStoreDBClient: EventStoreDBClient },
+    context: { client: EventStoreDBClient },
   ) => Promise<EventStoreDBEventStoreProcessorMessageHandlerResult>;
 };
 
@@ -88,7 +88,7 @@ export const eventStoreDBEventStoreProcessor = <
   return {
     id: options.processorId,
     start: (
-      _eventStoreDBClient: EventStoreDBClient,
+      _client: EventStoreDBClient,
     ): Promise<EventStoreDBSubscriptionStartFrom | undefined> => {
       isActive = true;
       if (options.startFrom !== 'CURRENT')

--- a/src/packages/emmett-esdb/src/eventStore/consumers/subscriptions/index.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/subscriptions/index.ts
@@ -44,7 +44,7 @@ export type EventStoreDBEventStoreMessagesBatchHandler<
 
 export type EventStoreDBSubscriptionOptions<EventType extends Event = Event> = {
   from?: EventStoreDBEventStoreConsumerType;
-  eventStoreDBClient: EventStoreDBClient;
+  client: EventStoreDBClient;
   batchSize: number;
   eachBatch: EventStoreDBEventStoreMessagesBatchHandler<EventType>;
 };
@@ -82,23 +82,23 @@ const toStreamPosition = (startFrom: EventStoreDBSubscriptionStartFrom) =>
       : startFrom.position;
 
 const subscribe = (
-  eventStoreDBClient: EventStoreDBClient,
+  client: EventStoreDBClient,
   from: EventStoreDBEventStoreConsumerType | undefined,
   options: EventStoreDBSubscriptionStartOptions,
 ) =>
   from == undefined || from.stream == $all
-    ? eventStoreDBClient.subscribeToAll({
+    ? client.subscribeToAll({
         fromPosition: toGlobalPosition(options.startFrom),
         filter: excludeSystemEvents(),
         ...(from?.options ?? {}),
       })
-    : eventStoreDBClient.subscribeToStream(from.stream, {
+    : client.subscribeToStream(from.stream, {
         fromRevision: toStreamPosition(options.startFrom),
         ...(from.options ?? {}),
       });
 
 export const eventStoreDBSubscription = <EventType extends Event = Event>({
-  eventStoreDBClient,
+  client,
   from,
   //batchSize,
   eachBatch,
@@ -112,7 +112,7 @@ export const eventStoreDBSubscription = <EventType extends Event = Event>({
   const pullMessages = async (
     options: EventStoreDBSubscriptionStartOptions,
   ) => {
-    subscription = subscribe(eventStoreDBClient, from, options);
+    subscription = subscribe(client, from, options);
 
     return new Promise<void>((resolve, reject) => {
       finished(

--- a/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.ts
+++ b/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.ts
@@ -67,7 +67,7 @@ export interface EventStoreDBEventStore
     options?: AppendToStreamOptions,
   ): Promise<AppendToStreamResultWithGlobalPosition>;
   consumer<ConsumerEventType extends Event = Event>(
-    options: EventStoreDBEventStoreConsumerConfig<ConsumerEventType>,
+    options?: EventStoreDBEventStoreConsumerConfig<ConsumerEventType>,
   ): EventStoreDBEventStoreConsumer<ConsumerEventType>;
 }
 
@@ -211,11 +211,11 @@ export const getEventStoreDBEventStore = (
     },
 
     consumer: <ConsumerEventType extends Event = Event>(
-      options: EventStoreDBEventStoreConsumerConfig<ConsumerEventType>,
+      options?: EventStoreDBEventStoreConsumerConfig<ConsumerEventType>,
     ): EventStoreDBEventStoreConsumer<ConsumerEventType> =>
       eventStoreDBEventStoreConsumer<ConsumerEventType>({
-        ...options,
-        eventStoreDBClient: eventStore,
+        ...(options ?? {}),
+        client: eventStore,
       }),
 
     //streamEvents: streamEvents(eventStore),

--- a/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.ts
@@ -51,7 +51,7 @@ export interface PostgresEventStore
     options?: AppendToStreamOptions,
   ): Promise<AppendToStreamResultWithGlobalPosition>;
   consumer<ConsumerEventType extends Event = Event>(
-    options: PostgreSQLEventStoreConsumerConfig<ConsumerEventType>,
+    options?: PostgreSQLEventStoreConsumerConfig<ConsumerEventType>,
   ): PostgreSQLEventStoreConsumer<ConsumerEventType>;
   close(): Promise<void>;
   schema: {
@@ -284,9 +284,12 @@ export const getPostgreSQLEventStore = (
       };
     },
     consumer: <ConsumerEventType extends Event = Event>(
-      options: PostgreSQLEventStoreConsumerConfig<ConsumerEventType>,
+      options?: PostgreSQLEventStoreConsumerConfig<ConsumerEventType>,
     ): PostgreSQLEventStoreConsumer<ConsumerEventType> =>
-      postgreSQLEventStoreConsumer<ConsumerEventType>({ ...options, pool }),
+      postgreSQLEventStoreConsumer<ConsumerEventType>({
+        ...(options ?? {}),
+        pool,
+      }),
     close: () => pool.close(),
 
     async withSession<T = unknown>(


### PR DESCRIPTION
By accident, a leftover forced the user to still provide an empty object, which doesn't make sense as it should be passed.

@mbirkegaard FYI