### PR TITLE
[MongoDBEventStore] Fix bug in `projections.inline.count` to ignore any `null` projections

### DIFF
--- a/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/mongoDBEventStore.ts
@@ -486,7 +486,7 @@ class MongoDBEventStoreImplementation implements MongoDBEventStore, Closeable {
     >(projectionQuery, prefix);
 
     const filters: Filter<EventStream>[] = [
-      { [`projections.${projectionName}`]: { $exists: true } },
+      { [`projections.${projectionName}`]: { $ne: null } },
     ];
 
     if (projectionFilter) {
@@ -549,7 +549,7 @@ class MongoDBEventStoreImplementation implements MongoDBEventStore, Closeable {
     >(projectionQuery, prefix);
 
     const filters: Filter<EventStream>[] = [
-      { [`projections.${projectionName}`]: { $exists: true } },
+      { [`projections.${projectionName}`]: { $ne: null } },
     ];
 
     if (projectionFilter) {


### PR DESCRIPTION
## Description

- Previously, the `projections.inline.count` helper attempted to exclude null projections by checking for `{ $exists: false }`
- This does not work for the MongoDB query where projections are explicitly set to `null`
- The new behavior ignores any non-existent or null projections
- Adjusted projection helper tests to account for new behavior