### PR TITLE
Add capability to specify custom checkpoint resolution by consumer or processor

### DIFF
--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.handling.int.spec.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.handling.int.spec.ts
@@ -486,7 +486,7 @@ void describe('EventStoreDB event store started consumer', () => {
         },
       );
 
-      void it.skip(
+      void it(
         `handles only new events when CURRENT position is stored for a new consumer from ${displayName}`,
         withDeadline,
         async () => {

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteProcessor.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteProcessor.ts
@@ -1,5 +1,6 @@
 import {
   EmmettError,
+  getCheckpoint,
   type Event,
   type ReadEvent,
   type ReadEventMetadataWithGlobalPosition,
@@ -178,12 +179,17 @@ const genericSQLiteProcessor = <EventType extends Event = Event>(
             fileName,
           });
 
+          const newPosition: bigint | null = getCheckpoint(
+            typedMessage,
+            context,
+          );
+
           // TODO: Add correct handling of the storing checkpoint
           await storeProcessorCheckpoint(connection, {
             processorId: options.processorId,
             version: options.version,
             lastProcessedPosition,
-            newPosition: typedMessage.metadata.globalPosition,
+            newPosition,
             partition: options.partition,
           });
 


### PR DESCRIPTION
You should not always use global position for checkpointing. EventStoreDB forces stream subscription to provide the stream position instead of the global one.

This adds the possibility to pass the getCheckpoint function to checkpointer as a way to tell that they should be using a different checkpointing strategy.

This fixes a bug on restarting the ESDB stream subscriber.