### PR TITLE
add first iteration of inMemoryDatabase with handle possibilities

### DIFF
--- a/src/packages/emmett/src/database/inMemoryDatabase.ts
+++ b/src/packages/emmett/src/database/inMemoryDatabase.ts
@@ -1,41 +1,310 @@
-import { JSONParser } from '../serialization';
+import { v7 as uuid } from 'uuid';
+import { deepEquals } from '../utils';
+import {
+  type DeleteResult,
+  type Document,
+  type DocumentHandler,
+  type HandleOptionErrors,
+  type HandleOptions,
+  type HandleResult,
+  type InsertOneResult,
+  type OptionalUnlessRequiredIdAndVersion,
+  type ReplaceOneOptions,
+  type UpdateResult,
+  type WithoutId,
+  type WithIdAndVersion,
+} from './types';
+import { expectedVersionValue, operationResult } from './utils';
 
-export interface DocumentsCollection<T> {
-  store: (id: string, obj: T) => void;
-  delete: (id: string) => void;
-  get: (id: string) => T | null;
+export interface DocumentsCollection<T extends Document> {
+  handle: (
+    id: string,
+    handle: DocumentHandler<T>,
+    options?: HandleOptions,
+  ) => HandleResult<T>;
+  findOne: (predicate?: Predicate<T>) => T | null;
+  insertOne: (
+    document: OptionalUnlessRequiredIdAndVersion<T>,
+  ) => InsertOneResult;
+  deleteOne: (predicate?: Predicate<T>) => DeleteResult;
+  replaceOne: (
+    predicate: Predicate<T>,
+    document: WithoutId<T>,
+    options?: ReplaceOneOptions,
+  ) => UpdateResult;
 }
 
 export interface Database {
-  collection: <T>(name: string) => DocumentsCollection<T>;
+  collection: <T extends Document>(name: string) => DocumentsCollection<T>;
 }
 
+type Predicate<T> = (item: T) => boolean;
+
 export const getInMemoryDatabase = (): Database => {
-  const storage = new Map<string, unknown>();
+  const storage = new Map<string, WithIdAndVersion<Document>[]>();
 
   return {
-    collection: <T>(
+    collection: <T extends Document>(
       collectionName: string,
-      _collectionOptions: {
-        errors?: { throwOnOperationFailures?: boolean } | undefined;
+      collectionOptions: {
+        errors?: HandleOptionErrors;
       } = {},
     ): DocumentsCollection<T> => {
-      const toFullId = (id: string) => `${collectionName}-${id}`;
+      const ensureCollectionCreated = () => {
+        if (!storage.has(collectionName)) storage.set(collectionName, []);
+      };
+
+      const errors = collectionOptions.errors;
 
       const collection = {
-        store: (id: string, obj: T): void => {
-          storage.set(toFullId(id), obj);
-        },
-        delete: (id: string): void => {
-          storage.delete(toFullId(id));
-        },
-        get: (id: string): T | null => {
-          const result = storage.get(toFullId(id));
+        collectionName,
+        insertOne: (
+          document: OptionalUnlessRequiredIdAndVersion<T>,
+        ): InsertOneResult => {
+          ensureCollectionCreated();
 
-          return result
-            ? // Clone to simulate getting new instance on loading
-              (JSONParser.parse(JSONParser.stringify(result)) as T)
-            : null;
+          const _id = (document._id as string | undefined | null) ?? uuid();
+          const _version = document._version ?? 1n;
+
+          const existing = collection.findOne((c) => c._id === _id);
+
+          if (existing) {
+            return operationResult<InsertOneResult>(
+              {
+                successful: false,
+                insertedId: null,
+                nextExpectedVersion: _version,
+              },
+              { operationName: 'insertOne', collectionName, errors },
+            );
+          }
+
+          const documentsInCollection = storage.get(collectionName)!;
+          const newDocument = { ...document, _id, _version };
+          const newCollection = [...documentsInCollection, newDocument];
+          storage.set(collectionName, newCollection);
+
+          return operationResult<InsertOneResult>(
+            {
+              successful: true,
+              insertedId: _id,
+              nextExpectedVersion: _version,
+            },
+            { operationName: 'insertOne', collectionName, errors },
+          );
+        },
+        findOne: (predicate?: Predicate<T>): T | null => {
+          ensureCollectionCreated();
+
+          const documentsInCollection = storage.get(collectionName);
+          const filteredDocuments = predicate
+            ? documentsInCollection?.filter((doc) => predicate(doc as T))
+            : documentsInCollection;
+
+          const firstOne = filteredDocuments?.[0] ?? null;
+
+          return firstOne as T | null;
+        },
+        deleteOne: (predicate?: Predicate<T>): DeleteResult => {
+          ensureCollectionCreated();
+
+          const documentsInCollection = storage.get(collectionName)!;
+
+          if (predicate) {
+            const foundIndex = documentsInCollection.findIndex((doc) =>
+              predicate(doc as T),
+            );
+
+            if (foundIndex === -1) {
+              return operationResult<DeleteResult>(
+                {
+                  successful: false,
+                  matchedCount: 0,
+                  deletedCount: 0,
+                },
+                { operationName: 'deleteOne', collectionName, errors },
+              );
+            } else {
+              const newCollection = documentsInCollection.toSpliced(
+                foundIndex,
+                1,
+              );
+
+              storage.set(collectionName, newCollection);
+
+              return operationResult<DeleteResult>(
+                {
+                  successful: true,
+                  matchedCount: 1,
+                  deletedCount: 1,
+                },
+                { operationName: 'deleteOne', collectionName, errors },
+              );
+            }
+          } else {
+            const newCollection = documentsInCollection.slice(1);
+
+            storage.set(collectionName, newCollection);
+
+            return operationResult<DeleteResult>(
+              {
+                successful: true,
+                matchedCount: 1,
+                deletedCount: 1,
+              },
+              { operationName: 'deleteOne', collectionName, errors },
+            );
+          }
+        },
+        replaceOne: (
+          predicate: Predicate<T>,
+          document: WithoutId<T>,
+          options?: ReplaceOneOptions,
+        ): UpdateResult => {
+          ensureCollectionCreated();
+
+          const documentsInCollection = storage.get(collectionName)!;
+
+          const foundIndexes = documentsInCollection
+            .filter((doc) => predicate(doc as T))
+            .map((_, index) => index);
+
+          const firstIndex = foundIndexes[0];
+
+          if (!firstIndex || firstIndex === -1) {
+            return operationResult<UpdateResult>(
+              {
+                successful: false,
+                matchedCount: 0,
+                modifiedCount: 0,
+                nextExpectedVersion: 0n,
+              },
+              { operationName: 'replaceOne', collectionName, errors },
+            );
+          }
+
+          const existing = documentsInCollection[firstIndex]!;
+
+          if (
+            typeof options?.expectedVersion === 'bigint' &&
+            existing._version !== options.expectedVersion
+          ) {
+            return operationResult<UpdateResult>(
+              {
+                successful: false,
+                matchedCount: 1,
+                modifiedCount: 0,
+                nextExpectedVersion: existing._version,
+              },
+              { operationName: 'replaceOne', collectionName, errors },
+            );
+          }
+
+          const newVersion = existing._version + 1n;
+
+          const newCollection = documentsInCollection.with(firstIndex, {
+            _id: existing._id,
+            ...document,
+            _version: newVersion,
+          });
+
+          storage.set(collectionName, newCollection);
+
+          return operationResult<UpdateResult>(
+            {
+              successful: true,
+              modifiedCount: 1,
+              matchedCount: foundIndexes.length,
+              nextExpectedVersion: newVersion,
+            },
+            { operationName: 'replaceOne', collectionName, errors },
+          );
+        },
+        handle: (
+          id: string,
+          handle: DocumentHandler<T>,
+          options?: HandleOptions,
+        ): HandleResult<T> => {
+          const { expectedVersion: version, ...operationOptions } =
+            options ?? {};
+          ensureCollectionCreated();
+          const existing = collection.findOne((c) => c.id === id);
+
+          const expectedVersion = expectedVersionValue(version);
+
+          if (
+            (existing == null && version === 'DOCUMENT_EXISTS') ||
+            (existing == null && expectedVersion != null) ||
+            (existing != null && version === 'DOCUMENT_DOES_NOT_EXIST') ||
+            (existing != null &&
+              expectedVersion !== null &&
+              existing._version !== expectedVersion)
+          ) {
+            return operationResult<HandleResult<T>>(
+              {
+                successful: false,
+                document: existing as WithIdAndVersion<T>,
+              },
+              { operationName: 'handle', collectionName, errors },
+            );
+          }
+
+          const result = handle(existing !== null ? { ...existing } : null);
+
+          if (deepEquals(existing, result))
+            return operationResult<HandleResult<T>>(
+              {
+                successful: true,
+                document: existing as WithIdAndVersion<T>,
+              },
+              { operationName: 'handle', collectionName, errors },
+            );
+
+          if (!existing && result) {
+            const newDoc = { ...result, _id: id };
+            const insertResult = collection.insertOne({
+              ...newDoc,
+              _id: id,
+            } as OptionalUnlessRequiredIdAndVersion<T>);
+            return {
+              ...insertResult,
+              document: {
+                ...newDoc,
+                _version: insertResult.nextExpectedVersion,
+              } as unknown as WithIdAndVersion<T>,
+            };
+          }
+
+          if (existing && !result) {
+            const deleteResult = collection.deleteOne(({ _id }) => id === _id);
+            return { ...deleteResult, document: null };
+          }
+
+          if (existing && result) {
+            const replaceResult = collection.replaceOne(
+              ({ _id }) => id === _id,
+              result,
+              {
+                ...operationOptions,
+                expectedVersion: expectedVersion ?? 'DOCUMENT_EXISTS',
+              },
+            );
+            return {
+              ...replaceResult,
+              document: {
+                ...result,
+                _version: replaceResult.nextExpectedVersion,
+              } as unknown as WithIdAndVersion<T>,
+            };
+          }
+
+          return operationResult<HandleResult<T>>(
+            {
+              successful: true,
+              document: existing as WithIdAndVersion<T>,
+            },
+            { operationName: 'handle', collectionName, errors },
+          );
         },
       };
 

--- a/src/packages/emmett/src/database/inMemoryDatabase.unit.spec.ts
+++ b/src/packages/emmett/src/database/inMemoryDatabase.unit.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it } from 'node:test';
+import { getInMemoryDatabase } from './inMemoryDatabase';
+import { equal } from 'node:assert';
+
+type TestUser = {
+  name: string;
+  age: number;
+};
+
+void describe('inMemoryDatabase', () => {
+  void it('should correctly insertOne document', () => {
+    const db = getInMemoryDatabase();
+
+    const collection = db.collection<TestUser>('test');
+
+    const result = collection.insertOne({ age: 10, name: 'test' });
+
+    equal(result.successful, true);
+  });
+
+  void it('should not allow inserting one with id that already is there', () => {
+    const db = getInMemoryDatabase();
+
+    const collection = db.collection<TestUser>('test');
+
+    const result = collection.insertOne({ age: 10, name: 'test' });
+
+    const result2 = collection.insertOne({
+      age: 10,
+      name: 'test',
+      _id: result.insertedId!,
+    });
+
+    equal(result2.successful, false);
+  });
+
+  void it('return first record found when using findOne without parameters', () => {
+    const db = getInMemoryDatabase();
+
+    const collection = db.collection<TestUser>('test');
+
+    collection.insertOne({ age: 10, name: 'test' });
+    collection.insertOne({ age: 15, name: 'test2' });
+
+    const result = collection.findOne();
+
+    equal(result!.name, 'test');
+  });
+
+  void it('should return the correct one found', () => {
+    const db = getInMemoryDatabase();
+
+    const collection = db.collection<TestUser>('test');
+
+    collection.insertOne({ age: 10, name: 'test' });
+    collection.insertOne({ age: 15, name: 'test2' });
+
+    const result = collection.findOne((c) => c.age === 15);
+
+    equal(result!.name, 'test2');
+  });
+
+  void it('should return null when not found', () => {
+    const db = getInMemoryDatabase();
+
+    const collection = db.collection<TestUser>('test');
+
+    collection.insertOne({ age: 10, name: 'test' });
+    collection.insertOne({ age: 15, name: 'test2' });
+
+    const result = collection.findOne((c) => c.age === 20);
+
+    equal(result, null);
+  });
+
+  void it('should correctly delete one', () => {
+    const db = getInMemoryDatabase();
+
+    const collection = db.collection<TestUser>('test');
+
+    collection.insertOne({ age: 10, name: 'test' });
+    collection.insertOne({ age: 15, name: 'test2' });
+
+    const deleteResult = collection.deleteOne((c) => c.age === 15);
+    const found = collection.findOne((c) => c.age === 15);
+
+    equal(deleteResult.deletedCount, 1);
+    equal(found, null);
+  });
+
+  void it('should delete first one when no parameter passed to deleteOne', () => {
+    const db = getInMemoryDatabase();
+
+    const collection = db.collection<TestUser>('test');
+
+    collection.insertOne({ age: 10, name: 'test' });
+    collection.insertOne({ age: 15, name: 'test2' });
+
+    const deleteResult = collection.deleteOne();
+    const found = collection.findOne((c) => c.age === 10);
+
+    equal(deleteResult.deletedCount, 1);
+    equal(found, null);
+  });
+});

--- a/src/packages/emmett/src/database/types.ts
+++ b/src/packages/emmett/src/database/types.ts
@@ -1,0 +1,158 @@
+/** TypeScript Omit (Exclude to be specific) does not work for objects with an "any" indexed type, and breaks discriminated unions @public */
+export declare type EnhancedOmit<TRecordOrUnion, KeyUnion> =
+  string extends keyof TRecordOrUnion
+    ? TRecordOrUnion
+    : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      TRecordOrUnion extends any
+      ? Pick<TRecordOrUnion, Exclude<keyof TRecordOrUnion, KeyUnion>>
+      : never;
+
+export declare type WithId<TSchema> = EnhancedOmit<TSchema, '_id'> & {
+  _id: string;
+};
+export type WithoutId<T> = Omit<T, '_id'>;
+
+export declare type WithVersion<TSchema> = EnhancedOmit<TSchema, '_version'> & {
+  _version: bigint;
+};
+export type WithoutVersion<T> = Omit<T, '_version'>;
+
+export type WithIdAndVersion<TSchema> = EnhancedOmit<
+  TSchema,
+  '_version' | '_id'
+> & {
+  _id: string;
+  _version: bigint;
+};
+
+export type Document = Record<string, unknown>;
+
+export type DocumentHandler<T extends Document> = (
+  document: T | null,
+) => T | null;
+
+export type ExpectedDocumentVersionGeneral =
+  | 'DOCUMENT_EXISTS'
+  | 'DOCUMENT_DOES_NOT_EXIST'
+  | 'NO_CONCURRENCY_CHECK';
+
+export type ExpectedDocumentVersion = bigint | ExpectedDocumentVersionGeneral;
+
+export type ExpectedDocumentVersionValue = bigint;
+
+export type HandleOptions = {
+  expectedVersion?: ExpectedDocumentVersion;
+};
+
+export type OperationResult = {
+  acknowledged: boolean;
+  successful: boolean;
+
+  assertSuccessful: (errorMessage?: string) => void;
+};
+
+export interface InsertOneResult extends OperationResult {
+  insertedId: string | null;
+  nextExpectedVersion: bigint;
+}
+
+export interface InsertManyResult extends OperationResult {
+  insertedIds: string[];
+  insertedCount: number;
+}
+
+export interface UpdateResult extends OperationResult {
+  matchedCount: number;
+  modifiedCount: number;
+  nextExpectedVersion: bigint;
+}
+
+export interface UpdateManyResult extends OperationResult {
+  matchedCount: number;
+  modifiedCount: number;
+}
+
+export interface DeleteResult extends OperationResult {
+  matchedCount: number;
+  deletedCount: number;
+}
+
+export interface DeleteManyResult extends OperationResult {
+  deletedCount: number;
+}
+
+export type HandleResult<T> =
+  | (InsertOneResult & { document: WithIdAndVersion<T> })
+  | (UpdateResult & { document: WithIdAndVersion<T> })
+  | (DeleteResult & { document: null })
+  | (OperationResult & { document: null });
+
+export type HandleOptionErrors =
+  | { throwOnOperationFailures?: boolean }
+  | undefined;
+
+export declare type OptionalId<TSchema> = EnhancedOmit<TSchema, '_id'> & {
+  _id?: string;
+};
+
+export declare type OptionalVersion<TSchema> = EnhancedOmit<
+  TSchema,
+  '_version'
+> & {
+  _version?: bigint;
+};
+
+export declare type OptionalUnlessRequiredId<TSchema> = TSchema extends {
+  _id: string;
+}
+  ? TSchema
+  : OptionalId<TSchema>;
+
+export declare type OptionalUnlessRequiredVersion<TSchema> = TSchema extends {
+  _version: bigint;
+}
+  ? TSchema
+  : OptionalVersion<TSchema>;
+
+export declare type OptionalUnlessRequiredIdAndVersion<TSchema> =
+  OptionalUnlessRequiredId<TSchema> & OptionalUnlessRequiredVersion<TSchema>;
+
+export type InsertOneOptions = {
+  expectedVersion?: Extract<
+    ExpectedDocumentVersion,
+    'DOCUMENT_DOES_NOT_EXIST' | 'NO_CONCURRENCY_CHECK'
+  >;
+};
+
+export type InsertManyOptions = {
+  expectedVersion?: Extract<
+    ExpectedDocumentVersion,
+    'DOCUMENT_DOES_NOT_EXIST' | 'NO_CONCURRENCY_CHECK'
+  >;
+};
+
+export type UpdateOneOptions = {
+  expectedVersion?: Exclude<ExpectedDocumentVersion, 'DOCUMENT_DOES_NOT_EXIST'>;
+};
+
+export type UpdateManyOptions = {
+  expectedVersion?: Extract<
+    ExpectedDocumentVersion,
+    'DOCUMENT_EXISTS' | 'NO_CONCURRENCY_CHECK'
+  >;
+};
+
+export type ReplaceOneOptions = {
+  expectedVersion?: Exclude<ExpectedDocumentVersion, 'DOCUMENT_DOES_NOT_EXIST'>;
+};
+
+export type DeleteOneOptions = {
+  expectedVersion?: Exclude<ExpectedDocumentVersion, 'DOCUMENT_DOES_NOT_EXIST'>;
+};
+
+export type DeleteManyOptions = {
+  expectedVersion?: Extract<
+    ExpectedDocumentVersion,
+    'DOCUMENT_EXISTS' | 'NO_CONCURRENCY_CHECK'
+  >;
+};

--- a/src/packages/emmett/src/database/utils.ts
+++ b/src/packages/emmett/src/database/utils.ts
@@ -1,0 +1,56 @@
+import { ConcurrencyInMemoryDatabaseError } from '../errors';
+import { JSONParser } from '../serialization';
+import type {
+  ExpectedDocumentVersion,
+  ExpectedDocumentVersionGeneral,
+  ExpectedDocumentVersionValue,
+  HandleOptionErrors,
+  OperationResult,
+} from './types';
+
+export const isGeneralExpectedDocumentVersion = (
+  version: ExpectedDocumentVersion | undefined,
+): version is ExpectedDocumentVersionGeneral => {
+  return (
+    version === 'DOCUMENT_DOES_NOT_EXIST' ||
+    version === 'DOCUMENT_EXISTS' ||
+    version === 'NO_CONCURRENCY_CHECK'
+  );
+};
+
+export const expectedVersionValue = (
+  version: ExpectedDocumentVersion | undefined,
+): ExpectedDocumentVersionValue | null =>
+  version === undefined || isGeneralExpectedDocumentVersion(version)
+    ? null
+    : version;
+
+export const operationResult = <T extends OperationResult>(
+  result: Omit<T, 'assertSuccess' | 'acknowledged' | 'assertSuccessful'>,
+  options: {
+    operationName: string;
+    collectionName: string;
+    errors?: HandleOptionErrors;
+  },
+): T => {
+  const operationResult: T = {
+    ...result,
+    acknowledged: true,
+    successful: result.successful,
+    assertSuccessful: (errorMessage?: string) => {
+      const { successful } = result;
+      const { operationName, collectionName } = options;
+
+      if (!successful)
+        throw new ConcurrencyInMemoryDatabaseError(
+          errorMessage ??
+            `${operationName} on ${collectionName} failed. Expected document state does not match current one! Result: ${JSONParser.stringify(result)}!`,
+        );
+    },
+  } as T;
+
+  if (options.errors?.throwOnOperationFailures)
+    operationResult.assertSuccessful();
+
+  return operationResult;
+};

--- a/src/packages/emmett/src/errors/index.ts
+++ b/src/packages/emmett/src/errors/index.ts
@@ -63,6 +63,18 @@ export class ConcurrencyError extends EmmettError {
   }
 }
 
+export class ConcurrencyInMemoryDatabaseError extends EmmettError {
+  constructor(message?: string) {
+    super({
+      errorCode: 412,
+      message: message ?? `Expected document state does not match current one!`,
+    });
+
+    // 👇️ because we are extending a built-in class
+    Object.setPrototypeOf(this, ConcurrencyInMemoryDatabaseError.prototype);
+  }
+}
+
 export class ValidationError extends EmmettError {
   constructor(message?: string) {
     super({


### PR DESCRIPTION
This PR introduces the first iteration of in memory database that is more compatible with Pongo, than the first tries. It is supposed to be the 3rd step from the issue: https://github.com/event-driven-io/emmett/issues/179