### PR TITLE
Ensured support for integration and e2e specification in Hono

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -11457,10 +11457,8 @@
       "peerDependencies": {
         "@event-driven-io/emmett": "0.41.0",
         "@hono/node-server": "^1.19.6",
-        "@types/supertest": "^6.0.2",
         "hono": "^4.10.6",
-        "http-problem-details": "^0.1.5",
-        "supertest": "^7.0.0"
+        "http-problem-details": "^0.1.5"
       }
     },
     "packages/emmett-mongodb": {

--- a/src/packages/emmett-expressjs/src/etag.ts
+++ b/src/packages/emmett-expressjs/src/etag.ts
@@ -1,4 +1,4 @@
-import { type Brand } from '@event-driven-io/emmett';
+import { type Brand, EmmettError } from '@event-driven-io/emmett';
 import type { Request, Response } from 'express';
 
 //////////////////////////////////////
@@ -29,7 +29,10 @@ export const isWeakETag = (etag: ETag): etag is WeakETag => {
 export const getWeakETagValue = (etag: ETag): string => {
   const result = WeakETagRegex.exec(etag as string);
   if (result === null || result.length === 0) {
-    throw new Error(ETagErrors.WRONG_WEAK_ETAG_FORMAT);
+    throw new EmmettError({
+      errorCode: EmmettError.Codes.ConcurrencyError,
+      message: ETagErrors.WRONG_WEAK_ETAG_FORMAT,
+    });
   }
   return result[1]!;
 };
@@ -42,7 +45,10 @@ export const getETagFromIfMatch = (request: Request): ETag => {
   const etag = request.headers[HeaderNames.IF_MATCH];
 
   if (etag === undefined) {
-    throw new Error(ETagErrors.MISSING_IF_MATCH_HEADER);
+    throw new EmmettError({
+      errorCode: EmmettError.Codes.ConcurrencyError,
+      message: ETagErrors.MISSING_IF_MATCH_HEADER,
+    });
   }
 
   return etag as ETag;
@@ -52,7 +58,10 @@ export const getETagFromIfNotMatch = (request: Request): ETag => {
   const etag = request.headers[HeaderNames.IF_NOT_MATCH];
 
   if (etag === undefined) {
-    throw new Error(ETagErrors.MISSING_IF_MATCH_HEADER);
+    throw new EmmettError({
+      errorCode: EmmettError.Codes.ConcurrencyError,
+      message: ETagErrors.MISSING_IF_NOT_MATCH_HEADER,
+    });
   }
 
   return (Array.isArray(etag) ? etag[0] : etag) as ETag;

--- a/src/packages/emmett-expressjs/src/testing/apiSpecification.int.spec.ts
+++ b/src/packages/emmett-expressjs/src/testing/apiSpecification.int.spec.ts
@@ -1,0 +1,162 @@
+import {
+  getInMemoryEventStore,
+  type EventStore,
+  type ReadEventMetadataWithGlobalPosition,
+} from '@event-driven-io/emmett';
+import { randomUUID } from 'node:crypto';
+import { beforeEach, describe, it } from 'node:test';
+import { getApplication, HeaderNames, toWeakETag } from '..';
+import { shoppingCartApi } from '../e2e/decider/api';
+import type {
+  PricedProductItem,
+  ProductItem,
+  ShoppingCartEvent,
+} from '../e2e/decider/shoppingCart';
+import {
+  ApiSpecification,
+  existingStream,
+  expectError,
+  expectNewEvents,
+  expectResponse,
+} from './apiSpecification';
+
+void describe('ShoppingCart', () => {
+  let clientId: string;
+  let shoppingCartId: string;
+
+  beforeEach(() => {
+    clientId = randomUUID();
+    shoppingCartId = `shopping_cart:${clientId}:current`;
+  });
+
+  void describe('When empty', () => {
+    void it('should open shopping cart', () => {
+      return given()
+        .when((request) => {
+          return request
+            .post(`/clients/${clientId}/shopping-carts/`)
+            .send(productItem);
+        })
+        .then([expectResponse(201)]);
+    });
+
+    void it('should NOT add product item', () => {
+      return given()
+        .when((request) => {
+          return request
+            .post(
+              `/clients/${clientId}/shopping-carts/${shoppingCartId}/product-items`,
+            )
+            .set(HeaderNames.IF_MATCH, toWeakETag(0))
+            .send(productItem);
+        })
+        .then([expectResponse(403)]);
+    });
+  });
+
+  void describe('When opened with product item', () => {
+    void it('should confirm', () => {
+      return given(
+        existingStream<ShoppingCartEvent>(shoppingCartId, [
+          {
+            type: 'ShoppingCartOpened',
+            data: { shoppingCartId, clientId, openedAt: oldTime },
+          },
+          {
+            type: 'ProductItemAddedToShoppingCart',
+            data: {
+              shoppingCartId,
+              productItem: pricedProductItem,
+            },
+          },
+        ]),
+      )
+        .when((request) =>
+          request
+            .post(
+              `/clients/${clientId}/shopping-carts/${shoppingCartId}/confirm`,
+            )
+            .set(HeaderNames.IF_MATCH, toWeakETag(2)),
+        )
+        .then([
+          expectResponse(204),
+          expectNewEvents(shoppingCartId, [
+            {
+              type: 'ShoppingCartConfirmed',
+              data: {
+                shoppingCartId,
+                confirmedAt: oldTime,
+              },
+            },
+          ]),
+        ]);
+    });
+  });
+
+  void describe('When confirmed', () => {
+    void it('should not add products', () => {
+      return given(
+        existingStream<ShoppingCartEvent>(shoppingCartId, [
+          {
+            type: 'ShoppingCartOpened',
+            data: { shoppingCartId, clientId, openedAt: oldTime },
+          },
+          {
+            type: 'ProductItemAddedToShoppingCart',
+            data: {
+              shoppingCartId,
+              productItem: pricedProductItem,
+            },
+          },
+          {
+            type: 'ShoppingCartConfirmed',
+            data: { shoppingCartId, confirmedAt: oldTime },
+          },
+        ]),
+      )
+        .when((request) =>
+          request
+            .post(
+              `/clients/${clientId}/shopping-carts/${shoppingCartId}/product-items`,
+            )
+            .set(HeaderNames.IF_MATCH, toWeakETag(3))
+            .send(productItem),
+        )
+        .then(
+          expectError(403, {
+            detail: 'CART_IS_ALREADY_CLOSED',
+            status: 403,
+            title: 'Forbidden',
+            type: 'about:blank',
+          }),
+        );
+    });
+  });
+
+  const oldTime = new Date();
+  const unitPrice = Math.random() * 10;
+
+  const given = ApiSpecification.for<
+    ShoppingCartEvent,
+    EventStore<ReadEventMetadataWithGlobalPosition>
+  >(
+    () => getInMemoryEventStore(),
+    (eventStore) =>
+      getApplication({
+        apis: [shoppingCartApi(eventStore)],
+      }),
+  );
+
+  const getRandomProduct = (): ProductItem => {
+    return {
+      productId: randomUUID(),
+      quantity: Math.random() * 10,
+    };
+  };
+
+  const productItem = getRandomProduct();
+  const pricedProductItem: PricedProductItem = {
+    ...productItem,
+    unitPrice,
+  };
+});

--- a/src/packages/emmett-honojs/package.json
+++ b/src/packages/emmett-honojs/package.json
@@ -52,10 +52,8 @@
   "devDependencies": {},
   "peerDependencies": {
     "@event-driven-io/emmett": "0.41.0",
-    "@types/supertest": "^6.0.2",
     "hono": "^4.10.6",
     "@hono/node-server": "^1.19.6",
-    "http-problem-details": "^0.1.5",
-    "supertest": "^7.0.0"
+    "http-problem-details": "^0.1.5"
   }
 }

--- a/src/packages/emmett-honojs/src/application.ts
+++ b/src/packages/emmett-honojs/src/application.ts
@@ -1,4 +1,4 @@
-import { serve } from '@hono/node-server/.';
+import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { etag } from 'hono/etag';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';

--- a/src/packages/emmett-honojs/src/e2e/decider/applicationLogicWithOC.int.spec.ts
+++ b/src/packages/emmett-honojs/src/e2e/decider/applicationLogicWithOC.int.spec.ts
@@ -1,238 +1,197 @@
-// import {
-//   assertEqual,
-//   assertFails,
-//   assertMatches,
-//   assertOk,
-//   getInMemoryEventStore,
-//   type InMemoryEventStore,
-// } from '@event-driven-io/emmett';
-// import type { response } from 'express';
-// import type { Hono } from 'hono';
-// import { randomUUID } from 'node:crypto';
-// import { beforeEach, describe, it } from 'node:test';
-// import { getApplication } from '../../application';
-// import { HeaderNames, toWeakETag } from '../../etag';
-// import { expectNextRevisionInResponseEtag } from '../testing';
-// import { shoppingCartApi } from './api';
-// import type { ShoppingCartEvent } from './shoppingCart';
+import {
+  assertEqual,
+  assertFails,
+  assertMatches,
+  assertOk,
+  getInMemoryEventStore,
+  type InMemoryEventStore,
+} from '@event-driven-io/emmett';
+import type { Hono } from 'hono';
+import { randomUUID } from 'node:crypto';
+import { beforeEach, describe, it } from 'node:test';
+import { getApplication } from '../../application';
+import { HeaderNames, toWeakETag } from '../../etag';
+import {
+  expectNextRevisionInResponseEtag,
+  runTwice,
+  statuses,
+} from '../testing';
+import { shoppingCartApi } from './api';
+import { ShoppingCartErrors } from './businessLogic';
+import type { ShoppingCartEvent } from './shoppingCart';
 
-// void describe('Application logic with optimistic concurrency', () => {
-//   let app: Hono;
-//   let eventStore: InMemoryEventStore;
+void describe('Application logic with optimistic concurrency', () => {
+  let app: Hono;
+  let eventStore: InMemoryEventStore;
 
-//   beforeEach(() => {
-//     eventStore = getInMemoryEventStore();
-//     app = getApplication({ apis: [shoppingCartApi(eventStore)] });
-//   });
+  beforeEach(() => {
+    eventStore = getInMemoryEventStore();
+    app = getApplication({ apis: [shoppingCartApi(eventStore)] });
+  });
 
-//   void it('Should handle requests correctly', async () => {
-//     const clientId = randomUUID();
-//     ///////////////////////////////////////////////////
-//     // 1. Open Shopping Cart
-//     ///////////////////////////////////////////////////
-//     const createResponse = await app.request(
-//       `/clients/${clientId}/shopping-carts`,
-//       { method: 'POST' },
-//     );
-//     const secondCreateResponse = await app.request(
-//       `/clients/${clientId}/shopping-carts`,
-//       { method: 'POST' },
-//     );
+  void it('Should handle requests correctly', async () => {
+    const clientId = randomUUID();
+    ///////////////////////////////////////////////////
+    // 1. Open Shopping Cart
+    ///////////////////////////////////////////////////
+    const createResponse = await runTwice(() =>
+      app.request(`/clients/${clientId}/shopping-carts/`, { method: 'POST' }),
+    ).expect(statuses(201, 412));
 
-//     assertEqual(createResponse.status, 201);
-//     assertEqual(secondCreateResponse.status, 412);
-//     let currentRevision = expectNextRevisionInResponseEtag(createResponse);
-//     const current = (await createResponse.json()) as { id?: string };
+    let currentRevision = expectNextRevisionInResponseEtag(createResponse);
+    const current = (await createResponse.json()) as { id?: string };
 
-//     if (!current.id) {
-//       assertFails();
-//     }
-//     assertOk(current.id);
+    if (!current.id) {
+      assertFails();
+    }
+    assertOk(current.id);
 
-//     const shoppingCartId = current.id;
+    const shoppingCartId = current.id;
 
-//     ///////////////////////////////////////////////////
-//     // 2. Add Two Pair of Shoes
-//     ///////////////////////////////////////////////////
-//     const twoPairsOfShoes = {
-//       quantity: 2,
-//       productId: '123',
-//     };
-//     const resp1 = await app.request(
-//       `/clients/${clientId}/shopping-carts/${shoppingCartId}/product-items`,
-//       {
-//         method: 'POST',
-//         headers: new Headers({
-//           [HeaderNames.IF_MATCH]: toWeakETag(currentRevision),
-//         }),
-//         body: twoPairsOfShoes,
-//       },
-//     );
-//     const resp2 = await app.request(
-//       `/clients/${clientId}/shopping-carts/${shoppingCartId}/product-items`,
-//       {
-//         method: 'POST',
-//         headers: new Headers({
-//           [HeaderNames.IF_MATCH]: toWeakETag(currentRevision),
-//         }),
-//         body: twoPairsOfShoes,
-//       },
-//     );
-//     assertEqual(resp1.status, 204);
-//     assertEqual(resp2.status, 412);
+    ///////////////////////////////////////////////////
+    // 2. Add Two Pair of Shoes
+    ///////////////////////////////////////////////////
+    const twoPairsOfShoes = {
+      quantity: 2,
+      productId: '123',
+    };
+    let response = await runTwice(() =>
+      app.request(
+        `/clients/${clientId}/shopping-carts/${shoppingCartId}/product-items`,
+        {
+          method: 'POST',
+          headers: new Headers({
+            'Content-Type': 'application/json',
+            [HeaderNames.IF_MATCH]: toWeakETag(currentRevision),
+          }),
+          body: JSON.stringify(twoPairsOfShoes),
+        },
+      ),
+    ).expect(statuses(204, 412));
 
-//     currentRevision = expectNextRevisionInResponseEtag(response);
+    currentRevision = expectNextRevisionInResponseEtag(response);
 
-//     ///////////////////////////////////////////////////
-//     // 3. Add T-Shirt
-//     ///////////////////////////////////////////////////
-//     const tShirt = {
-//       productId: '456',
-//       quantity: 1,
-//     };
-//     const resp3 = await app.request(
-//       `/clients/${clientId}/shopping-carts/${shoppingCartId}/product-items`,
-//       {
-//         method: 'POST',
-//         headers: new Headers({
-//           [HeaderNames.IF_MATCH]: toWeakETag(currentRevision),
-//         }),
-//         body: tShirt,
-//       },
-//     );
-//     const resp4 = await app.request(
-//       `/clients/${clientId}/shopping-carts/${shoppingCartId}/product-items`,
-//       {
-//         method: 'POST',
-//         headers: new Headers({
-//           [HeaderNames.IF_MATCH]: toWeakETag(currentRevision),
-//         }),
-//         body: tShirt,
-//       },
-//     );
-//     assertEqual(resp3.status, 204);
-//     assertEqual(resp4.status, 412);
+    ///////////////////////////////////////////////////
+    // 3. Add T-Shirt
+    ///////////////////////////////////////////////////
+    const tShirt = {
+      productId: '456',
+      quantity: 1,
+    };
+    response = await runTwice(() =>
+      app.request(
+        `/clients/${clientId}/shopping-carts/${shoppingCartId}/product-items`,
+        {
+          method: 'POST',
+          headers: new Headers({
+            'Content-Type': 'application/json',
+            [HeaderNames.IF_MATCH]: toWeakETag(currentRevision),
+          }),
+          body: JSON.stringify(tShirt),
+        },
+      ),
+    ).expect(statuses(204, 412));
 
-//     currentRevision = expectNextRevisionInResponseEtag(response);
+    currentRevision = expectNextRevisionInResponseEtag(response);
 
-//     ///////////////////////////////////////////////////
-//     // 4. Remove pair of shoes
-//     ///////////////////////////////////////////////////
-//     const pairOfShoes = {
-//       productId: '123',
-//       quantity: 1,
-//       unitPrice: 100,
-//     };
-//     const resp5 = await app.request(
-//       `/clients/${clientId}/shopping-carts/${shoppingCartId}/product-items?productId=${pairOfShoes.productId}&quantity=${pairOfShoes.quantity}&unitPrice=${pairOfShoes.unitPrice}`,
-//       {
-//         method: 'DELETE',
-//         headers: new Headers({
-//           [HeaderNames.IF_MATCH]: toWeakETag(currentRevision),
-//         }),
-//       },
-//     );
-//     const resp6 = await app.request(
-//       `/clients/${clientId}/shopping-carts/${shoppingCartId}/product-items?productId=${pairOfShoes.productId}&quantity=${pairOfShoes.quantity}&unitPrice=${pairOfShoes.unitPrice}`,
-//       {
-//         method: 'DELETE',
-//         headers: new Headers({
-//           [HeaderNames.IF_MATCH]: toWeakETag(currentRevision),
-//         }),
-//       },
-//     );
-//     assertEqual(resp5.status, 204);
-//     assertEqual(resp6.status, 412);
+    ///////////////////////////////////////////////////
+    // 4. Remove pair of shoes
+    ///////////////////////////////////////////////////
+    const pairOfShoes = {
+      productId: '123',
+      quantity: 1,
+      unitPrice: 100,
+    };
+    response = await runTwice(() =>
+      app.request(
+        `/clients/${clientId}/shopping-carts/${shoppingCartId}/product-items?productId=${pairOfShoes.productId}&quantity=${pairOfShoes.quantity}&unitPrice=${pairOfShoes.unitPrice}`,
+        {
+          method: 'DELETE',
+          headers: new Headers({
+            [HeaderNames.IF_MATCH]: toWeakETag(currentRevision),
+          }),
+        },
+      ),
+    ).expect(statuses(204, 412));
 
-//     currentRevision = expectNextRevisionInResponseEtag(response);
+    currentRevision = expectNextRevisionInResponseEtag(response);
 
-//     ///////////////////////////////////////////////////
-//     // 5. Confirm cart
-//     ///////////////////////////////////////////////////
+    ///////////////////////////////////////////////////
+    // 5. Confirm cart
+    ///////////////////////////////////////////////////
 
-//     const resp7 = await app.request(
-//       `/clients/${clientId}/shopping-carts/${shoppingCartId}/confirm`,
-//       {
-//         method: 'POST',
-//         headers: new Headers({
-//           [HeaderNames.IF_MATCH]: toWeakETag(currentRevision),
-//         }),
-//       },
-//     );
-//     const resp8 = await app.request(
-//       `/clients/${clientId}/shopping-carts/${shoppingCartId}/confirm`,
-//       {
-//         method: 'POST',
-//         headers: new Headers({
-//           [HeaderNames.IF_MATCH]: toWeakETag(currentRevision),
-//         }),
-//       },
-//     );
+    response = await runTwice(() =>
+      app.request(
+        `/clients/${clientId}/shopping-carts/${shoppingCartId}/confirm`,
+        {
+          method: 'POST',
+          headers: new Headers({
+            [HeaderNames.IF_MATCH]: toWeakETag(currentRevision),
+          }),
+        },
+      ),
+    ).expect(statuses(204, 412));
 
-//     currentRevision = expectNextRevisionInResponseEtag(resp7);
+    currentRevision = expectNextRevisionInResponseEtag(response);
 
-//     ///////////////////////////////////////////////////
-//     // 6. Try Cancel Cart
-//     ///////////////////////////////////////////////////
+    ///////////////////////////////////////////////////
+    // 6. Try Cancel Cart
+    ///////////////////////////////////////////////////
 
-//     const resp9 = await app.request(
-//       `/clients/${clientId}/shopping-carts/${shoppingCartId}`,
-//       {
-//         method: 'DELETE',
-//         headers: new Headers({
-//           [HeaderNames.IF_MATCH]: toWeakETag(currentRevision),
-//         }),
-//       },
-//     );
+    response = await app.request(
+      `/clients/${clientId}/shopping-carts/${shoppingCartId}`,
+      {
+        method: 'DELETE',
+        headers: new Headers({
+          [HeaderNames.IF_MATCH]: toWeakETag(currentRevision),
+        }),
+      },
+    );
 
-//     const result =
-//       await eventStore.readStream<ShoppingCartEvent>(shoppingCartId);
+    assertEqual(response.status, 403);
+    const body = (await response.json()) as { detail?: string };
+    assertMatches(body, {
+      detail: ShoppingCartErrors.CART_IS_ALREADY_CLOSED,
+    });
 
-//     assertOk(result);
-//     assertEqual(result.events.length, Number(currentRevision));
+    const result =
+      await eventStore.readStream<ShoppingCartEvent>(shoppingCartId);
 
-//     assertMatches(result?.events, [
-//       {
-//         type: 'ShoppingCartOpened',
-//         data: {
-//           shoppingCartId,
-//           clientId,
-//           //openedAt,
-//         },
-//       },
-//       {
-//         type: 'ProductItemAddedToShoppingCart',
-//         data: {
-//           shoppingCartId,
-//           productItem: twoPairsOfShoes,
-//         },
-//       },
-//       {
-//         type: 'ProductItemAddedToShoppingCart',
-//         data: {
-//           shoppingCartId,
-//           productItem: tShirt,
-//         },
-//       },
-//       {
-//         type: 'ProductItemRemovedFromShoppingCart',
-//         data: { shoppingCartId, productItem: pairOfShoes },
-//       },
-//       {
-//         type: 'ShoppingCartConfirmed',
-//         data: {
-//           shoppingCartId,
-//           //confirmedAt,
-//         },
-//       },
-//       // This should fail
-//       // {
-//       //   type: 'ShoppingCartCanceled',
-//       //   data: {
-//       //     shoppingCartId,
-//       //     canceledAt,
-//       //   },
-//       // },
-//     ]);
-//   });
-// });
+    assertOk(result);
+    assertEqual(result.events.length, Number(currentRevision));
+
+    assertMatches(result?.events, [
+      {
+        type: 'ShoppingCartOpened',
+        data: {
+          shoppingCartId,
+          clientId,
+        },
+      },
+      {
+        type: 'ProductItemAddedToShoppingCart',
+        data: {
+          shoppingCartId,
+          productItem: twoPairsOfShoes,
+        },
+      },
+      {
+        type: 'ProductItemAddedToShoppingCart',
+        data: {
+          shoppingCartId,
+          productItem: tShirt,
+        },
+      },
+      {
+        type: 'ProductItemRemovedFromShoppingCart',
+        data: { shoppingCartId, productItem: pairOfShoes },
+      },
+      {
+        type: 'ShoppingCartConfirmed',
+        data: {
+          shoppingCartId,
+        },
+      },
+    ]);
+  });
+});

--- a/src/packages/emmett-honojs/src/etag.ts
+++ b/src/packages/emmett-honojs/src/etag.ts
@@ -1,4 +1,4 @@
-import { type Brand } from '@event-driven-io/emmett';
+import { type Brand, EmmettError } from '@event-driven-io/emmett';
 import type { Context } from 'hono';
 
 //////////////////////////////////////
@@ -29,7 +29,10 @@ export const isWeakETag = (etag: ETag): etag is WeakETag => {
 export const getWeakETagValue = (etag: ETag): string => {
   const result = WeakETagRegex.exec(etag as string);
   if (result === null || result.length === 0) {
-    throw new Error(ETagErrors.WRONG_WEAK_ETAG_FORMAT);
+    throw new EmmettError({
+      errorCode: EmmettError.Codes.ConcurrencyError,
+      message: ETagErrors.WRONG_WEAK_ETAG_FORMAT,
+    });
   }
   return result[1]!;
 };
@@ -42,7 +45,10 @@ export const getETagFromIfMatch = (context: Context): ETag => {
   const etag = context.req.header(HeaderNames.IF_MATCH);
 
   if (etag === undefined) {
-    throw new Error(ETagErrors.MISSING_IF_MATCH_HEADER);
+    throw new EmmettError({
+      errorCode: EmmettError.Codes.ConcurrencyError,
+      message: ETagErrors.MISSING_IF_MATCH_HEADER,
+    });
   }
 
   return etag as ETag;
@@ -52,7 +58,10 @@ export const getETagFromIfNotMatch = (context: Context): ETag => {
   const etag = context.req.header(HeaderNames.IF_NOT_MATCH);
 
   if (etag === undefined) {
-    throw new Error(ETagErrors.MISSING_IF_MATCH_HEADER);
+    throw new EmmettError({
+      errorCode: EmmettError.Codes.ConcurrencyError,
+      message: ETagErrors.MISSING_IF_NOT_MATCH_HEADER,
+    });
   }
 
   return (Array.isArray(etag) ? etag[0] : etag) as ETag;

--- a/src/packages/emmett-honojs/src/index.ts
+++ b/src/packages/emmett-honojs/src/index.ts
@@ -1,5 +1,6 @@
 export * from './application';
 export * from './etag';
 export * from './handler';
+export * from './middlewares';
 export * from './responses';
 export * from './testing';

--- a/src/packages/emmett-honojs/src/middlewares/index.ts
+++ b/src/packages/emmett-honojs/src/middlewares/index.ts
@@ -1,0 +1,1 @@
+export * from './problemDetailsMiddleware';

--- a/src/packages/emmett-honojs/src/testing/apiSpecification.int.spec.ts
+++ b/src/packages/emmett-honojs/src/testing/apiSpecification.int.spec.ts
@@ -1,0 +1,162 @@
+import {
+  getInMemoryEventStore,
+  type EventStore,
+  type ReadEventMetadataWithGlobalPosition,
+} from '@event-driven-io/emmett';
+import { randomUUID } from 'node:crypto';
+import { beforeEach, describe, it } from 'node:test';
+import { getApplication, HeaderNames, toWeakETag } from '..';
+import { shoppingCartApi } from '../e2e/decider/api';
+import type {
+  PricedProductItem,
+  ProductItem,
+  ShoppingCartEvent,
+} from '../e2e/decider/shoppingCart';
+import {
+  ApiSpecification,
+  existingStream,
+  expectError,
+  expectNewEvents,
+  expectResponse,
+} from './apiSpecification';
+
+void describe('ShoppingCart', () => {
+  let clientId: string;
+  let shoppingCartId: string;
+
+  beforeEach(() => {
+    clientId = randomUUID();
+    shoppingCartId = `shopping_cart:${clientId}:current`;
+  });
+
+  void describe('When empty', () => {
+    void it('should open shopping cart', () => {
+      return given()
+        .when((request) => {
+          return request
+            .post(`/clients/${clientId}/shopping-carts/`)
+            .send(productItem);
+        })
+        .then([expectResponse(201)]);
+    });
+
+    void it('should NOT add product item', () => {
+      return given()
+        .when((request) => {
+          return request
+            .post(
+              `/clients/${clientId}/shopping-carts/${shoppingCartId}/product-items`,
+            )
+            .set({ [HeaderNames.IF_MATCH]: toWeakETag(0) })
+            .send(productItem);
+        })
+        .then([expectResponse(403)]);
+    });
+  });
+
+  void describe('When opened with product item', () => {
+    void it('should confirm', () => {
+      return given(
+        existingStream<ShoppingCartEvent>(shoppingCartId, [
+          {
+            type: 'ShoppingCartOpened',
+            data: { shoppingCartId, clientId, openedAt: oldTime },
+          },
+          {
+            type: 'ProductItemAddedToShoppingCart',
+            data: {
+              shoppingCartId,
+              productItem: pricedProductItem,
+            },
+          },
+        ]),
+      )
+        .when((request) =>
+          request
+            .post(
+              `/clients/${clientId}/shopping-carts/${shoppingCartId}/confirm`,
+            )
+            .set({ [HeaderNames.IF_MATCH]: toWeakETag(2) }),
+        )
+        .then([
+          expectResponse(204),
+          expectNewEvents(shoppingCartId, [
+            {
+              type: 'ShoppingCartConfirmed',
+              data: {
+                shoppingCartId,
+                confirmedAt: oldTime,
+              },
+            },
+          ]),
+        ]);
+    });
+  });
+
+  void describe('When confirmed', () => {
+    void it('should not add products', () => {
+      return given(
+        existingStream<ShoppingCartEvent>(shoppingCartId, [
+          {
+            type: 'ShoppingCartOpened',
+            data: { shoppingCartId, clientId, openedAt: oldTime },
+          },
+          {
+            type: 'ProductItemAddedToShoppingCart',
+            data: {
+              shoppingCartId,
+              productItem: pricedProductItem,
+            },
+          },
+          {
+            type: 'ShoppingCartConfirmed',
+            data: { shoppingCartId, confirmedAt: oldTime },
+          },
+        ]),
+      )
+        .when((request) =>
+          request
+            .post(
+              `/clients/${clientId}/shopping-carts/${shoppingCartId}/product-items`,
+            )
+            .set({ [HeaderNames.IF_MATCH]: toWeakETag(3) })
+            .send(productItem),
+        )
+        .then(
+          expectError(403, {
+            detail: 'CART_IS_ALREADY_CLOSED',
+            status: 403,
+            title: 'Forbidden',
+            type: 'about:blank',
+          }),
+        );
+    });
+  });
+
+  const oldTime = new Date();
+  const unitPrice = Math.random() * 10;
+
+  const given = ApiSpecification.for<
+    ShoppingCartEvent,
+    EventStore<ReadEventMetadataWithGlobalPosition>
+  >(
+    () => getInMemoryEventStore(),
+    (eventStore) =>
+      getApplication({
+        apis: [shoppingCartApi(eventStore)],
+      }),
+  );
+
+  const getRandomProduct = (): ProductItem => {
+    return {
+      productId: randomUUID(),
+      quantity: Math.random() * 10,
+    };
+  };
+
+  const productItem = getRandomProduct();
+  const pricedProductItem: PricedProductItem = {
+    ...productItem,
+    unitPrice,
+  };
+});


### PR DESCRIPTION
Besides that, added integration tests for Express accordingly and fixed ETag-related error mappings.

Removed `supertest` from hono package, as hono has its own test server utils.

@dawidhermann FYI