### PR TITLE
Pass handleOptions to "read" which is consumed by readStream

### DIFF
--- a/src/packages/emmett/src/commandHandling/handleCommand.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.ts
@@ -114,6 +114,7 @@ export const CommandHandler =
             evolve,
             initialState,
             read: {
+              (handleOptions && ...handleOptions),
               // expected stream version is passed to fail fast
               // if stream is in the wrong state
               expectedStreamVersion:


### PR DESCRIPTION
My understanding is that the "handleOptions" is consumed for getting the value of "partition" elsewhere. However, aggregateStream does not respect it. To maintain consistency, I propose passing the handleOptions to this "read" property.