### PR TITLE
Fix ESDB consumer filtering of a single stream

### DIFF
--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.ts
@@ -110,6 +110,7 @@ export const eventStoreDBEventStoreConsumer = <
 
   const subscription = (currentSubscription = eventStoreDBSubscription({
     client,
+    from: options.from,
     eachBatch,
     batchSize:
       pulling?.batchSize ?? DefaultEventStoreDBEventStoreProcessorBatchSize,


### PR DESCRIPTION
The stream to subscribe from did not get passed, which caused all consumers to subscribe to everything.

Follow up to #221 as I couldn't push tests to fork.
