### PR TITLE
Made in-memory database return Promises instead of sync results

### DIFF
--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.inMemory.projections.int.spec.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.inMemory.projections.int.spec.ts
@@ -3,7 +3,7 @@ import {
   getInMemoryDatabase,
   inMemoryProjector,
   inMemorySingleStreamProjection,
-  type DocumentsCollection,
+  type InMemoryDocumentsCollection,
   type ReadEvent,
 } from '@event-driven-io/emmett';
 import {
@@ -28,7 +28,7 @@ void describe('EventStoreDB event store started consumer', () => {
   let eventStoreDB: StartedEventStoreDBContainer;
   let connectionString: string;
   let eventStore: EventStoreDBEventStore;
-  let summaries: DocumentsCollection<ShoppingCartSummary>;
+  let summaries: InMemoryDocumentsCollection<ShoppingCartSummary>;
   const productItem = { price: 10, productId: uuid(), quantity: 10 };
   const confirmedAt = new Date();
   const database = getInMemoryDatabase();
@@ -84,7 +84,7 @@ void describe('EventStoreDB event store started consumer', () => {
         try {
           await consumer.start();
 
-          const summary = summaries.findOne((d) => d._id === streamName);
+          const summary = await summaries.findOne((d) => d._id === streamName);
 
           assertMatches(summary, {
             _id: streamName,
@@ -146,7 +146,7 @@ void describe('EventStoreDB event store started consumer', () => {
 
           await consumerPromise;
 
-          const summary = summaries.findOne((d) => d._id === streamName);
+          const summary = await summaries.findOne((d) => d._id === streamName);
 
           assertMatches(summary, {
             _id: streamName,
@@ -212,7 +212,7 @@ void describe('EventStoreDB event store started consumer', () => {
 
           await consumerPromise;
 
-          const summary = summaries.findOne((d) => d._id === streamName);
+          const summary = await summaries.findOne((d) => d._id === streamName);
 
           assertMatches(summary, {
             _id: streamName,
@@ -279,7 +279,7 @@ void describe('EventStoreDB event store started consumer', () => {
 
           await consumerPromise;
 
-          const summary = summaries.findOne((d) => d._id === streamName);
+          const summary = await summaries.findOne((d) => d._id === streamName);
 
           assertMatches(summary, {
             _id: streamName,
@@ -352,7 +352,7 @@ void describe('EventStoreDB event store started consumer', () => {
 
           await consumerPromise;
 
-          const summary = summaries.findOne((d) => d._id === streamName);
+          const summary = await summaries.findOne((d) => d._id === streamName);
 
           assertMatches(summary, {
             _id: streamName,
@@ -433,7 +433,7 @@ void describe('EventStoreDB event store started consumer', () => {
 
           await consumerPromise;
 
-          const summary = summaries.findOne((d) => d._id === streamName);
+          const summary = await summaries.findOne((d) => d._id === streamName);
 
           assertMatches(summary, {
             _id: streamName,

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.inMemory.projections.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.inMemory.projections.int.spec.ts
@@ -3,7 +3,7 @@ import {
   getInMemoryDatabase,
   inMemoryProjector,
   inMemorySingleStreamProjection,
-  type DocumentsCollection,
+  type InMemoryDocumentsCollection,
   type ReadEvent,
 } from '@event-driven-io/emmett';
 import {
@@ -28,7 +28,7 @@ void describe('PostgreSQL event store started consumer', () => {
   let postgres: StartedPostgreSqlContainer;
   let connectionString: string;
   let eventStore: PostgresEventStore;
-  let summaries: DocumentsCollection<ShoppingCartSummary>;
+  let summaries: InMemoryDocumentsCollection<ShoppingCartSummary>;
   const productItem = { price: 10, productId: uuid(), quantity: 10 };
   const confirmedAt = new Date();
   const database = getInMemoryDatabase();
@@ -87,7 +87,7 @@ void describe('PostgreSQL event store started consumer', () => {
         try {
           await consumer.start();
 
-          const summary = summaries.findOne((d) => d._id === streamName);
+          const summary = await summaries.findOne((d) => d._id === streamName);
 
           assertMatches(summary, {
             _id: streamName,
@@ -150,7 +150,7 @@ void describe('PostgreSQL event store started consumer', () => {
 
           await consumerPromise;
 
-          const summary = summaries.findOne((d) => d._id === streamName);
+          const summary = await summaries.findOne((d) => d._id === streamName);
 
           assertMatches(summary, {
             _id: streamName,
@@ -217,7 +217,7 @@ void describe('PostgreSQL event store started consumer', () => {
 
           await consumerPromise;
 
-          const summary = summaries.findOne((d) => d._id === streamName);
+          const summary = await summaries.findOne((d) => d._id === streamName);
 
           assertMatches(summary, {
             _id: streamName,
@@ -285,7 +285,7 @@ void describe('PostgreSQL event store started consumer', () => {
 
           await consumerPromise;
 
-          const summary = summaries.findOne((d) => d._id === streamName);
+          const summary = await summaries.findOne((d) => d._id === streamName);
 
           assertMatches(summary, {
             _id: streamName,
@@ -359,7 +359,7 @@ void describe('PostgreSQL event store started consumer', () => {
 
           await consumerPromise;
 
-          const summary = summaries.findOne((d) => d._id === streamName);
+          const summary = await summaries.findOne((d) => d._id === streamName);
 
           assertMatches(summary, {
             _id: streamName,
@@ -441,7 +441,7 @@ void describe('PostgreSQL event store started consumer', () => {
 
           await consumerPromise;
 
-          const summary = summaries.findOne((d) => d._id === streamName);
+          const summary = await summaries.findOne((d) => d._id === streamName);
 
           assertMatches(summary, {
             _id: streamName,

--- a/src/packages/emmett/src/database/handle.unit.spec.ts
+++ b/src/packages/emmett/src/database/handle.unit.spec.ts
@@ -1,7 +1,7 @@
 import { deepStrictEqual, equal, ok } from 'node:assert/strict';
 import { beforeEach, describe, it } from 'node:test';
 import {
-  type DocumentsCollection,
+  type InMemoryDocumentsCollection,
   getInMemoryDatabase,
 } from './inMemoryDatabase';
 
@@ -23,7 +23,7 @@ type User = {
 };
 
 void describe('InMemoryDatabase Handle Operations', () => {
-  let users: DocumentsCollection<User>;
+  let users: InMemoryDocumentsCollection<User>;
 
   beforeEach(() => {
     const db = getInMemoryDatabase();

--- a/src/packages/emmett/src/database/inMemoryDatabase.ts
+++ b/src/packages/emmett/src/database/inMemoryDatabase.ts
@@ -16,7 +16,7 @@ import {
 } from './types';
 import { expectedVersionValue, operationResult } from './utils';
 
-export interface DocumentsCollection<T extends Document> {
+export interface InMemoryDocumentsCollection<T extends Document> {
   handle: (
     id: string,
     handle: DocumentHandler<T>,
@@ -35,14 +35,16 @@ export interface DocumentsCollection<T extends Document> {
   ) => Promise<UpdateResult>;
 }
 
-export interface Database {
-  collection: <T extends Document>(name: string) => DocumentsCollection<T>;
+export interface InMemoryDatabase {
+  collection: <T extends Document>(
+    name: string,
+  ) => InMemoryDocumentsCollection<T>;
 }
 
 type Predicate<T> = (item: T) => boolean;
 type CollectionName = string;
 
-export const getInMemoryDatabase = (): Database => {
+export const getInMemoryDatabase = (): InMemoryDatabase => {
   const storage = new Map<CollectionName, WithIdAndVersion<Document>[]>();
 
   return {
@@ -51,7 +53,7 @@ export const getInMemoryDatabase = (): Database => {
       collectionOptions: {
         errors?: DatabaseHandleOptionErrors;
       } = {},
-    ): DocumentsCollection<T> => {
+    ): InMemoryDocumentsCollection<T> => {
       const ensureCollectionCreated = () => {
         if (!storage.has(collectionName)) storage.set(collectionName, []);
       };

--- a/src/packages/emmett/src/database/inMemoryDatabase.unit.spec.ts
+++ b/src/packages/emmett/src/database/inMemoryDatabase.unit.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
+import { assertDeepEqual, assertEqual, assertOk } from '../testing';
 import { getInMemoryDatabase } from './inMemoryDatabase';
-import { deepStrictEqual, equal, ok } from 'node:assert';
 
 type TestUser = {
   name: string;
@@ -8,128 +8,128 @@ type TestUser = {
 };
 
 void describe('inMemoryDatabase', () => {
-  void it('should correctly insertOne document', () => {
+  void it('should correctly insertOne document', async () => {
     const db = getInMemoryDatabase();
 
     const collection = db.collection<TestUser>('test');
 
-    const result = collection.insertOne({ age: 10, name: 'test' });
+    const result = await collection.insertOne({ age: 10, name: 'test' });
 
-    ok(result.successful);
+    assertOk(result.successful);
   });
 
-  void it('should not allow inserting one with id that already is there', () => {
+  void it('should not allow inserting one with id that already is there', async () => {
     const db = getInMemoryDatabase();
 
     const collection = db.collection<TestUser>('test');
 
-    const result = collection.insertOne({ age: 10, name: 'test' });
+    const result = await collection.insertOne({ age: 10, name: 'test' });
 
-    const result2 = collection.insertOne({
+    const result2 = await collection.insertOne({
       age: 10,
       name: 'test',
       _id: result.insertedId!,
     });
 
-    equal(result2.successful, false);
+    assertEqual(result2.successful, false);
   });
 
-  void it('return first record found when using findOne without parameters', () => {
+  void it('return first record found when using findOne without parameters', async () => {
     const db = getInMemoryDatabase();
 
     const collection = db.collection<TestUser>('test');
 
-    collection.insertOne({ age: 10, name: 'test' });
-    collection.insertOne({ age: 15, name: 'test2' });
+    await collection.insertOne({ age: 10, name: 'test' });
+    await collection.insertOne({ age: 15, name: 'test2' });
 
-    const result = collection.findOne();
+    const result = await collection.findOne();
 
-    equal(result!.name, 'test');
+    assertEqual(result?.name, 'test');
   });
 
-  void it('should return the correct one found', () => {
+  void it('should return the correct one found', async () => {
     const db = getInMemoryDatabase();
 
     const collection = db.collection<TestUser>('test');
 
-    collection.insertOne({ age: 10, name: 'test' });
-    collection.insertOne({ age: 15, name: 'test2' });
+    await collection.insertOne({ age: 10, name: 'test' });
+    await collection.insertOne({ age: 15, name: 'test2' });
 
-    const result = collection.findOne((c) => c.age === 15);
+    const result = await collection.findOne((c) => c.age === 15);
 
-    equal(result!.name, 'test2');
+    assertEqual(result?.name, 'test2');
   });
 
-  void it('should return null when not found', () => {
+  void it('should return null when not found', async () => {
     const db = getInMemoryDatabase();
 
     const collection = db.collection<TestUser>('test');
 
-    collection.insertOne({ age: 10, name: 'test' });
-    collection.insertOne({ age: 15, name: 'test2' });
+    await collection.insertOne({ age: 10, name: 'test' });
+    await collection.insertOne({ age: 15, name: 'test2' });
 
-    const result = collection.findOne((c) => c.age === 20);
+    const result = await collection.findOne((c) => c.age === 20);
 
-    equal(result, null);
+    assertEqual(result, null);
   });
 
-  void it('should return empty array when find no results matching found', () => {
+  void it('should return empty array when find no results matching found', async () => {
     const db = getInMemoryDatabase();
 
     const collection = db.collection<TestUser>('test');
 
-    collection.insertOne({ age: 10, name: 'test' });
-    collection.insertOne({ age: 15, name: 'test2' });
+    await collection.insertOne({ age: 10, name: 'test' });
+    await collection.insertOne({ age: 15, name: 'test2' });
 
-    const result = collection.find((c) => c.age === 20);
+    const result = await collection.find((c) => c.age === 20);
 
-    equal(result.length, 0);
+    assertEqual(result.length, 0);
   });
 
-  void it('should return all results matching found', () => {
+  void it('should return all results matching found', async () => {
     const db = getInMemoryDatabase();
 
     const collection = db.collection<TestUser>('test');
 
-    collection.insertOne({ _id: 'test', age: 10, name: 'test' });
-    collection.insertOne({ _id: 'test2', age: 15, name: 'test2' });
-    collection.insertOne({ _id: 'test3', age: 20, name: 'test3' });
+    await collection.insertOne({ _id: 'test', age: 10, name: 'test' });
+    await collection.insertOne({ _id: 'test2', age: 15, name: 'test2' });
+    await collection.insertOne({ _id: 'test3', age: 20, name: 'test3' });
 
-    const result = collection.find((c) => c.age > 10);
+    const result = await collection.find((c) => c.age > 10);
 
-    deepStrictEqual(result, [
-      { _id: 'test2', _version: 1n, age: 15, name: 'test2' },
-      { _id: 'test3', _version: 1n, age: 20, name: 'test3' },
+    assertDeepEqual(result, [
+      { _id: 'test2', _version: 1n, age: 15, name: 'test2' } as TestUser,
+      { _id: 'test3', _version: 1n, age: 20, name: 'test3' } as TestUser,
     ]);
   });
 
-  void it('should correctly delete one', () => {
+  void it('should correctly delete one', async () => {
     const db = getInMemoryDatabase();
 
     const collection = db.collection<TestUser>('test');
 
-    collection.insertOne({ age: 10, name: 'test' });
-    collection.insertOne({ age: 15, name: 'test2' });
+    await collection.insertOne({ age: 10, name: 'test' });
+    await collection.insertOne({ age: 15, name: 'test2' });
 
-    const deleteResult = collection.deleteOne((c) => c.age === 15);
-    const found = collection.findOne((c) => c.age === 15);
+    const deleteResult = await collection.deleteOne((c) => c.age === 15);
+    const found = await collection.findOne((c) => c.age === 15);
 
-    equal(deleteResult.deletedCount, 1);
-    equal(found, null);
+    assertEqual(deleteResult.deletedCount, 1);
+    assertEqual(found, null);
   });
 
-  void it('should delete first one when no parameter passed to deleteOne', () => {
+  void it('should delete first one when no parameter passed to deleteOne', async () => {
     const db = getInMemoryDatabase();
 
     const collection = db.collection<TestUser>('test');
 
-    collection.insertOne({ age: 10, name: 'test' });
-    collection.insertOne({ age: 15, name: 'test2' });
+    await collection.insertOne({ age: 10, name: 'test' });
+    await collection.insertOne({ age: 15, name: 'test2' });
 
-    const deleteResult = collection.deleteOne();
-    const found = collection.findOne((c) => c.age === 10);
+    const deleteResult = await collection.deleteOne();
+    const found = await collection.findOne((c) => c.age === 10);
 
-    equal(deleteResult.deletedCount, 1);
-    equal(found, null);
+    assertEqual(deleteResult.deletedCount, 1);
+    assertEqual(found, null);
   });
 });

--- a/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
+++ b/src/packages/emmett/src/eventStore/inMemoryEventStore.ts
@@ -1,7 +1,7 @@
 import { v4 as uuid } from 'uuid';
 import {
   getInMemoryDatabase,
-  type Database,
+  type InMemoryDatabase,
 } from '../database/inMemoryDatabase';
 import type { ProjectionRegistration } from '../projections';
 import type {
@@ -30,14 +30,14 @@ export const InMemoryEventStoreDefaultStreamVersion = 0n;
 
 export type InMemoryEventStore =
   EventStore<ReadEventMetadataWithGlobalPosition> & {
-    database: Database;
+    database: InMemoryDatabase;
   };
 
 export type InMemoryReadEventMetadata = ReadEventMetadataWithGlobalPosition;
 
 export type InMemoryProjectionHandlerContext = {
   eventStore?: InMemoryEventStore;
-  database?: Database;
+  database?: InMemoryDatabase;
 };
 
 export type InMemoryEventStoreOptions =
@@ -47,7 +47,7 @@ export type InMemoryEventStoreOptions =
       InMemoryReadEventMetadata,
       InMemoryProjectionHandlerContext
     >[];
-    database?: Database;
+    database?: InMemoryDatabase;
   };
 
 export type InMemoryReadEvent<EventType extends Event = Event> = ReadEvent<

--- a/src/packages/emmett/src/eventStore/projections/inMemory/inMemoryProjection.ts
+++ b/src/packages/emmett/src/eventStore/projections/inMemory/inMemoryProjection.ts
@@ -177,24 +177,20 @@ export const inMemoryMultiStreamProjection = <
       );
     },
     canHandle,
-    truncate: ({
+    truncate: async ({
       database,
     }: InMemoryProjectionHandlerContext & { database: Database }) => {
-      return new Promise<void>((resolve) => {
-        // For InMemory database, we can't directly truncate a collection
-        // So we'll delete all documents from the collection
-        const collection = database.collection<DocumentType>(collectionName);
-        const documents = collection.find();
+      // For InMemory database, we can't directly truncate a collection
+      // So we'll delete all documents from the collection
+      const collection = database.collection<DocumentType>(collectionName);
+      const documents = await collection.find();
 
-        for (const doc of documents) {
-          if (doc && '_id' in doc) {
-            const id = doc._id;
-            collection.deleteOne((d) => d._id === id);
-          }
+      for (const doc of documents) {
+        if (doc && '_id' in doc) {
+          const id = doc._id;
+          await collection.deleteOne((d) => d._id === id);
         }
-
-        resolve();
-      });
+      }
     },
   });
 };

--- a/src/packages/emmett/src/eventStore/projections/inMemory/inMemoryProjectionSpec.ts
+++ b/src/packages/emmett/src/eventStore/projections/inMemory/inMemoryProjectionSpec.ts
@@ -5,8 +5,8 @@ import {
 } from '.';
 import {
   getInMemoryDatabase,
-  type Database,
   type Document,
+  type InMemoryDatabase,
 } from '../../../database';
 import { isErrorConstructor } from '../../../errors';
 import {
@@ -50,7 +50,7 @@ export type InMemoryProjectionSpec<EventType extends Event> = (
 };
 
 export type InMemoryProjectionAssert = (options: {
-  database: Database;
+  database: InMemoryDatabase;
 }) => Promise<void | boolean>;
 
 export type InMemoryProjectionSpecOptions<EventType extends Event> = {
@@ -72,7 +72,7 @@ export const InMemoryProjectionSpec = {
           const allEvents: ReadEvent<EventType, InMemoryReadEventMetadata>[] =
             [];
 
-          const run = async (database: Database) => {
+          const run = async (database: InMemoryDatabase) => {
             let globalPosition = 0n;
             const numberOfTimes = options?.numberOfTimes ?? 1;
 
@@ -226,10 +226,10 @@ export function documentExists<T extends DocumentWithId>(
   expected: Partial<T>,
   options: { inCollection: string; withId: string | number },
 ): InMemoryProjectionAssert {
-  return ({ database }) => {
+  return async ({ database }) => {
     const collection = database.collection<T>(options.inCollection);
 
-    const document = collection.findOne((doc) => {
+    const document = await collection.findOne((doc) => {
       // Handle both string IDs and numeric IDs in a type-safe way
       const docId = '_id' in doc ? doc._id : undefined;
       return docId === options.withId;

--- a/src/packages/emmett/src/processors/inMemoryProcessors.ts
+++ b/src/packages/emmett/src/processors/inMemoryProcessors.ts
@@ -1,4 +1,4 @@
-import { getInMemoryDatabase, type Database } from '../database';
+import { getInMemoryDatabase, type InMemoryDatabase } from '../database';
 import { EmmettError } from '../errors';
 import {
   type AnyEvent,
@@ -20,7 +20,7 @@ import {
 } from './processors';
 
 export type InMemoryProcessorHandlerContext = {
-  database: Database;
+  database: InMemoryDatabase;
 };
 
 export type InMemoryProcessor<MessageType extends AnyMessage = AnyMessage> =
@@ -29,7 +29,7 @@ export type InMemoryProcessor<MessageType extends AnyMessage = AnyMessage> =
     // TODO: generalize this to support other metadata types
     ReadEventMetadataWithGlobalPosition,
     InMemoryProcessorHandlerContext
-  > & { database: Database };
+  > & { database: InMemoryDatabase };
 
 export type InMemoryProcessorEachMessageHandler<
   MessageType extends AnyMessage = AnyMessage,
@@ -48,7 +48,7 @@ export type InMemoryProcessorEachBatchHandler<
 >;
 
 export type InMemoryProcessorConnectionOptions = {
-  database?: Database;
+  database?: InMemoryDatabase;
 };
 
 type CheckpointDocument = {
@@ -100,7 +100,7 @@ export const inMemoryCheckpointer = <
           reason: currentPosition === newCheckpoint ? 'IGNORED' : 'MISMATCH',
         });
 
-      checkpoints.handle(processorId, (existing) => ({
+      await checkpoints.handle(processorId, (existing) => ({
         ...(existing ?? {}),
         _id: processorId,
         lastCheckpoint: newCheckpoint,
@@ -139,7 +139,7 @@ export type InMemoryProcessorOptions<
   | InMemoryProjectorOptions<MessageType & AnyEvent>;
 
 const inMemoryProcessingScope = (options: {
-  database: Database | null;
+  database: InMemoryDatabase | null;
   processorId: string;
 }): MessageProcessingScope<InMemoryProcessorHandlerContext> => {
   const processorDatabase = options.database;

--- a/src/packages/emmett/src/processors/inMemoryProcessors.ts
+++ b/src/packages/emmett/src/processors/inMemoryProcessors.ts
@@ -67,8 +67,8 @@ export const inMemoryCheckpointer = <
   MessageType extends AnyMessage = AnyMessage,
 >(): InMemoryCheckpointer<MessageType> => {
   return {
-    read: ({ processorId }, { database }) => {
-      const checkpoint = database
+    read: async ({ processorId }, { database }) => {
+      const checkpoint = await database
         .collection<CheckpointDocument>('emt_processor_checkpoints')
         .findOne((d) => d._id === processorId);
 
@@ -76,17 +76,18 @@ export const inMemoryCheckpointer = <
         lastCheckpoint: checkpoint?.lastCheckpoint ?? null,
       });
     },
-    store: (context, { database }) => {
+    store: async (context, { database }) => {
       const { message, processorId, lastCheckpoint } = context;
       const checkpoints = database.collection<CheckpointDocument>(
         'emt_processor_checkpoints',
       );
 
-      const checkpoint = checkpoints.findOne((d) => d._id === processorId);
+      const checkpoint = await checkpoints.findOne(
+        (d) => d._id === processorId,
+      );
 
       const currentPosition = checkpoint?.lastCheckpoint ?? null;
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const newCheckpoint: bigint | null = getCheckpoint(message, context);
 
       if (


### PR DESCRIPTION
## 1. Made in-memory database return Promises instead of sync results
For now, this may seem redundant, but in the future, we may add tracing and a single writer, which will require Promises. Also, we should make it closer to Pongo definitions.

Better to do those breaking changes sooner rather than later.

## 2. Renamed the Database to the InMemoryDatabase and DocumentsCollection to InMemoryDocumentsCollection. 

This will make it more explicit, especially since some signatures, like find by predicate, already assume that we may add a base signature when needed in the future.

@stepaniukm  @GaryACraine @mbirkegaard FYI

