### PR TITLE
Added the first version of PostgreSQL async projections

### DIFF
--- a/src/packages/emmett-mongodb/src/eventStore/projections/mongoDBInlineProjection.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/projections/mongoDBInlineProjection.ts
@@ -1,9 +1,9 @@
 import {
   type CanHandle,
   type Event,
+  type ProjectionDefinition,
   type ProjectionHandler,
   type ReadEvent,
-  type TypedProjectionDefinition,
 } from '@event-driven-io/emmett';
 import type { Collection, Document, UpdateFilter } from 'mongodb';
 import type {
@@ -37,7 +37,7 @@ export type MongoDBInlineProjectionHandler<
 export type MongoDBInlineProjectionDefinition<
   EventType extends Event = Event,
   EventMetaDataType extends MongoDBReadEventMetadata = MongoDBReadEventMetadata,
-> = TypedProjectionDefinition<
+> = ProjectionDefinition<
   EventType,
   EventMetaDataType,
   MongoDBProjectionInlineHandlerContext

--- a/src/packages/emmett-postgresql/src/eventStore/commandHandler.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/commandHandler.int.spec.ts
@@ -3,7 +3,6 @@ import {
   assertEqual,
   assertIsNotNull,
   CommandHandler,
-  projections,
 } from '@event-driven-io/emmett';
 import { pongoClient, type PongoClient } from '@event-driven-io/pongo';
 import {
@@ -35,7 +34,9 @@ void describe('Postgres Projections', () => {
     postgres = await new PostgreSqlContainer().start();
     connectionString = postgres.getConnectionUri();
     eventStore = getPostgreSQLEventStore(connectionString, {
-      projections: projections.inline([shoppingCartShortInfoProjection]),
+      projections: [
+        { type: 'inline', projection: shoppingCartShortInfoProjection },
+      ],
       schema: {
         autoMigration: 'None',
       },

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.projections.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.projections.int.spec.ts
@@ -1,0 +1,388 @@
+import { assertThatArray, type Event } from '@event-driven-io/emmett';
+import {
+  PostgreSqlContainer,
+  StartedPostgreSqlContainer,
+} from '@testcontainers/postgresql';
+import { after, before, describe, it } from 'node:test';
+import { v4 as uuid } from 'uuid';
+import {
+  getPostgreSQLEventStore,
+  type PostgresEventStore,
+} from '../postgreSQLEventStore';
+import { postgreSQLEventStoreConsumer } from './postgreSQLEventStoreConsumer';
+import type { PostgreSQLProcessorOptions } from './postgreSQLProcessor';
+
+const withDeadline = { timeout: 5000 };
+
+void describe('PostgreSQL event store started consumer', () => {
+  let postgres: StartedPostgreSqlContainer;
+  let connectionString: string;
+  let eventStore: PostgresEventStore;
+
+  before(async () => {
+    postgres = await new PostgreSqlContainer().start();
+    connectionString = postgres.getConnectionUri();
+    eventStore = getPostgreSQLEventStore(connectionString);
+    await eventStore.schema.migrate();
+  });
+
+  after(async () => {
+    try {
+      await eventStore.close();
+      await postgres.stop();
+    } catch (error) {
+      console.log(error);
+    }
+  });
+
+  void describe('eachMessage', () => {
+    void it(
+      'handles all events appended to event store BEFORE processor was started',
+      withDeadline,
+      async () => {
+        // Given
+        const guestId = uuid();
+        const streamName = `guestStay-${guestId}`;
+        const events: GuestStayEvent[] = [
+          { type: 'GuestCheckedIn', data: { guestId } },
+          { type: 'GuestCheckedOut', data: { guestId } },
+        ];
+        const appendResult = await eventStore.appendToStream(
+          streamName,
+          events,
+        );
+
+        const result: GuestStayEvent[] = [];
+
+        // When
+        const consumer = postgreSQLEventStoreConsumer({
+          connectionString,
+        });
+        consumer.processor<GuestStayEvent>({
+          processorId: uuid(),
+          stopAfter: (event) =>
+            event.metadata.globalPosition ===
+            appendResult.lastEventGlobalPosition,
+          eachMessage: (event) => {
+            result.push(event);
+          },
+        });
+
+        try {
+          await consumer.start();
+
+          assertThatArray(result).containsElementsMatching(events);
+        } finally {
+          await consumer.close();
+        }
+      },
+    );
+
+    void it(
+      'handles all events appended to event store AFTER processor was started',
+      withDeadline,
+      async () => {
+        // Given
+
+        const result: GuestStayEvent[] = [];
+        let stopAfterPosition: bigint | undefined = undefined;
+
+        // When
+        const consumer = postgreSQLEventStoreConsumer({
+          connectionString,
+        });
+        consumer.processor<GuestStayEvent>({
+          processorId: uuid(),
+          stopAfter: (event) =>
+            event.metadata.globalPosition === stopAfterPosition,
+          eachMessage: (event) => {
+            result.push(event);
+          },
+        });
+
+        const guestId = uuid();
+        const streamName = `guestStay-${guestId}`;
+        const events: GuestStayEvent[] = [
+          { type: 'GuestCheckedIn', data: { guestId } },
+          { type: 'GuestCheckedOut', data: { guestId } },
+        ];
+
+        try {
+          const consumerPromise = consumer.start();
+
+          const appendResult = await eventStore.appendToStream(
+            streamName,
+            events,
+          );
+          stopAfterPosition = appendResult.lastEventGlobalPosition;
+
+          await consumerPromise;
+
+          assertThatArray(result).containsElementsMatching(events);
+        } finally {
+          await consumer.close();
+        }
+      },
+    );
+
+    void it(
+      'handles ONLY events AFTER provided global position',
+      withDeadline,
+      async () => {
+        // Given
+        const guestId = uuid();
+        const otherGuestId = uuid();
+        const streamName = `guestStay-${guestId}`;
+
+        const initialEvents: GuestStayEvent[] = [
+          { type: 'GuestCheckedIn', data: { guestId } },
+          { type: 'GuestCheckedOut', data: { guestId } },
+        ];
+        const { lastEventGlobalPosition: startPosition } =
+          await eventStore.appendToStream(streamName, initialEvents);
+
+        const events: GuestStayEvent[] = [
+          { type: 'GuestCheckedIn', data: { guestId: otherGuestId } },
+          { type: 'GuestCheckedOut', data: { guestId: otherGuestId } },
+        ];
+
+        const result: GuestStayEvent[] = [];
+        let stopAfterPosition: bigint | undefined = undefined;
+
+        // When
+        const consumer = postgreSQLEventStoreConsumer({
+          connectionString,
+        });
+        consumer.processor<GuestStayEvent>({
+          processorId: uuid(),
+          startFrom: { globalPosition: startPosition },
+          stopAfter: (event) =>
+            event.metadata.globalPosition === stopAfterPosition,
+          eachMessage: (event) => {
+            result.push(event);
+          },
+        });
+
+        try {
+          const consumerPromise = consumer.start();
+
+          const appendResult = await eventStore.appendToStream(
+            streamName,
+            events,
+          );
+          stopAfterPosition = appendResult.lastEventGlobalPosition;
+
+          await consumerPromise;
+
+          assertThatArray(result).containsOnlyElementsMatching(events);
+        } finally {
+          await consumer.close();
+        }
+      },
+    );
+
+    void it(
+      'handles all events when CURRENT position is NOT stored',
+      withDeadline,
+      async () => {
+        // Given
+        const guestId = uuid();
+        const otherGuestId = uuid();
+        const streamName = `guestStay-${guestId}`;
+
+        const initialEvents: GuestStayEvent[] = [
+          { type: 'GuestCheckedIn', data: { guestId } },
+          { type: 'GuestCheckedOut', data: { guestId } },
+        ];
+
+        await eventStore.appendToStream(streamName, initialEvents);
+
+        const events: GuestStayEvent[] = [
+          { type: 'GuestCheckedIn', data: { guestId: otherGuestId } },
+          { type: 'GuestCheckedOut', data: { guestId: otherGuestId } },
+        ];
+
+        const result: GuestStayEvent[] = [];
+        let stopAfterPosition: bigint | undefined = undefined;
+
+        // When
+        const consumer = postgreSQLEventStoreConsumer({
+          connectionString,
+        });
+        consumer.processor<GuestStayEvent>({
+          processorId: uuid(),
+          startFrom: 'CURRENT',
+          stopAfter: (event) =>
+            event.metadata.globalPosition === stopAfterPosition,
+          eachMessage: (event) => {
+            result.push(event);
+          },
+        });
+
+        try {
+          const consumerPromise = consumer.start();
+
+          const appendResult = await eventStore.appendToStream(
+            streamName,
+            events,
+          );
+          stopAfterPosition = appendResult.lastEventGlobalPosition;
+
+          await consumerPromise;
+
+          assertThatArray(result).containsElementsMatching([
+            ...initialEvents,
+            ...events,
+          ]);
+        } finally {
+          await consumer.close();
+        }
+      },
+    );
+
+    void it(
+      'handles only new events when CURRENT position is stored for restarted consumer',
+      withDeadline,
+      async () => {
+        // Given
+        const guestId = uuid();
+        const otherGuestId = uuid();
+        const streamName = `guestStay-${guestId}`;
+
+        const initialEvents: GuestStayEvent[] = [
+          { type: 'GuestCheckedIn', data: { guestId } },
+          { type: 'GuestCheckedOut', data: { guestId } },
+        ];
+        const { lastEventGlobalPosition } = await eventStore.appendToStream(
+          streamName,
+          initialEvents,
+        );
+
+        const events: GuestStayEvent[] = [
+          { type: 'GuestCheckedIn', data: { guestId: otherGuestId } },
+          { type: 'GuestCheckedOut', data: { guestId: otherGuestId } },
+        ];
+
+        let result: GuestStayEvent[] = [];
+        let stopAfterPosition: bigint | undefined = lastEventGlobalPosition;
+
+        // When
+        const consumer = postgreSQLEventStoreConsumer({
+          connectionString,
+        });
+        consumer.processor<GuestStayEvent>({
+          processorId: uuid(),
+          startFrom: 'CURRENT',
+          stopAfter: (event) =>
+            event.metadata.globalPosition === stopAfterPosition,
+          eachMessage: (event) => {
+            result.push(event);
+          },
+        });
+
+        await consumer.start();
+        await consumer.stop();
+
+        result = [];
+
+        stopAfterPosition = undefined;
+
+        try {
+          const consumerPromise = consumer.start();
+
+          const appendResult = await eventStore.appendToStream(
+            streamName,
+            events,
+          );
+          stopAfterPosition = appendResult.lastEventGlobalPosition;
+
+          await consumerPromise;
+
+          assertThatArray(result).containsOnlyElementsMatching(events);
+        } finally {
+          await consumer.close();
+        }
+      },
+    );
+
+    void it(
+      'handles only new events when CURRENT position is stored for a new consumer',
+      withDeadline,
+      async () => {
+        // Given
+        const guestId = uuid();
+        const otherGuestId = uuid();
+        const streamName = `guestStay-${guestId}`;
+
+        const initialEvents: GuestStayEvent[] = [
+          { type: 'GuestCheckedIn', data: { guestId } },
+          { type: 'GuestCheckedOut', data: { guestId } },
+        ];
+        const { lastEventGlobalPosition } = await eventStore.appendToStream(
+          streamName,
+          initialEvents,
+        );
+
+        const events: GuestStayEvent[] = [
+          { type: 'GuestCheckedIn', data: { guestId: otherGuestId } },
+          { type: 'GuestCheckedOut', data: { guestId: otherGuestId } },
+        ];
+
+        let result: GuestStayEvent[] = [];
+        let stopAfterPosition: bigint | undefined = lastEventGlobalPosition;
+
+        const processorOptions: PostgreSQLProcessorOptions<GuestStayEvent> = {
+          processorId: uuid(),
+          startFrom: 'CURRENT',
+          stopAfter: (event) =>
+            event.metadata.globalPosition === stopAfterPosition,
+          eachMessage: (event) => {
+            result.push(event);
+          },
+        };
+
+        // When
+        const consumer = postgreSQLEventStoreConsumer({
+          connectionString,
+        });
+        try {
+          consumer.processor<GuestStayEvent>(processorOptions);
+
+          await consumer.start();
+        } finally {
+          await consumer.close();
+        }
+
+        result = [];
+
+        stopAfterPosition = undefined;
+
+        const newConsumer = postgreSQLEventStoreConsumer({
+          connectionString,
+        });
+        newConsumer.processor<GuestStayEvent>(processorOptions);
+
+        try {
+          const consumerPromise = newConsumer.start();
+
+          const appendResult = await eventStore.appendToStream(
+            streamName,
+            events,
+          );
+          stopAfterPosition = appendResult.lastEventGlobalPosition;
+
+          await consumerPromise;
+
+          assertThatArray(result).containsOnlyElementsMatching(events);
+        } finally {
+          await newConsumer.close();
+        }
+      },
+    );
+  });
+});
+
+type GuestCheckedIn = Event<'GuestCheckedIn', { guestId: string }>;
+type GuestCheckedOut = Event<'GuestCheckedOut', { guestId: string }>;
+
+type GuestStayEvent = GuestCheckedIn | GuestCheckedOut;

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
@@ -1,5 +1,6 @@
 import { dumbo, type Dumbo } from '@event-driven-io/dumbo';
 import { EmmettError, type Event } from '@event-driven-io/emmett';
+import type { PostgreSQLProjectionDefinition } from '../projections';
 import {
   DefaultPostgreSQLEventStoreProcessorBatchSize,
   DefaultPostgreSQLEventStoreProcessorPullingFrequencyInMs,
@@ -10,6 +11,7 @@ import {
 } from './messageBatchProcessing';
 import {
   postgreSQLProcessor,
+  postgreSQLProjectionProcessor,
   type PostgreSQLProcessor,
   type PostgreSQLProcessorOptions,
 } from './postgreSQLProcessor';
@@ -37,6 +39,11 @@ export type PostgreSQLEventStoreConsumer<
   processors: PostgreSQLProcessor<ConsumerEventType>[];
   processor: <EventType extends ConsumerEventType = ConsumerEventType>(
     options: PostgreSQLProcessorOptions<EventType>,
+  ) => PostgreSQLProcessor<EventType>;
+  projectionProcessor: <
+    EventType extends ConsumerEventType = ConsumerEventType,
+  >(
+    projection: PostgreSQLProjectionDefinition<EventType>,
   ) => PostgreSQLProcessor<EventType>;
   start: () => Promise<void>;
   stop: () => Promise<void>;
@@ -120,6 +127,17 @@ export const postgreSQLEventStoreConsumer = <
       options: PostgreSQLProcessorOptions<EventType>,
     ): PostgreSQLProcessor<EventType> => {
       const processor = postgreSQLProcessor<EventType>(options);
+
+      processors.push(processor);
+
+      return processor;
+    },
+    projectionProcessor: <
+      EventType extends ConsumerEventType = ConsumerEventType,
+    >(
+      projection: PostgreSQLProjectionDefinition<EventType>,
+    ): PostgreSQLProcessor<EventType> => {
+      const processor = postgreSQLProjectionProcessor<EventType>(projection);
 
       processors.push(processor);
 

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
@@ -25,13 +25,10 @@ export type PostgreSQLEventStoreConsumerConfig<
 };
 export type PostgreSQLEventStoreConsumerOptions<
   ConsumerEventType extends Event = Event,
-> = PostgreSQLEventStoreConsumerConfig<ConsumerEventType> &
-  (
-    | {
-        connectionString: string;
-      }
-    | { pool: Dumbo }
-  );
+> = PostgreSQLEventStoreConsumerConfig<ConsumerEventType> & {
+  connectionString: string;
+  pool?: Dumbo;
+};
 
 export type PostgreSQLEventStoreConsumer<
   ConsumerEventType extends Event = Event,
@@ -59,10 +56,9 @@ export const postgreSQLEventStoreConsumer = <
 
   let currentMessagePuller: PostgreSQLEventStoreMessageBatchPuller | undefined;
 
-  const pool =
-    'pool' in options
-      ? options.pool
-      : dumbo({ connectionString: options.connectionString });
+  const pool = options.pool
+    ? options.pool
+    : dumbo({ connectionString: options.connectionString });
 
   const eachBatch: PostgreSQLEventStoreMessagesBatchHandler<
     ConsumerEventType
@@ -78,7 +74,10 @@ export const postgreSQLEventStoreConsumer = <
     const result = await Promise.allSettled(
       activeProcessors.map((s) => {
         // TODO: Add here filtering to only pass messages that can be handled by processor
-        return s.handle(messagesBatch, { pool });
+        return s.handle(messagesBatch, {
+          pool,
+          connectionString: options.connectionString,
+        });
       }),
     );
 

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
@@ -1,6 +1,5 @@
 import { dumbo, type Dumbo } from '@event-driven-io/dumbo';
 import { EmmettError, type Event } from '@event-driven-io/emmett';
-import type { PostgreSQLProjectionDefinition } from '../projections';
 import {
   DefaultPostgreSQLEventStoreProcessorBatchSize,
   DefaultPostgreSQLEventStoreProcessorPullingFrequencyInMs,
@@ -11,7 +10,6 @@ import {
 } from './messageBatchProcessing';
 import {
   postgreSQLProcessor,
-  postgreSQLProjectionProcessor,
   type PostgreSQLProcessor,
   type PostgreSQLProcessorOptions,
 } from './postgreSQLProcessor';
@@ -39,11 +37,6 @@ export type PostgreSQLEventStoreConsumer<
   processors: PostgreSQLProcessor<ConsumerEventType>[];
   processor: <EventType extends ConsumerEventType = ConsumerEventType>(
     options: PostgreSQLProcessorOptions<EventType>,
-  ) => PostgreSQLProcessor<EventType>;
-  projectionProcessor: <
-    EventType extends ConsumerEventType = ConsumerEventType,
-  >(
-    projection: PostgreSQLProjectionDefinition<EventType>,
   ) => PostgreSQLProcessor<EventType>;
   start: () => Promise<void>;
   stop: () => Promise<void>;
@@ -127,17 +120,6 @@ export const postgreSQLEventStoreConsumer = <
       options: PostgreSQLProcessorOptions<EventType>,
     ): PostgreSQLProcessor<EventType> => {
       const processor = postgreSQLProcessor<EventType>(options);
-
-      processors.push(processor);
-
-      return processor;
-    },
-    projectionProcessor: <
-      EventType extends ConsumerEventType = ConsumerEventType,
-    >(
-      projection: PostgreSQLProjectionDefinition<EventType>,
-    ): PostgreSQLProcessor<EventType> => {
-      const processor = postgreSQLProjectionProcessor<EventType>(projection);
 
       processors.push(processor);
 

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLProcessor.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLProcessor.ts
@@ -92,11 +92,10 @@ export const postgreSQLProjectionProcessor = <EventType extends Event = Event>(
 ): PostgreSQLProcessor => {
   return postgreSQLProcessor<EventType>({
     processorId: `projection:${projection.name}`,
-    eachMessage: async (event) => {
+    eachMessage: async (event, context) => {
       if (!projection.canHandle.includes(event.type)) return;
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-      await projection.handle([event as any], {} as any);
+      await projection.handle([event], context);
     },
   });
 };

--- a/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.ts
@@ -187,6 +187,7 @@ export const getPostgreSQLEventStore = (
             projections: inlineProjections,
             connection: {
               connectionString,
+              pool,
               transaction,
             },
             // TODO: Add proper handling of global data
@@ -289,6 +290,7 @@ export const getPostgreSQLEventStore = (
       postgreSQLEventStoreConsumer<ConsumerEventType>({
         ...(options ?? {}),
         pool,
+        connectionString,
       }),
     close: () => pool.close(),
 

--- a/src/packages/emmett-postgresql/src/eventStore/projections/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/index.ts
@@ -31,35 +31,26 @@ export type PostgreSQLProjectionHandler<
   PostgreSQLProjectionHandlerContext
 >;
 
-export type PostgreSQLProjectionDefinition<
-  EventType extends Event = Event,
-  EventMetaDataType extends
-    PostgresReadEventMetadata = PostgresReadEventMetadata,
-> = TypedProjectionDefinition<
-  EventType,
-  EventMetaDataType,
-  PostgreSQLProjectionHandlerContext
->;
+export type PostgreSQLProjectionDefinition<EventType extends Event = Event> =
+  TypedProjectionDefinition<
+    EventType,
+    PostgresReadEventMetadata,
+    PostgreSQLProjectionHandlerContext
+  >;
 
-export type ProjectionHandlerOptions<
+export type PostgreSQLProjectionHandlerOptions<
   EventType extends Event = Event,
-  EventMetaDataType extends
-    PostgresReadEventMetadata = PostgresReadEventMetadata,
 > = {
-  events: ReadEvent<EventType, EventMetaDataType>[];
-  projections: PostgreSQLProjectionDefinition<EventType, EventMetaDataType>[];
+  events: ReadEvent<EventType, PostgresReadEventMetadata>[];
+  projections: PostgreSQLProjectionDefinition<EventType>[];
   connection: {
     connectionString: string;
     transaction: NodePostgresTransaction;
   };
 };
 
-export const handleProjections = async <
-  EventType extends Event = Event,
-  EventMetaDataType extends
-    PostgresReadEventMetadata = PostgresReadEventMetadata,
->(
-  options: ProjectionHandlerOptions<EventType, EventMetaDataType>,
+export const handleProjections = async <EventType extends Event = Event>(
+  options: PostgreSQLProjectionHandlerOptions<EventType>,
 ): Promise<void> => {
   const {
     projections: allProjections,
@@ -85,18 +76,14 @@ export const handleProjections = async <
   }
 };
 
-export const postgreSQLProjection = <
-  EventType extends Event,
-  EventMetaDataType extends
-    PostgresReadEventMetadata = PostgresReadEventMetadata,
->(
-  definition: PostgreSQLProjectionDefinition<EventType, EventMetaDataType>,
+export const postgreSQLProjection = <EventType extends Event>(
+  definition: PostgreSQLProjectionDefinition<EventType>,
 ): PostgreSQLProjectionDefinition =>
   projection<
     EventType,
-    EventMetaDataType,
+    PostgresReadEventMetadata,
     PostgreSQLProjectionHandlerContext,
-    PostgreSQLProjectionDefinition<EventType, EventMetaDataType>
+    PostgreSQLProjectionDefinition<EventType>
   >(definition) as PostgreSQLProjectionDefinition;
 
 export const postgreSQLRawBatchSQLProjection = <EventType extends Event>(

--- a/src/packages/emmett-postgresql/src/eventStore/projections/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/index.ts
@@ -86,13 +86,13 @@ export const handleProjections = async <EventType extends Event = Event>(
 
 export const postgreSQLProjection = <EventType extends Event>(
   definition: PostgreSQLProjectionDefinition<EventType>,
-): PostgreSQLProjectionDefinition =>
+): PostgreSQLProjectionDefinition<EventType> =>
   projection<
     EventType,
     PostgresReadEventMetadata,
     PostgreSQLProjectionHandlerContext,
     PostgreSQLProjectionDefinition<EventType>
-  >(definition) as PostgreSQLProjectionDefinition;
+  >(definition);
 
 export const postgreSQLRawBatchSQLProjection = <EventType extends Event>(
   handle: (
@@ -100,7 +100,7 @@ export const postgreSQLRawBatchSQLProjection = <EventType extends Event>(
     context: PostgreSQLProjectionHandlerContext,
   ) => Promise<SQL[]> | SQL[],
   ...canHandle: CanHandle<EventType>
-): PostgreSQLProjectionDefinition =>
+): PostgreSQLProjectionDefinition<EventType> =>
   postgreSQLProjection<EventType>({
     canHandle,
     handle: async (events, context) => {
@@ -116,7 +116,7 @@ export const postgreSQLRawSQLProjection = <EventType extends Event>(
     context: PostgreSQLProjectionHandlerContext,
   ) => Promise<SQL> | SQL,
   ...canHandle: CanHandle<EventType>
-): PostgreSQLProjectionDefinition =>
+): PostgreSQLProjectionDefinition<EventType> =>
   postgreSQLRawBatchSQLProjection<EventType>(
     async (events, context) => {
       const sqls: SQL[] = [];

--- a/src/packages/emmett-postgresql/src/eventStore/projections/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/index.ts
@@ -9,9 +9,9 @@ import {
   projection,
   type CanHandle,
   type Event,
+  type ProjectionDefinition,
   type ProjectionHandler,
   type ReadEvent,
-  type TypedProjectionDefinition,
 } from '@event-driven-io/emmett';
 import type { PostgresReadEventMetadata } from '../postgreSQLEventStore';
 
@@ -36,7 +36,7 @@ export type PostgreSQLProjectionHandler<
 >;
 
 export type PostgreSQLProjectionDefinition<EventType extends Event = Event> =
-  TypedProjectionDefinition<
+  ProjectionDefinition<
     EventType,
     PostgresReadEventMetadata,
     PostgreSQLProjectionHandlerContext
@@ -90,8 +90,7 @@ export const postgreSQLProjection = <EventType extends Event>(
   projection<
     EventType,
     PostgresReadEventMetadata,
-    PostgreSQLProjectionHandlerContext,
-    PostgreSQLProjectionDefinition<EventType>
+    PostgreSQLProjectionHandlerContext
   >(definition);
 
 export const postgreSQLRawBatchSQLProjection = <EventType extends Event>(

--- a/src/packages/emmett-postgresql/src/eventStore/projections/pongo/projections.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/pongo/projections.ts
@@ -74,7 +74,9 @@ export const pongoProjection = <EventType extends Event>({
   postgreSQLProjection<EventType>({
     canHandle,
     handle: async (events, context) => {
-      const { connectionString, client } = context;
+      const {
+        connection: { connectionString, client },
+      } = context;
       const pongo = pongoClient(connectionString, {
         connectionOptions: { client },
       });

--- a/src/packages/emmett-postgresql/src/eventStore/projections/pongo/projections.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/pongo/projections.ts
@@ -59,30 +59,19 @@ export type PongoDocumentEvolve<
   | PongoWithNotNullDocumentEvolve<Document, EventType, EventMetaDataType>
   | PongoWithNullableDocumentEvolve<Document, EventType, EventMetaDataType>;
 
-export type PongoProjectionOptions<
-  EventType extends Event,
-  EventMetaDataType extends
-    PostgresReadEventMetadata = PostgresReadEventMetadata,
-> = {
+export type PongoProjectionOptions<EventType extends Event> = {
   handle: (
-    events: ReadEvent<EventType, EventMetaDataType>[],
+    events: ReadEvent<EventType, PostgresReadEventMetadata>[],
     context: PongoProjectionHandlerContext,
   ) => Promise<void>;
   canHandle: CanHandle<EventType>;
 };
 
-export const pongoProjection = <
-  EventType extends Event,
-  EventMetaDataType extends
-    PostgresReadEventMetadata = PostgresReadEventMetadata,
->({
+export const pongoProjection = <EventType extends Event>({
   handle,
   canHandle,
-}: PongoProjectionOptions<
-  EventType,
-  EventMetaDataType
->): PostgreSQLProjectionDefinition =>
-  postgreSQLProjection<EventType, EventMetaDataType>({
+}: PongoProjectionOptions<EventType>): PostgreSQLProjectionDefinition =>
+  postgreSQLProjection<EventType>({
     canHandle,
     handle: async (events, context) => {
       const { connectionString, client } = context;

--- a/src/packages/emmett-postgresql/src/eventStore/projections/pongo/projections.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/pongo/projections.ts
@@ -70,7 +70,7 @@ export type PongoProjectionOptions<EventType extends Event> = {
 export const pongoProjection = <EventType extends Event>({
   handle,
   canHandle,
-}: PongoProjectionOptions<EventType>): PostgreSQLProjectionDefinition =>
+}: PongoProjectionOptions<EventType>): PostgreSQLProjectionDefinition<EventType> =>
   postgreSQLProjection<EventType>({
     canHandle,
     handle: async (events, context) => {
@@ -126,7 +126,7 @@ export const pongoMultiStreamProjection = <
     EventType,
     EventMetaDataType
   >,
-): PostgreSQLProjectionDefinition => {
+): PostgreSQLProjectionDefinition<EventType> => {
   const { collectionName, getDocumentId, canHandle } = options;
 
   return pongoProjection({
@@ -190,7 +190,7 @@ export const pongoSingleStreamProjection = <
     EventType,
     EventMetaDataType
   >,
-): PostgreSQLProjectionDefinition => {
+): PostgreSQLProjectionDefinition<EventType> => {
   return pongoMultiStreamProjection<Document, EventType, EventMetaDataType>({
     ...options,
     getDocumentId:

--- a/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjection.customid.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjection.customid.int.spec.ts
@@ -10,10 +10,7 @@ import {
   pongoSingleStreamProjection,
   PostgreSQLProjectionSpec,
 } from '.';
-import type {
-  DiscountApplied,
-  PricedProductItem,
-} from '../../testing/shoppingCart.domain';
+import type { PricedProductItem } from '../../testing/shoppingCart.domain';
 
 export type ProductItemAdded = Event<
   'ProductItemAdded',
@@ -23,7 +20,7 @@ export type ProductItemAdded = Event<
 void describe('Postgres Projections', () => {
   let postgres: StartedPostgreSqlContainer;
   let connectionString: string;
-  let given: PostgreSQLProjectionSpec<ProductItemAdded | DiscountApplied>;
+  let given: PostgreSQLProjectionSpec<ProductItemAdded>;
   let shoppingCartId: string;
   let streamName: string;
 

--- a/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjection.multi.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjection.multi.int.spec.ts
@@ -15,7 +15,6 @@ import {
   PostgreSQLProjectionSpec,
 } from '.';
 import {
-  type DiscountApplied,
   type ProductItemAdded,
   type ShoppingCartConfirmed,
 } from '../../testing/shoppingCart.domain';
@@ -23,7 +22,7 @@ import {
 void describe('Postgres Projections', () => {
   let postgres: StartedPostgreSqlContainer;
   let connectionString: string;
-  let given: PostgreSQLProjectionSpec<ProductItemAdded | DiscountApplied>;
+  let given: PostgreSQLProjectionSpec<ProductItemAdded | ShoppingCartConfirmed>;
   let shoppingCartId: string;
   let clientId: string;
 

--- a/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjectionSpec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjectionSpec.ts
@@ -52,13 +52,13 @@ export type PostgreSQLProjectionAssert = (options: {
   connectionString: string;
 }) => Promise<void | boolean>;
 
-export type PostgreSQLProjectionSpecOptions = {
-  projection: PostgreSQLProjectionDefinition;
+export type PostgreSQLProjectionSpecOptions<EventType extends Event> = {
+  projection: PostgreSQLProjectionDefinition<EventType>;
 } & DumboOptions;
 
 export const PostgreSQLProjectionSpec = {
   for: <EventType extends Event>(
-    options: PostgreSQLProjectionSpecOptions,
+    options: PostgreSQLProjectionSpecOptions<EventType>,
   ): PostgreSQLProjectionSpec<EventType> => {
     {
       const { projection, ...dumoOptions } = options;

--- a/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjectionSpec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjectionSpec.ts
@@ -105,6 +105,7 @@ export const PostgreSQLProjectionSpec = {
                   events: allEvents,
                   projections: [projection],
                   connection: {
+                    pool,
                     connectionString,
                     transaction,
                   },

--- a/src/packages/emmett-tests/src/eventStore/postgresql/postgreSQLEventStore.e2e.spec.ts
+++ b/src/packages/emmett-tests/src/eventStore/postgresql/postgreSQLEventStore.e2e.spec.ts
@@ -2,7 +2,6 @@ import {
   assertDeepEqual,
   assertEqual,
   assertIsNotNull,
-  projections,
   type ReadEvent,
 } from '@event-driven-io/emmett';
 import {
@@ -36,10 +35,10 @@ void describe('EventStoreDBEventStore', async () => {
     postgres = await new PostgreSqlContainer().start();
     connectionString = postgres.getConnectionUri();
     eventStore = getPostgreSQLEventStore(connectionString, {
-      projections: projections.inline([
-        shoppingCartShortInfoProjection,
-        customProjection,
-      ]),
+      projections: [
+        { type: 'inline', projection: shoppingCartShortInfoProjection },
+        { type: 'inline', projection: customProjection },
+      ],
     });
     pongo = pongoClient(connectionString);
     return eventStore;

--- a/src/packages/emmett/src/typing/event.ts
+++ b/src/packages/emmett/src/typing/event.ts
@@ -23,6 +23,9 @@ export type Event<
   'Event'
 >;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyEvent = Event<any, any, any>;
+
 export type EventTypeOf<T extends Event> = T['type'];
 export type EventDataOf<T extends Event> = T['data'];
 export type EventMetaDataOf<T extends Event> = T extends { metadata: infer M }

--- a/src/packages/emmett/src/typing/event.ts
+++ b/src/packages/emmett/src/typing/event.ts
@@ -83,6 +83,10 @@ export type ReadEvent<
   metadata: CombinedReadEventMetadata<EventType, EventMetaDataType>;
 };
 
+export type AnyReadEvent<
+  EventMetaDataType extends AnyReadEventMetadata = AnyReadEventMetadata,
+> = ReadEvent<AnyEvent, EventMetaDataType>;
+
 export type CommonReadEventMetadata<StreamPosition = BigIntStreamPosition> =
   Readonly<{
     eventId: string;


### PR DESCRIPTION
1. It can support both generic handling and async projection abstractions.
2. It should be possible to plug it into EventStoreDB consumer, but that'll be tested in the follow-up PR. The key for that was allowed to pass connection options for the processor and using them as a fallback if the context got from the consumer doesn't have it. This will be useful also if you'd like to store read models in a different database than consumer code.
3. Simplified `ProjectionDefinition` type and merged `TypedProjectionDefinition` into. That was made possible thanks to introducing `AnyEvent` type and enabling contravariance.