### PR TITLE
Removed Dumbo usage in SQLite package

### DIFF
--- a/src/packages/emmett-sqlite/src/eventStore/projections/sqliteProjectionSpec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/projections/sqliteProjectionSpec.ts
@@ -1,4 +1,3 @@
-import { type QueryResultRow, type SQL } from '@event-driven-io/dumbo';
 import {
   assertFails,
   AssertionError,
@@ -198,7 +197,7 @@ export const eventsInStream = <
 export const newEventsInStream = eventsInStream;
 
 export const assertSQLQueryResultMatches =
-  <T extends QueryResultRow>(sql: string, rows: T[]): SQLiteProjectionAssert =>
+  <T>(sql: string, rows: T[]): SQLiteProjectionAssert =>
   async ({ connection }: { connection: SQLiteConnection }): Promise<void> => {
     const result = await connection.query<T>(sql);
 
@@ -206,10 +205,9 @@ export const assertSQLQueryResultMatches =
   };
 
 export const expectSQL = {
-  query: (sql: SQL) => ({
+  query: (sql: string) => ({
     resultRows: {
-      toBeTheSame: <T extends QueryResultRow>(rows: T[]) =>
-        assertSQLQueryResultMatches(sql, rows),
+      toBeTheSame: <T>(rows: T[]) => assertSQLQueryResultMatches(sql, rows),
     },
   }),
 };


### PR DESCRIPTION
For now, we don't use Dumbo, it'll come in the future, but not atm.

@LuccaHellriegel FYI