### PR TITLE
Add API reference link to documentation sidebar and update title in API docs

### DIFF
--- a/src/docs/.vitepress/config.mts
+++ b/src/docs/.vitepress/config.mts
@@ -27,7 +27,10 @@ export default defineConfig({
     sidebar: [
       {
         text: 'Documentation',
-        items: [{ text: 'Getting Started', link: '/getting-started' }],
+        items: [
+          { text: 'Getting Started', link: '/getting-started' },
+          { text: 'API reference', link: '/api-docs' },
+        ],
       },
     ],
 

--- a/src/docs/api-docs.md
+++ b/src/docs/api-docs.md
@@ -2,7 +2,7 @@
 outline: deep
 ---
 
-# API docs
+# API reference
 
 ## Event
 


### PR DESCRIPTION
The API docs page is actually a kind of reference documenation that provides a deep dive into the intrinsics of Emmet. Change the page title to reflect this change and make the page accessible via the sidebar navigation.

Note: I did not rename the file, as cool URIs dont change. However I am planning to refactor the page into several parts for improved developer experience in the future, so it might simply redirect to a new page at some point.