### PR TITLE
Add Diataxis documentation type

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,10 @@ The source codes are located in [src](./src/) folder. Packages are nested under 
 
 For documentation Emmett is using [Vitepress](https://vitepress.dev). Documentation is located under [./src/docs](./src/docs/) folder.
 
+## Contributing to the documentation
+
+Contributions to the documentation are more than welcome. The Emmett documentation is generated using [Vitepress](https://vitepress.dev/) and the default theme.
+
 To build documentation locally, run in `src` folder:
 
 ```shell
@@ -115,6 +119,38 @@ npm run docs:dev
 ```
 
 See also other helpful scripts in [./src/package.json](./src/package.json).
+
+### Frontmatter convention
+
+As per [Vitepress documentation on frontmatter](https://vitepress.dev/guide/frontmatter) the keys for the frontmatter should be in `camelCase`.
+
+### Using the Diataxis documentation system
+
+Emmett uses [Diataxis](https://diataxis.fr) as a guide towards first-class user experience (see [PR#203](https://github.com/event-driven-io/emmett/pull/200)) for its documentation.
+
+Please note that Diataxis is not [prescriptive about the structure of the documentation](https://diataxis.fr/how-to-use-diataxis/#don-t-worry-about-structure). In facto it endorses organic growth towards adapting the documentation system.
+
+### Documentation type
+
+In Diataxis each type of documentation comes with specific language and guidelines. To make the intent of the document clear for contributors,
+the type of documentation is defined by the `documentationType` field in the [frontmatter](https://vitepress.dev/guide/frontmatter) of each markdown file:
+
+```md
+---
+documentationType: tutorial #One of: tutorial, how-to-guide, reference, explanation
+---
+
+Lorem ipsum doloret sit amet
+```
+
+The possible values for `documentation-type` [correspond to the Diataxis types](https://diataxis.fr/start-here/) as follows:
+
+- `tutorial` for [tutorials](https://diataxis.fr/tutorials/). _A tutorial is an experience that takes place under the guidance of a tutor. A tutorial is always learning-oriented._
+- `how-to-guide` for [how-to guides](https://diataxis.fr/how-to-guides/). _How-to guides are directions that guide the reader through a problem or towards a result. How-to guides are goal-oriented._
+- `reference` for [reference documentation](https://diataxis.fr/reference/). _Reference guides are technical descriptions of the machinery and how to operate it. Reference material is information-oriented._
+- `explanation` for [explanations](https://diataxis.fr/explanation/)._Explanation is a discursive treatment of a subject, that permits reflection. Explanation is understanding-oriented._
+
+It is recommended to take a look at [the Diataxis compass](https://diataxis.fr/compass/) when unsure which type might be most appropriate for a document.
 
 ## Working with the Git
 

--- a/src/docs/api-docs.md
+++ b/src/docs/api-docs.md
@@ -1,5 +1,6 @@
 ---
 outline: deep
+documentationType: reference
 ---
 
 # API reference

--- a/src/docs/api-reference/command.md
+++ b/src/docs/api-reference/command.md
@@ -1,3 +1,7 @@
+---
+documentationType: reference
+---
+
 # Command
 
 **Commands represent intention to perform business operation.** It targets a specific _audience_. It can be an application service and request with intention to “add user” or “change the order status to confirmed”. So the sender of the command must know the recipient and expects the request to be executed. Of course, the recipient may refuse to do it by not passing us the salt or throwing an exception during the request handling.

--- a/src/docs/api-reference/commandhandler.md
+++ b/src/docs/api-reference/commandhandler.md
@@ -1,3 +1,6 @@
+---
+documentationType: reference
+---
 # Command Handler
 
 **Event Sourcing brings a repeatable pattern for handling business logic.** We can expand that to application logic.

--- a/src/docs/api-reference/commandhandler.md
+++ b/src/docs/api-reference/commandhandler.md
@@ -1,6 +1,7 @@
 ---
 documentationType: reference
 ---
+
 # Command Handler
 
 **Event Sourcing brings a repeatable pattern for handling business logic.** We can expand that to application logic.

--- a/src/docs/api-reference/event.md
+++ b/src/docs/api-reference/event.md
@@ -1,3 +1,7 @@
+---
+documentationType: reference
+---
+
 # Event
 
 **Events are the centrepiece of event-sourced systems.** They represent both critical points of the business process but are also used as the state. That enables you to reflect your business into the code better, getting the synergy. Let's model a simple business process: a shopping cart. You can open it, add or remove the product from it and confirm or cancel.

--- a/src/docs/api-reference/eventstore.md
+++ b/src/docs/api-reference/eventstore.md
@@ -1,6 +1,7 @@
 ---
 documentationType: reference
 ---
+
 # Event Store
 
 **Emmett is an Event Sourcing framework, so we need an event store to store events, aye?** [Event stores are key-value databases](https://event-driven.io/en/event_stores_are_key_value_stores/). The key is a record id, and the value is an ordered list of events. Such a sequence of events is called _Event Stream_. One stream keeps all events recorded for a particular business process or entity.

--- a/src/docs/api-reference/eventstore.md
+++ b/src/docs/api-reference/eventstore.md
@@ -1,3 +1,6 @@
+---
+documentationType: reference
+---
 # Event Store
 
 **Emmett is an Event Sourcing framework, so we need an event store to store events, aye?** [Event stores are key-value databases](https://event-driven.io/en/event_stores_are_key_value_stores/). The key is a record id, and the value is an ordered list of events. Such a sequence of events is called _Event Stream_. One stream keeps all events recorded for a particular business process or entity.

--- a/src/docs/api-reference/index.md
+++ b/src/docs/api-reference/index.md
@@ -2,6 +2,7 @@
 next:
   text: 'Event'
   link: '/api-reference/event'
+documentationType: reference
 ---
 
 # API reference

--- a/src/docs/getting-started.md
+++ b/src/docs/getting-started.md
@@ -1,3 +1,6 @@
+---
+documentationType: user-guide
+---
 # Getting Started
 
 ![](/logo.png)

--- a/src/docs/getting-started.md
+++ b/src/docs/getting-started.md
@@ -1,9 +1,10 @@
 ---
 documentationType: user-guide
 ---
+
 # Getting Started
 
-![](/logo.png)
+![Emmett logo](/logo.png)
 
 ## Event Sourcing
 


### PR DESCRIPTION
As discuessed in [on Discord](https://discord.com/channels/1211601942984532018/1345105617785978960/1345913092663414876) this pull request adds a `documentationType` property to each documentation file that corresponds to the diataxis type of documentation.

I tried to decide on the YAML naming conventions, but Vitepress frontmatter endorses `camelCase` here: https://vitepress.dev/guide/frontmatter

One minor thought is `documentationType` vs `documentationKind` vs `documentationCategory`. See https://dictionary.cambridge.org/de/grammatik/britisch-grammatik/sort-type-and-kind for a distinction:

> Sort, type and kind all generally mean the same thing. They are words we use to refer to a group of people or things which share the same characteristics. 
> \[...]
> We often use and that kind of thing or and that sort of thing to refer to categories.