### PR TITLE
[#fix] Pass handleOptions to 'read' which is consumed by readStream

### DIFF
--- a/src/packages/emmett/src/commandHandling/handleCommand.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.ts
@@ -114,6 +114,7 @@ export const CommandHandler =
             evolve,
             initialState,
             read: {
+              ...(handleOptions ? handleOptions : {}),
               // expected stream version is passed to fail fast
               // if stream is in the wrong state
               expectedStreamVersion:


### PR DESCRIPTION
## Problem

I want to use non-default partition names. When I configure the partition name in `HandleOptions`, I expect that messages and streams respect that value and set it to "partition", rather than using the default partition name "default_partition". - And they do.

However, when reading the streams via `aggregateStream`, it tries to use the default partition name. After investigation, I noticed `aggregateStream` internally uses `readStream` and the `readStream` does not have the partition option passed through `HandleOptions`. This is because `aggregateStream` selectively sets `HandleOptions` when it's calling `readStream`.

## Solution

To maintain consistency, I propose passing the handleOptions to the "read" property, so the `aggregateStream` calls `readStream` with the expected options.