### PR TITLE
Added order by to SQL querues in readStream to ensure messages ordering 

### DIFF
--- a/src/packages/emmett-postgresql/src/eventStore/schema/appendToStream.int.spec copy.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/appendToStream.int.spec copy.ts
@@ -1,0 +1,229 @@
+import { dumbo, sql, type Dumbo } from '@event-driven-io/dumbo';
+import {
+  assertEqual,
+  assertFalse,
+  assertIsNotNull,
+  assertOk,
+  assertTrue,
+  type Event,
+} from '@event-driven-io/emmett';
+import {
+  PostgreSqlContainer,
+  type StartedPostgreSqlContainer,
+} from '@testcontainers/postgresql';
+import { after, before, describe, it } from 'node:test';
+import { v4 as uuid } from 'uuid';
+import { createEventStoreSchema } from '.';
+import { appendToStream } from './appendToStream';
+
+export type PricedProductItem = {
+  productId: string;
+  quantity: number;
+  price: number;
+};
+
+export type ShoppingCart = {
+  productItems: PricedProductItem[];
+  totalAmount: number;
+};
+
+export type ProductItemAdded = Event<
+  'ProductItemAdded',
+  { productItem: PricedProductItem },
+  { meta: string }
+>;
+export type DiscountApplied = Event<
+  'DiscountApplied',
+  { percent: number },
+  { meta: string }
+>;
+
+export type ShoppingCartEvent = ProductItemAdded | DiscountApplied;
+
+void describe('appendEvent', () => {
+  let postgres: StartedPostgreSqlContainer;
+  let pool: Dumbo;
+
+  before(async () => {
+    postgres = await new PostgreSqlContainer().start();
+    pool = dumbo({
+      connectionString: postgres.getConnectionUri(),
+    });
+
+    await createEventStoreSchema(pool);
+  });
+
+  after(async () => {
+    try {
+      await pool.close();
+      await postgres.stop();
+    } catch (error) {
+      console.log(error);
+    }
+  });
+
+  const events: ShoppingCartEvent[] = [
+    {
+      type: 'ProductItemAdded',
+      data: { productItem: { productId: '1', quantity: 2, price: 30 } },
+      metadata: { meta: 'data1' },
+    },
+    {
+      type: 'DiscountApplied',
+      data: { percent: 10 },
+      metadata: { meta: 'data2' },
+    },
+  ];
+
+  void it('should append events correctly using appendEvent function', async () => {
+    const result = await appendToStream(pool, uuid(), 'shopping_cart', events, {
+      expectedStreamVersion: 0n,
+    });
+
+    assertTrue(result.success);
+    assertEqual(result.nextStreamPosition, 2n);
+    assertIsNotNull(result.lastGlobalPosition);
+    assertTrue(result.lastGlobalPosition > 0n);
+    assertOk(result.transactionId);
+  });
+
+  void it('should append events correctly without expected stream position', async () => {
+    const result = await appendToStream(
+      pool,
+      uuid(),
+      'shopping_cart',
+      events,
+      {},
+    );
+
+    assertTrue(result.success);
+    assertEqual(result.nextStreamPosition, 2n);
+    assertIsNotNull(result.lastGlobalPosition);
+    assertTrue(result.lastGlobalPosition > 0n);
+    assertOk(result.transactionId);
+  });
+
+  void it('should handle stream position conflict correctly when two streams are created', async () => {
+    // Given
+    const streamId = uuid();
+
+    const firstResult = await appendToStream(
+      pool,
+      streamId,
+      'shopping_cart',
+      events,
+      {
+        expectedStreamVersion: 0n,
+      },
+    );
+    assertTrue(firstResult.success);
+
+    // When
+    const secondResult = await appendToStream(
+      pool,
+      streamId,
+      'shopping_cart',
+      events,
+      {
+        expectedStreamVersion: 0n,
+      },
+    );
+
+    // Then
+    assertFalse(secondResult.success);
+
+    const resultEvents = await pool.execute.query(
+      sql(`SELECT * FROM emt_messages WHERE stream_id = %L`, streamId),
+    );
+
+    assertEqual(events.length, resultEvents.rows.length);
+  });
+
+  void it('should handle stream position conflict correctly when version mismatches', async () => {
+    // Given
+    const streamId = uuid();
+
+    const creationResult = await appendToStream(
+      pool,
+      streamId,
+      'shopping_cart',
+      events,
+    );
+    assertTrue(creationResult.success);
+    const expectedStreamVersion = creationResult.nextStreamPosition;
+
+    const firstResult = await appendToStream(
+      pool,
+      streamId,
+      'shopping_cart',
+      events,
+      {
+        expectedStreamVersion,
+      },
+    );
+    assertTrue(firstResult.success);
+
+    // When
+    const secondResult = await appendToStream(
+      pool,
+      streamId,
+      'shopping_cart',
+      events,
+      {
+        expectedStreamVersion,
+      },
+    );
+
+    // Then
+    assertFalse(secondResult.success);
+
+    const resultEvents = await pool.execute.query(
+      sql(`SELECT * FROM emt_messages WHERE stream_id = %L`, streamId),
+    );
+
+    assertEqual(events.length * 2, resultEvents.rows.length);
+  });
+
+  void it('should not have stream position conflict when version matches', async () => {
+    // Given
+    const streamId = uuid();
+    const expectedStreamVersion = 0n;
+
+    const firstResult = await appendToStream(
+      pool,
+      streamId,
+      'shopping_cart',
+      events,
+      {
+        expectedStreamVersion,
+      },
+    );
+    assertTrue(firstResult.success);
+
+    // When
+    const secondResult = await appendToStream(
+      pool,
+      streamId,
+      'shopping_cart',
+      events,
+      {
+        expectedStreamVersion: firstResult.nextStreamPosition,
+      },
+    );
+
+    // Then
+    assertTrue(secondResult.success);
+
+    const resultEvents = await pool.execute.query(
+      sql(`SELECT * FROM emt_messages WHERE stream_id = %L`, streamId),
+    );
+
+    assertEqual(events.length * 2, resultEvents.rows.length);
+  });
+
+  void it('should handle appending an empty events array gracefully', async () => {
+    const result = await appendToStream(pool, uuid(), 'shopping_cart', []);
+
+    assertFalse(result.success);
+  });
+});

