### PR TITLE
Fixed EventStoreDB category stream checkpointing

### DIFF
--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.handling.int.spec.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.handling.int.spec.ts
@@ -3,6 +3,7 @@ import {
   getInMemoryDatabase,
   type Event,
   type InMemoryReactorOptions,
+  type RecordedMessage,
 } from '@event-driven-io/emmett';
 import {
   EventStoreDBContainer,
@@ -48,9 +49,134 @@ void describe('EventStoreDB event store started consumer', () => {
   ][] = [
     ['all', () => ({ stream: $all })],
     ['stream', (streamName) => ({ stream: streamName })],
+    [
+      'category',
+      () => ({ stream: '$ce-guestStay', options: { resolveLinkTos: true } }),
+    ],
   ];
 
   void describe('eachMessage', () => {
+    void it(
+      `handles all events from $ce stream for subscription to stream`,
+      withDeadline,
+      async () => {
+        // Given
+        const guestId = uuid();
+        const otherGuestId = uuid();
+        const streamName = `guestStay-${otherGuestId}`;
+        const otherStreamName = `guestStay-${guestId}`;
+        const events: GuestStayEvent[] = [
+          { type: 'GuestCheckedIn', data: { guestId } },
+          { type: 'GuestCheckedOut', data: { guestId } },
+        ];
+        await eventStore.appendToStream(streamName, events);
+        const appendResult = await eventStore.appendToStream(
+          otherStreamName,
+          events,
+        );
+
+        const result: RecordedMessage<GuestStayEvent>[] = [];
+
+        // When
+        const consumer = eventStoreDBEventStoreConsumer({
+          connectionString,
+          from: { stream: '$ce-guestStay', options: { resolveLinkTos: true } },
+        });
+
+        consumer.reactor<GuestStayEvent>({
+          processorId: uuid(),
+          stopAfter: (event) =>
+            event.metadata.globalPosition ===
+            appendResult.lastEventGlobalPosition,
+          eachMessage: (event) => {
+            if (
+              event.metadata.streamName === streamName ||
+              event.metadata.streamName === otherStreamName
+            )
+              result.push(event);
+          },
+        });
+
+        try {
+          await consumer.start();
+
+          const expectedEvents: RecordedMessage<GuestStayEvent>[] = [
+            ...events,
+            ...events,
+          ].map(
+            (e, i) =>
+              ({
+                ...e,
+                metadata: {
+                  checkpoint: BigInt(i),
+                },
+              }) as unknown as RecordedMessage<GuestStayEvent>,
+          );
+
+          assertThatArray(result).hasSize(expectedEvents.length);
+          assertThatArray(result).containsElementsMatching(expectedEvents);
+        } finally {
+          await consumer.close();
+        }
+      },
+    );
+
+    void it(
+      `handles all events from $ce streams for subscription to stream`,
+      withDeadline,
+      async () => {
+        // Given
+        const guestId = uuid();
+        const otherGuestId = uuid();
+        const streamName = `guestStay-${otherGuestId}`;
+        const otherStreamName = `guestStay-${guestId}`;
+        const events: GuestStayEvent[] = [
+          { type: 'GuestCheckedIn', data: { guestId } },
+          { type: 'GuestCheckedOut', data: { guestId } },
+        ];
+        await eventStore.appendToStream(streamName, events);
+        const appendResult = await eventStore.appendToStream(
+          otherStreamName,
+          events,
+        );
+
+        const result: GuestStayEvent[] = [];
+
+        // When
+        const consumer = eventStoreDBEventStoreConsumer({
+          connectionString,
+          from: { stream: $all },
+        });
+
+        consumer.reactor<GuestStayEvent>({
+          processorId: uuid(),
+          stopAfter: (event) =>
+            event.metadata.globalPosition ===
+            appendResult.lastEventGlobalPosition,
+          eachMessage: (event) => {
+            if (
+              event.metadata.streamName === streamName ||
+              event.metadata.streamName === otherStreamName
+            )
+              result.push(event);
+          },
+        });
+
+        try {
+          await consumer.start();
+
+          assertThatArray(result).hasSize(events.length * 2);
+
+          assertThatArray(result).containsElementsMatching([
+            ...events,
+            ...events,
+          ]);
+        } finally {
+          await consumer.close();
+        }
+      },
+    );
+
     void it(
       `handles ONLY events from single streams for subscription to stream`,
       withDeadline,

--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.ts
@@ -9,14 +9,12 @@ import {
   type AsyncRetryOptions,
   type BatchRecordedMessageHandlerWithoutContext,
   type DefaultRecord,
-  type GetCheckpoint,
   type InMemoryProcessor,
   type InMemoryProjectorOptions,
   type InMemoryReactorOptions,
   type Message,
   type MessageConsumer,
   type MessageConsumerOptions,
-  type RecordedMessage,
 } from '@event-driven-io/emmett';
 import {
   EventStoreDBClient,
@@ -88,13 +86,6 @@ export type EventStoreDBEventStoreConsumer<
       }>
     : object);
 
-export const getStreamPositionAsCheckpoint = <
-  MessageType extends AnyMessage = AnyMessage,
->(
-  message: RecordedMessage<MessageType, EventStoreDBReadEventMetadata>,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
-): bigint => message.metadata.streamPosition;
-
 export const eventStoreDBEventStoreConsumer = <
   ConsumerMessageType extends Message = AnyMessage,
 >(
@@ -113,13 +104,6 @@ export const eventStoreDBEventStoreConsumer = <
       ? options.client
       : EventStoreDBClient.connectionString(options.connectionString);
 
-  const getCheckpoint:
-    | GetCheckpoint<ConsumerMessageType, EventStoreDBReadEventMetadata, bigint>
-    | undefined =
-    options.from?.stream && options.from.stream !== $all
-      ? getStreamPositionAsCheckpoint
-      : undefined;
-
   const eachBatch: BatchRecordedMessageHandlerWithoutContext<
     ConsumerMessageType,
     EventStoreDBReadEventMetadata
@@ -135,8 +119,7 @@ export const eventStoreDBEventStoreConsumer = <
     const result = await Promise.allSettled(
       activeProcessors.map((s) => {
         // TODO: Add here filtering to only pass messages that can be handled by
-        // TODO: Try to add typing for getCheckpoint
-        return s.handle(messagesBatch, { client, getCheckpoint });
+        return s.handle(messagesBatch, { client });
       }),
     );
 

--- a/src/packages/emmett-esdb/src/eventStore/consumers/subscriptions/index.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/subscriptions/index.ts
@@ -11,7 +11,6 @@ import {
   EventStoreDBClient,
   excludeSystemEvents,
   START,
-  type JSONRecordedEvent,
   type StreamSubscription,
 } from '@eventstore/db-client';
 import { finished, Readable } from 'stream';
@@ -144,9 +143,7 @@ export const eventStoreDBSubscription = <
             subscription.on('data', async (resolvedEvent) => {
               if (!resolvedEvent.event) return;
 
-              const message = mapFromESDBEvent(
-                resolvedEvent.event as JSONRecordedEvent<MessageType>,
-              );
+              const message = mapFromESDBEvent(resolvedEvent, from);
 
               const result = await eachBatch([message]);
 
@@ -163,7 +160,11 @@ export const eventStoreDBSubscription = <
                     ? {
                         fromPosition: resolvedEvent.event.position,
                       }
-                    : { fromRevision: resolvedEvent.event.revision }),
+                    : {
+                        fromRevision:
+                          resolvedEvent.link?.revision ??
+                          resolvedEvent.event.revision,
+                      }),
                 },
               };
             }) as unknown as Readable,

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLProcessor.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLProcessor.ts
@@ -144,7 +144,7 @@ export const postgreSQLCheckpointer = <
     return { lastCheckpoint: result?.lastProcessedPosition };
   },
   store: async (options, context) => {
-    const newPosition: bigint | null = getCheckpoint(options.message, options);
+    const newPosition: bigint | null = getCheckpoint(options.message);
 
     const result = await storeProcessorCheckpoint(context.execute, {
       lastProcessedPosition: options.lastCheckpoint,

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteProcessor.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteProcessor.ts
@@ -179,10 +179,7 @@ const genericSQLiteProcessor = <EventType extends Event = Event>(
             fileName,
           });
 
-          const newPosition: bigint | null = getCheckpoint(
-            typedMessage,
-            context,
-          );
+          const newPosition: bigint | null = getCheckpoint(typedMessage);
 
           // TODO: Add correct handling of the storing checkpoint
           await storeProcessorCheckpoint(connection, {

--- a/src/packages/emmett/src/processors/inMemoryProcessors.ts
+++ b/src/packages/emmett/src/processors/inMemoryProcessors.ts
@@ -88,7 +88,7 @@ export const inMemoryCheckpointer = <
 
       const currentPosition = checkpoint?.lastCheckpoint ?? null;
 
-      const newCheckpoint: bigint | null = getCheckpoint(message, context);
+      const newCheckpoint: bigint | null = getCheckpoint(message);
 
       if (
         currentPosition &&


### PR DESCRIPTION
Refactored checkpointing handling to allow more advanced checkpointing strategies. 

For instance, EventStoreDB for the category or event type system streams should use the category stream position, which differs from the original stream position used (and mapped to the stream) and the global position.

Now, the consumer fills the checkpoint property in metadata instead of passing a custom function to distinguish the checkpointing detection. Now, the checkpointer can just use this property. This will also be useful in the future, for example, with a Kafka consumer, as it will use a partition offset.

@mbirkegaard FYI.