### PR TITLE
chore: add max for discounts

### DIFF
--- a/src/packages/emmett-tests/src/eventStore/shoppingCart.domain.ts
+++ b/src/packages/emmett-tests/src/eventStore/shoppingCart.domain.ts
@@ -38,7 +38,7 @@ export const evolve = (
     case 'DiscountApplied':
       return {
         ...state,
-        totalAmount: state.totalAmount * (1 - data.percent / 100),
+        totalAmount: Math.max(state.totalAmount * (1 - data.percent / 100), 0)
       };
   }
 };

--- a/src/packages/emmett-tests/src/eventStore/shoppingCart.domain.ts
+++ b/src/packages/emmett-tests/src/eventStore/shoppingCart.domain.ts
@@ -38,7 +38,7 @@ export const evolve = (
     case 'DiscountApplied':
       return {
         ...state,
-        totalAmount: Math.max(state.totalAmount * (1 - data.percent / 100), 0)
+        totalAmount: Math.max(state.totalAmount * (1 - data.percent / 100), 0),
       };
   }
 };


### PR DESCRIPTION
https://github.com/event-driven-io/emmett/issues/196

## Summary 
Bug- Prevent discounts from causing negative amounts

Current Behaviour-

```ts 
 case 'DiscountApplied':
      return {
        ...state,
        totalAmount: state.totalAmount * (1 - data.percent / 100),
      };
 ```

