### PR TITLE
Fix incorrect package names in "Getting Started" documentation

### DIFF
--- a/src/docs/getting-started.md
+++ b/src/docs/getting-started.md
@@ -415,19 +415,19 @@ Let's start by adding some flavour and finally use a real database, so PostgreSQ
 ::: code-group
 
 ```sh [npm]
-$ npm add @event-driven-io/@event-driven-io/emmett-postgresql
+$ npm add @event-driven-io/emmett-postgresql
 ```
 
 ```sh [pnpm]
-$ pnpm add @event-driven-io/@event-driven-io/emmett-postgresql
+$ pnpm add @event-driven-io/emmett-postgresql
 ```
 
 ```sh [yarn]
-$ yarn add @event-driven-io/@event-driven-io/emmett-postgresql
+$ yarn add @event-driven-io/emmett-postgresql
 ```
 
 ```sh [bun]
-$ bun add @event-driven-io/@event-driven-io/emmett-postgresql
+$ bun add @event-driven-io/emmett-postgresql
 ```
 
 :::


### PR DESCRIPTION
In the "End-to-End Testing" section of the "Getting Started" documentation (https://event-driven-io.github.io/emmett/getting-started.html#end-to-end-testing), the package names for installing `emmett-postgresql` are incorrect.

<img width="530" alt="image" src="https://github.com/user-attachments/assets/999c3cc6-8258-45b6-9bb0-9a315d445bfe" />

This PR removes the duplicate `@event-driven-io` from the package names.