### PR TITLE
Fixed "is subset" assertion crashing on property with null value

### DIFF
--- a/src/packages/emmett/src/testing/assertions.ts
+++ b/src/packages/emmett/src/testing/assertions.ts
@@ -16,7 +16,7 @@ export const isSubset = (superObj: unknown, subObj: unknown): boolean => {
   assertOk(sub);
 
   return Object.keys(sub).every((ele: string) => {
-    if (typeof sub[ele] == 'object') {
+    if (sub[ele] !== null && typeof sub[ele] == 'object') {
       return isSubset(sup[ele], sub[ele]);
     }
     return sub[ele] === sup[ele];

--- a/src/packages/emmett/src/testing/assertions.unit.spec.ts
+++ b/src/packages/emmett/src/testing/assertions.unit.spec.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { isSubset } from './assertions';
+
+void describe('isSubset', () => {
+  void it('should return true for matching flat objects', () => {
+    assert.equal(isSubset({ a: 1, b: 'x' }, { a: 1, b: 'x' }), true);
+  });
+
+  void it('should return false when values differ', () => {
+    assert.equal(isSubset({ a: 1, b: 'x' }, { a: 2, b: 'x' }), false);
+  });
+
+  void it('should return true when superObj has extra properties', () => {
+    assert.equal(isSubset({ a: 1, b: 'x', c: 3 }, { a: 1 }), true);
+  });
+
+  void it('should handle null property values', () => {
+    assert.equal(isSubset({ a: null, b: 'x' }, { a: null, b: 'x' }), true);
+    assert.equal(isSubset({ a: 'y', b: 'x' }, { a: null, b: 'x' }), false);
+    assert.equal(isSubset({ a: null, b: 'x' }, { a: 'y', b: 'x' }), false);
+  });
+});


### PR DESCRIPTION
In general I've tried to not use null in event values, because most of the time optional/undefined works well. However, I had a scenario where I wanted to use null and discovered the tests were crashing down. This fixes it! 

First time contributing, so let me know if there is something I should address! 😊 

## Summary
- `isSubset` crashes on null property values because `typeof null === "object"` in JavaScript, causing a recursive call with null where `assertOk(null)` throws "Condition is not truthy"
- Fix: added a null guard (`sub[ele] !== null &&`) before the `typeof` check, so null falls through to the `===` strict equality comparison
- Added `ProductItemRemoved` event with nullable `removedBy` field to shopping cart domain (`null` = system removal, `string` = user removal)

## Test plan
- [x] Unit tests for `isSubset` with null values (both matching and mismatching)
- [x] `DeciderSpecification` test with shopping cart `ProductItemRemoved` event exercising null through the full `.then()` assertion path
- [x] Existing tests remain green (30/30 pass)
