### PR TITLE
InMemoryDatabase: apply fixes on comments from previous PR.

### DIFF
--- a/src/packages/emmett/src/database/handle.unit.spec.ts
+++ b/src/packages/emmett/src/database/handle.unit.spec.ts
@@ -1,0 +1,202 @@
+import { equal, ok, deepStrictEqual } from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
+import {
+  type DocumentsCollection,
+  getInMemoryDatabase,
+} from './inMemoryDatabase';
+
+type History = { street: string };
+type Address = {
+  city: string;
+  street?: string;
+  zip?: string;
+  history?: History[];
+};
+
+type User = {
+  _id?: string;
+  name: string;
+  age: number;
+  address?: Address;
+  tags?: string[];
+  _version?: bigint;
+};
+
+void describe('InMemoryDatabase Handle Operations', () => {
+  let users: DocumentsCollection<User>;
+  beforeEach(() => {
+    const db = getInMemoryDatabase();
+    users = db.collection<User>('users');
+  });
+  void it('should NOT insert a new document if it does not exist and expected DOCUMENT_EXISTS', () => {
+    const nonExistingId = 'test';
+    const newDoc: User = { name: 'John', age: 25 };
+    const handle = (_existing: User | null) => newDoc;
+    const resultInMemoryDatabase = users.handle(nonExistingId, handle, {
+      expectedVersion: 'DOCUMENT_EXISTS',
+    });
+    equal(resultInMemoryDatabase.successful, false);
+    equal(resultInMemoryDatabase.document, null);
+    const inMemoryDatabaseDoc = users.findOne(
+      ({ _id }) => _id === nonExistingId,
+    );
+    equal(inMemoryDatabaseDoc, null);
+  });
+  void it('should NOT insert a new document if it does not exist and expected is numeric value', () => {
+    const nonExistingId = 'test';
+    const newDoc: User = { name: 'John', age: 25 };
+    const handle = (_existing: User | null) => newDoc;
+    const resultInMemoryDatabase = users.handle(nonExistingId, handle, {
+      expectedVersion: 1n,
+    });
+    equal(resultInMemoryDatabase.successful, false);
+    equal(resultInMemoryDatabase.document, null);
+    const inMemoryDatabaseDoc = users.findOne(
+      ({ _id }) => _id === nonExistingId,
+    );
+    equal(inMemoryDatabaseDoc, null);
+  });
+  void it('should replace an existing document when expected version matches', () => {
+    const existingDoc: User = { _id: 'existingId', name: 'John', age: 25 };
+    const updatedDoc: User = { _id: existingDoc._id!, name: 'John', age: 30 };
+    const inMemoryDatabaseInsertResult = users.insertOne(existingDoc);
+    const handle = (_existing: User | null) => updatedDoc;
+    const resultInMemoryDatabase = users.handle(
+      inMemoryDatabaseInsertResult.insertedId!,
+      handle,
+    );
+
+    ok(resultInMemoryDatabase.successful);
+    deepStrictEqual(resultInMemoryDatabase.document, {
+      ...updatedDoc,
+      _version: 2n,
+    });
+    const inMemoryDatabaseDoc = users.findOne(
+      ({ _id }) => _id === inMemoryDatabaseInsertResult.insertedId,
+    );
+    deepStrictEqual(inMemoryDatabaseDoc, {
+      ...updatedDoc,
+      _version: 2n,
+    });
+  });
+  void it('should NOT replace an existing document when expected DOCUMENT_DOES_NOT_EXIST', () => {
+    const existingDoc: User = { _id: 'test', name: 'John', age: 25 };
+    const updatedDoc: User = { _id: existingDoc._id!, name: 'John', age: 30 };
+    const inMemoryDatabaseInsertResult = users.insertOne(existingDoc);
+    const handle = (_existing: User | null) => updatedDoc;
+    const resultInMemoryDatabase = users.handle(
+      inMemoryDatabaseInsertResult.insertedId!,
+      handle,
+      {
+        expectedVersion: 'DOCUMENT_DOES_NOT_EXIST',
+      },
+    );
+    equal(resultInMemoryDatabase.successful, false);
+    deepStrictEqual(resultInMemoryDatabase.document, {
+      ...existingDoc,
+      _version: 1n,
+    });
+    const inMemoryDatabaseDoc = users.findOne(
+      ({ _id }) => _id === inMemoryDatabaseInsertResult.insertedId,
+    );
+    deepStrictEqual(inMemoryDatabaseDoc, {
+      ...existingDoc,
+      _version: 1n,
+    });
+  });
+  void it('should NOT replace an existing document when expected version is mismatched ', () => {
+    const existingDoc: User = { _id: 'test', name: 'John', age: 25 };
+    const updatedDoc: User = { _id: existingDoc._id!, name: 'John', age: 30 };
+    const inMemoryDatabaseInsertResult = users.insertOne(existingDoc);
+    const handle = (_existing: User | null) => updatedDoc;
+    const resultInMemoryDatabase = users.handle(
+      inMemoryDatabaseInsertResult.insertedId!,
+      handle,
+      {
+        expectedVersion: 333n,
+      },
+    );
+    equal(resultInMemoryDatabase.successful, false);
+    deepStrictEqual(resultInMemoryDatabase.document, {
+      ...existingDoc,
+      _version: 1n,
+    });
+    const inMemoryDatabaseDoc = users.findOne(
+      ({ _id }) => _id === inMemoryDatabaseInsertResult.insertedId,
+    );
+    deepStrictEqual(inMemoryDatabaseDoc, {
+      ...existingDoc,
+      _version: 1n,
+    });
+  });
+  void it('should delete an existing document when expected version matches', () => {
+    const existingDoc: User = { name: 'John', age: 25 };
+    const inMemoryDatabaseInsertResult = users.insertOne(existingDoc);
+    const handle = (_existing: User | null) => null;
+    const resultInMemoryDatabase = users.handle(
+      inMemoryDatabaseInsertResult.insertedId!,
+      handle,
+      {
+        expectedVersion: 1n,
+      },
+    );
+    ok(resultInMemoryDatabase.successful);
+    equal(resultInMemoryDatabase.document, null);
+    const inMemoryDatabaseDoc = users.findOne(
+      ({ _id }) => _id === inMemoryDatabaseInsertResult.insertedId,
+    );
+    equal(inMemoryDatabaseDoc, null);
+  });
+  void it('should NOT delete an existing document when expected DOCUMENT_DOES_NOT_EXIST', () => {
+    const existingDoc: User = { name: 'John', age: 25 };
+    const inMemoryDatabaseInsertResult = users.insertOne(existingDoc);
+    const handle = (_existing: User | null) => null;
+    const resultInMemoryDatabase = users.handle(
+      inMemoryDatabaseInsertResult.insertedId!,
+      handle,
+      {
+        expectedVersion: 'DOCUMENT_DOES_NOT_EXIST',
+      },
+    );
+    equal(resultInMemoryDatabase.successful, false);
+    deepStrictEqual(resultInMemoryDatabase.document, {
+      ...existingDoc,
+      _id: inMemoryDatabaseInsertResult.insertedId!,
+      _version: 1n,
+    });
+    const inMemoryDatabaseDoc = users.findOne(
+      ({ _id }) => _id === inMemoryDatabaseInsertResult.insertedId,
+    );
+    deepStrictEqual(inMemoryDatabaseDoc, {
+      ...existingDoc,
+      _id: inMemoryDatabaseInsertResult.insertedId!,
+      _version: 1n,
+    });
+  });
+  void it('should NOT delete an existing document when expected version is mismatched', () => {
+    const existingDoc: User = { name: 'John', age: 25 };
+    const inMemoryDatabaseInsertResult = users.insertOne(existingDoc);
+    const handle = (_existing: User | null) => null;
+    const resultInMemoryDatabase = users.handle(
+      inMemoryDatabaseInsertResult.insertedId!,
+      handle,
+      {
+        expectedVersion: 333n,
+      },
+    );
+    equal(resultInMemoryDatabase.successful, false);
+    deepStrictEqual(resultInMemoryDatabase.document, {
+      ...existingDoc,
+      _id: inMemoryDatabaseInsertResult.insertedId!,
+      _version: 1n,
+    });
+    const inMemoryDatabaseDoc = users.findOne(
+      ({ _id }) => _id === inMemoryDatabaseInsertResult.insertedId,
+    );
+    deepStrictEqual(inMemoryDatabaseDoc, {
+      ...existingDoc,
+      _id: inMemoryDatabaseInsertResult.insertedId!,
+      _version: 1n,
+    });
+  });
+});

