### PR TITLE
Fixed ESDB reactors to handle events sequentially

### DIFF
--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.inMemory.projections.int.spec.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.inMemory.projections.int.spec.ts
@@ -22,7 +22,7 @@ import {
 } from '../eventstoreDBEventStore';
 import { eventStoreDBEventStoreConsumer } from './eventStoreDBEventStoreConsumer';
 
-const withDeadline = { timeout: 5000 };
+const withDeadline = { timeout: 10000 };
 
 void describe('EventStoreDB event store started consumer', () => {
   let eventStoreDB: StartedEventStoreDBContainer;

--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.inMemory.projections.int.spec.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.inMemory.projections.int.spec.ts
@@ -217,7 +217,7 @@ void describe('EventStoreDB event store started consumer', () => {
           assertMatches(summary, {
             _id: streamName,
             status: 'confirmed',
-            //_version: 2n,
+            _version: 2n,
             productItemsCount: productItem.quantity,
           });
         } finally {

--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.ts
@@ -123,12 +123,17 @@ export const eventStoreDBEventStoreConsumer = <
       }),
     );
 
+    const error = result.find((r) => r.status === 'rejected')?.reason as
+      | Error
+      | undefined;
+
     return result.some(
       (r) => r.status === 'fulfilled' && r.value?.type !== 'STOP',
     )
       ? undefined
       : {
           type: 'STOP',
+          error: error ? EmmettError.mapFrom(error) : undefined,
         };
   };
 

--- a/src/packages/emmett/src/database/inMemoryDatabase.ts
+++ b/src/packages/emmett/src/database/inMemoryDatabase.ts
@@ -185,11 +185,9 @@ export const getInMemoryDatabase = (): InMemoryDatabase => {
 
           const documentsInCollection = storage.get(collectionName)!;
 
-          const foundIndexes = documentsInCollection
-            .filter((doc) => predicate(doc as T))
-            .map((_, index) => index);
-
-          const firstIndex = foundIndexes[0];
+          const firstIndex = documentsInCollection.findIndex((doc) =>
+            predicate(doc as T),
+          );
 
           if (firstIndex === undefined || firstIndex === -1) {
             return Promise.resolve(
@@ -239,7 +237,7 @@ export const getInMemoryDatabase = (): InMemoryDatabase => {
               {
                 successful: true,
                 modifiedCount: 1,
-                matchedCount: foundIndexes.length,
+                matchedCount: firstIndex,
                 nextExpectedVersion: newVersion,
               },
               { operationName: 'replaceOne', collectionName, errors },

--- a/src/packages/emmett/src/errors/index.ts
+++ b/src/packages/emmett/src/errors/index.ts
@@ -43,6 +43,24 @@ export class EmmettError extends Error {
     // 👇️ because we are extending a built-in class
     Object.setPrototypeOf(this, EmmettError.prototype);
   }
+
+  public static mapFrom(
+    error: Error | { message?: string; errorCode?: number },
+  ): EmmettError {
+    if (error instanceof EmmettError) {
+      return error;
+    }
+
+    return new EmmettError({
+      errorCode:
+        'errorCode' in error &&
+        error.errorCode !== undefined &&
+        error.errorCode !== null
+          ? error.errorCode
+          : 500,
+      message: error.message ?? 'An unknown error occurred',
+    });
+  }
 }
 
 export class ConcurrencyError extends EmmettError {

--- a/src/packages/emmett/src/eventStore/projections/inMemory/inMemoryProjectionSpec.ts
+++ b/src/packages/emmett/src/eventStore/projections/inMemory/inMemoryProjectionSpec.ts
@@ -9,6 +9,7 @@ import {
   type InMemoryDatabase,
 } from '../../../database';
 import { isErrorConstructor } from '../../../errors';
+import { JSONParser } from '../../../serialization';
 import {
   assertFails,
   AssertionError,
@@ -247,7 +248,7 @@ export function documentExists<T extends DocumentWithId>(
       const propKey = key as keyof typeof document;
       if (
         !(key in document) ||
-        JSON.stringify(document[propKey]) !== JSON.stringify(value)
+        JSONParser.stringify(document[propKey]) !== JSONParser.stringify(value)
       ) {
         assertFails(`Property ${key} doesn't match the expected value`);
         return Promise.resolve(false);

--- a/src/packages/emmett/src/processors/inMemoryProcessors.ts
+++ b/src/packages/emmett/src/processors/inMemoryProcessors.ts
@@ -94,11 +94,12 @@ export const inMemoryCheckpointer = <
         currentPosition &&
         (currentPosition === newCheckpoint ||
           currentPosition !== lastCheckpoint)
-      )
-        return Promise.resolve({
+      ) {
+        return {
           success: false,
           reason: currentPosition === newCheckpoint ? 'IGNORED' : 'MISMATCH',
-        });
+        };
+      }
 
       await checkpoints.handle(processorId, (existing) => ({
         ...(existing ?? {}),
@@ -106,7 +107,7 @@ export const inMemoryCheckpointer = <
         lastCheckpoint: newCheckpoint,
       }));
 
-      return Promise.resolve({ success: true, newCheckpoint });
+      return { success: true, newCheckpoint };
     },
   };
 };

--- a/src/packages/emmett/src/utils/index.ts
+++ b/src/packages/emmett/src/utils/index.ts
@@ -3,4 +3,5 @@ export * from './collections';
 export * from './deepEquals';
 export * from './iterators';
 export * from './locking';
+export * from './promises';
 export * from './retry';

--- a/src/packages/emmett/src/utils/promises.ts
+++ b/src/packages/emmett/src/utils/promises.ts
@@ -1,0 +1,3 @@
+export const delay = (ms: number): Promise<void> => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};

--- a/src/packages/emmett/src/utils/promises.ts
+++ b/src/packages/emmett/src/utils/promises.ts
@@ -1,3 +1,25 @@
 export const delay = (ms: number): Promise<void> => {
   return new Promise((resolve) => setTimeout(resolve, ms));
 };
+
+export type AsyncAwaiter<T = void> = {
+  wait: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reject: (reason?: any) => void;
+  reset: () => void;
+};
+
+// TODO: Remove this after migrating to Node 22
+export const asyncAwaiter = <T = void>(): AsyncAwaiter<T> => {
+  const result: AsyncAwaiter<T> = {} as AsyncAwaiter<T>;
+
+  (result.reset = () => {
+    result.wait = new Promise<T>((res, rej) => {
+      result.resolve = res;
+      result.reject = rej;
+    });
+  })();
+
+  return result;
+};

--- a/src/packages/emmett/src/utils/retry.ts
+++ b/src/packages/emmett/src/utils/retry.ts
@@ -29,6 +29,7 @@ export const asyncRetry = async <T>(
       } catch (error) {
         if (opts?.shouldRetryError && !opts.shouldRetryError(error)) {
           bail(error as Error);
+          return undefined as unknown as T;
         }
         throw error;
       }


### PR DESCRIPTION
It appeared that using just raw Node.js streams for EventStoreDB subscription doesn't stop handling sequential asynchronous promises.

Fixes by introducing a custom async transformer, added error handling, and strengthened tests to handle race conditions correctly.

Besides that, added ignoring already handled messages in processors (based on the checkpoint) and fixed replace function to correctly select item, which was causing checkpoint storing mismatch.

@mbirkegaard FYI