### PR TITLE
Fix ESDB consumers

### DIFF
--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.ts
@@ -110,6 +110,7 @@ export const eventStoreDBEventStoreConsumer = <
 
   const subscription = (currentSubscription = eventStoreDBSubscription({
     client,
+    from: options.from,
     eachBatch,
     batchSize:
       pulling?.batchSize ?? DefaultEventStoreDBEventStoreProcessorBatchSize,


### PR DESCRIPTION
The stream to subscribe from did not get passed, which caused all consumers to subscribe to everything

I'm not sure exactly if this is the right way to solve, but it does fix the issue, where otherwise the stream name passed to `.consumer` would just get ignored.