--- a/src/packages/emmett-postgresql/src/eventStore/schema/readStream.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/readStream.ts
@@ -53,7 +53,8 @@ export const readStream = async <EventType extends Event>(
         sql(
           `SELECT stream_id, stream_position, global_position, message_data, message_metadata, message_schema_version, message_type, message_id
            FROM ${messagesTable.name}
-           WHERE stream_id = %L AND partition = %L AND is_archived = FALSE ${fromCondition} ${toCondition}`,
+           WHERE stream_id = %L AND partition = %L AND is_archived = FALSE ${fromCondition} ${toCondition}
+           ORDER BY stream_position ASC`,
           streamId,
           options?.partition ?? defaultTag,
         ),

--- a/src/packages/emmett-sqlite/src/eventStore/schema/readStream.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/schema/readStream.ts
@@ -47,7 +47,8 @@ export const readStream = async <EventType extends Event>(
   const results = await db.query<ReadStreamSqlResult>(
     `SELECT stream_id, stream_position, global_position, message_data, message_metadata, message_schema_version, message_type, message_id
            FROM ${messagesTable.name}
-           WHERE stream_id = ? AND partition = ? AND is_archived = FALSE ${fromCondition} ${toCondition}`,
+           WHERE stream_id = ? AND partition = ? AND is_archived = FALSE ${fromCondition} ${toCondition}
+           ORDER BY stream_position ASC`,
     [streamId, options?.partition ?? defaultTag],
   );
 


### PR DESCRIPTION
Based on the @dawidranda finding in #239, it seems that sometimes the PostgreSQL event store does not return events in the proper order.

Emmett has an index on stream_id and stream position, which is ascending, so when reading, it uses the index and returns messages in the right order.

If it doesn't work for you, it probably means that Postgres is not using an index for some reason. One potential reason is that it may only have rows from a single stream and then decide to do a full scan, which will be faster than using an index.

I wasn't able to reproduce the issues on my local box, even when adding tests simulating the scenario described in #239, but adding ORDER BY won't do harm, as it should still use the index, so we should not get the performance penalty. Plus relying on a certain query plan is not the smartest move.

Applied the same for SQLite implementation.

Fixes #239