--- a/src/packages/emmett/src/database/inMemoryDatabase.ts
+++ b/src/packages/emmett/src/database/inMemoryDatabase.ts
@@ -23,7 +23,7 @@ export interface DocumentsCollection<T extends Document> {
     options?: HandleOptions,
   ) => HandleResult<T>;
   findOne: (predicate?: Predicate<T>) => T | null;
-  find: (predicate?: Predicate<T>) => T[] | null;
+  find: (predicate?: Predicate<T>) => T[];
   insertOne: (
     document: OptionalUnlessRequiredIdAndVersion<T>,
   ) => InsertOneResult;
@@ -107,7 +107,7 @@ export const getInMemoryDatabase = (): Database => {
 
           return firstOne as T | null;
         },
-        find: (predicate?: Predicate<T>): T[] | null => {
+        find: (predicate?: Predicate<T>): T[] => {
           ensureCollectionCreated();
 
           const documentsInCollection = storage.get(collectionName);
@@ -115,7 +115,7 @@ export const getInMemoryDatabase = (): Database => {
             ? documentsInCollection?.filter((doc) => predicate(doc as T))
             : documentsInCollection;
 
-          return filteredDocuments as T[] | null;
+          return filteredDocuments as T[];
         },
         deleteOne: (predicate?: Predicate<T>): DeleteResult => {
           ensureCollectionCreated();

--- a/src/packages/emmett/src/database/inMemoryDatabase.ts
+++ b/src/packages/emmett/src/database/inMemoryDatabase.ts
@@ -23,6 +23,7 @@ export interface DocumentsCollection<T extends Document> {
     options?: HandleOptions,
   ) => HandleResult<T>;
   findOne: (predicate?: Predicate<T>) => T | null;
+  find: (predicate?: Predicate<T>) => T[] | null;
   insertOne: (
     document: OptionalUnlessRequiredIdAndVersion<T>,
   ) => InsertOneResult;
@@ -39,13 +40,14 @@ export interface Database {
 }
 
 type Predicate<T> = (item: T) => boolean;
+type CollectionName = string;
 
 export const getInMemoryDatabase = (): Database => {
-  const storage = new Map<string, WithIdAndVersion<Document>[]>();
+  const storage = new Map<CollectionName, WithIdAndVersion<Document>[]>();
 
   return {
-    collection: <T extends Document>(
-      collectionName: string,
+    collection: <T extends Document, CollectionName extends string>(
+      collectionName: CollectionName,
       collectionOptions: {
         errors?: HandleOptionErrors;
       } = {},
@@ -105,6 +107,16 @@ export const getInMemoryDatabase = (): Database => {
 
           return firstOne as T | null;
         },
+        find: (predicate?: Predicate<T>): T[] | null => {
+          ensureCollectionCreated();
+
+          const documentsInCollection = storage.get(collectionName);
+          const filteredDocuments = predicate
+            ? documentsInCollection?.filter((doc) => predicate(doc as T))
+            : documentsInCollection;
+
+          return filteredDocuments as T[] | null;
+        },
         deleteOne: (predicate?: Predicate<T>): DeleteResult => {
           ensureCollectionCreated();
 
@@ -141,20 +153,20 @@ export const getInMemoryDatabase = (): Database => {
                 { operationName: 'deleteOne', collectionName, errors },
               );
             }
-          } else {
-            const newCollection = documentsInCollection.slice(1);
-
-            storage.set(collectionName, newCollection);
-
-            return operationResult<DeleteResult>(
-              {
-                successful: true,
-                matchedCount: 1,
-                deletedCount: 1,
-              },
-              { operationName: 'deleteOne', collectionName, errors },
-            );
           }
+
+          const newCollection = documentsInCollection.slice(1);
+
+          storage.set(collectionName, newCollection);
+
+          return operationResult<DeleteResult>(
+            {
+              successful: true,
+              matchedCount: 1,
+              deletedCount: 1,
+            },
+            { operationName: 'deleteOne', collectionName, errors },
+          );
         },
         replaceOne: (
           predicate: Predicate<T>,
@@ -171,7 +183,7 @@ export const getInMemoryDatabase = (): Database => {
 
           const firstIndex = foundIndexes[0];
 
-          if (!firstIndex || firstIndex === -1) {
+          if (firstIndex === undefined || firstIndex === -1) {
             return operationResult<UpdateResult>(
               {
                 successful: false,
@@ -228,7 +240,7 @@ export const getInMemoryDatabase = (): Database => {
           const { expectedVersion: version, ...operationOptions } =
             options ?? {};
           ensureCollectionCreated();
-          const existing = collection.findOne((c) => c.id === id);
+          const existing = collection.findOne(({ _id }) => _id === id);
 
           const expectedVersion = expectedVersionValue(version);
 

--- a/src/packages/emmett/src/database/inMemoryDatabase.unit.spec.ts
+++ b/src/packages/emmett/src/database/inMemoryDatabase.unit.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import { getInMemoryDatabase } from './inMemoryDatabase';
-import { equal, ok } from 'node:assert';
+import { deepStrictEqual, equal, ok } from 'node:assert';
 
 type TestUser = {
   name: string;
@@ -71,6 +71,36 @@ void describe('inMemoryDatabase', () => {
     const result = collection.findOne((c) => c.age === 20);
 
     equal(result, null);
+  });
+
+  void it('should return empty array when find no results matching found', () => {
+    const db = getInMemoryDatabase();
+
+    const collection = db.collection<TestUser>('test');
+
+    collection.insertOne({ age: 10, name: 'test' });
+    collection.insertOne({ age: 15, name: 'test2' });
+
+    const result = collection.find((c) => c.age === 20);
+
+    equal(result.length, 0);
+  });
+
+  void it('should return all results matching found', () => {
+    const db = getInMemoryDatabase();
+
+    const collection = db.collection<TestUser>('test');
+
+    collection.insertOne({ _id: 'test', age: 10, name: 'test' });
+    collection.insertOne({ _id: 'test2', age: 15, name: 'test2' });
+    collection.insertOne({ _id: 'test3', age: 20, name: 'test3' });
+
+    const result = collection.find((c) => c.age > 10);
+
+    deepStrictEqual(result, [
+      { _id: 'test2', _version: 1n, age: 15, name: 'test2' },
+      { _id: 'test3', _version: 1n, age: 20, name: 'test3' },
+    ]);
   });
 
   void it('should correctly delete one', () => {

--- a/src/packages/emmett/src/database/inMemoryDatabase.unit.spec.ts
+++ b/src/packages/emmett/src/database/inMemoryDatabase.unit.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import { getInMemoryDatabase } from './inMemoryDatabase';
-import { equal } from 'node:assert';
+import { equal, ok } from 'node:assert';
 
 type TestUser = {
   name: string;
@@ -15,7 +15,7 @@ void describe('inMemoryDatabase', () => {
 
     const result = collection.insertOne({ age: 10, name: 'test' });
 
-    equal(result.successful, true);
+    ok(result.successful);
   });
 
   void it('should not allow inserting one with id that already is there', () => {

--- a/src/packages/emmett/src/database/types.ts
+++ b/src/packages/emmett/src/database/types.ts
@@ -156,3 +156,8 @@ export type DeleteManyOptions = {
     'DOCUMENT_EXISTS' | 'NO_CONCURRENCY_CHECK'
   >;
 };
+
+export type FullId<
+  Collection extends string,
+  Id extends string,
+> = `${Collection}-${Id}`;

--- a/src/packages/emmett/src/database/utils.unit.spec.ts
+++ b/src/packages/emmett/src/database/utils.unit.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it } from 'node:test';
+import { operationResult } from './utils';
+import assert from 'node:assert/strict';
+
+void describe('inMemoryDatabase utils', () => {
+  void it('operation result should throw an error when not successful', () => {
+    assert.throws(() => {
+      operationResult(
+        {
+          successful: false,
+        },
+        {
+          collectionName: 'test',
+          operationName: 'test',
+          errors: { throwOnOperationFailures: true },
+        },
+      );
+    });
+  });
+});


### PR DESCRIPTION
This PR is a continuation of the previous one https://github.com/event-driven-io/emmett/pull/207.

Scope of changes:
- Added tests for throwing an error in operationResult when opted-in.
- Added tests for `handle` method on collection.
- Added `find` method on callection to get all results.
- Simplified one if statements 

Regarding `ConcurrencyInMemoryDatabaseError` I decided to create a new Error just because of the porting from https://github.com/event-driven-io/Pongo/blob/main/src/packages/pongo/src/core/typing/operations.ts#L458 that doesn't have matching signature with existing `ConcurrencyError` and I didn't want to drastically reshape that `operationResult`, but I could apply that in next commit if you @oskardudycz think it's better.

Regarding `toFullId` function, I decided for now to not bother figuring out exact behavior of that in inMemoryDatabase implementation with store being simple `Map`. Probably worth revisiting when actually adding different storage possibility.