### PR TITLE
fix: Eliminate dead links in vitepress

### DIFF
--- a/src/docs/api-docs.md
+++ b/src/docs/api-docs.md
@@ -14,6 +14,6 @@ outline: deep
 
 ## Event Store
 
-[Moved here](/api-reference/event-store)
+[Moved here](/api-reference/eventstore)
 
 ## Command Handler

--- a/src/docs/api-reference/command.md
+++ b/src/docs/api-reference/command.md
@@ -20,4 +20,4 @@ The type is a simple wrapper to ensure the structure's correctness. It defines:
 
 ## See also
 
-See more context in [getting started guide](./getting-started.md#commands)
+See more context in [getting started guide](/getting-started.md#commands)

--- a/src/docs/overview.md
+++ b/src/docs/overview.md
@@ -14,7 +14,7 @@ If you need help or got stuck, feel free to ask on the [Emmett Community Discord
 
 ## API reference
 
-The [API reference](/api-reference) provides you with definitions and insights of Emmetts core building blocks:
+The [API reference](/api-reference/) provides you with definitions and insights of Emmetts core building blocks:
 
 - **Events** are the centerpiece of event-sourced systems. They represent both critical points of the business process but are also used as the state.
 - **Commands** represent the intent to perform a business operation.


### PR DESCRIPTION
This eliminates the dead links amended by the docs:build step, so the build passes.