### PR TITLE
Plugged SQLite processors into generic processors mechanism

### DIFF
--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
@@ -1,4 +1,4 @@
-import { dumbo, type Dumbo, type SQLExecutor } from '@event-driven-io/dumbo';
+import { dumbo, type Dumbo } from '@event-driven-io/dumbo';
 import type { MessageProcessor } from '@event-driven-io/emmett';
 import {
   EmmettError,
@@ -27,17 +27,6 @@ import {
   type PostgreSQLProjectorOptions,
   type PostgreSQLReactorOptions,
 } from './postgreSQLProcessor';
-
-export type PostgreSQLConsumerContext = {
-  execute: SQLExecutor;
-  connection: {
-    connectionString: string;
-    pool: Dumbo;
-  };
-};
-
-export type ExtendableContext = Partial<PostgreSQLConsumerContext> &
-  DefaultRecord;
 
 export type PostgreSQLEventStoreConsumerConfig<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/packages/emmett-postgresql/src/eventStore/schema/storeProcessorCheckpoint.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/storeProcessorCheckpoint.ts
@@ -101,7 +101,7 @@ export const callStoreProcessorCheckpoint = (
       ${params.processorInstanceId}
     ) as result;`;
 
-export type StoreLastProcessedProcessorPositionResult =
+export type StoreProcessorCheckpointResult =
   | {
       success: true;
       newCheckpoint: ProcessorCheckpoint | null;
@@ -118,7 +118,7 @@ export const storeProcessorCheckpoint = async (
     partition?: string;
     processorInstanceId?: string;
   },
-): Promise<StoreLastProcessedProcessorPositionResult> => {
+): Promise<StoreProcessorCheckpointResult> => {
   try {
     const { result } = await single(
       execute.command<{ result: 0 | 1 | 2 | 3 }>(

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteCheckpointer.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteCheckpointer.ts
@@ -1,0 +1,40 @@
+import type { AnyMessage, Message } from '@event-driven-io/emmett';
+import {
+  type Checkpointer,
+  type ReadEventMetadataWithGlobalPosition,
+  getCheckpoint,
+} from '@event-driven-io/emmett';
+import { readProcessorCheckpoint, storeProcessorCheckpoint } from '../schema';
+import type { SQLiteProcessorHandlerContext } from './sqliteProcessor';
+
+export type SQLiteCheckpointer<MessageType extends AnyMessage = AnyMessage> =
+  Checkpointer<
+    MessageType,
+    ReadEventMetadataWithGlobalPosition,
+    SQLiteProcessorHandlerContext
+  >;
+
+export const sqliteCheckpointer = <
+  MessageType extends Message = Message,
+>(): SQLiteCheckpointer<MessageType> => ({
+  read: async (options, context) => {
+    const result = await readProcessorCheckpoint(context.execute, options);
+
+    return { lastCheckpoint: result?.lastProcessedCheckpoint };
+  },
+  store: async (options, context) => {
+    const newCheckpoint = getCheckpoint(options.message);
+
+    const result = await storeProcessorCheckpoint(context.execute, {
+      lastProcessedCheckpoint: options.lastCheckpoint,
+      newCheckpoint,
+      processorId: options.processorId,
+      partition: options.partition,
+      version: options.version,
+    });
+
+    return result.success
+      ? { success: true, newCheckpoint: result.newCheckpoint }
+      : result;
+  },
+});

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.int.spec.ts
@@ -1,6 +1,10 @@
 import { InMemorySQLiteDatabase } from '@event-driven-io/dumbo/sqlite3';
 import type { EmmettError } from '@event-driven-io/emmett';
-import { assertFalse, assertThrowsAsync } from '@event-driven-io/emmett';
+import {
+  assertFalse,
+  assertThrowsAsync,
+  MessageProcessorType,
+} from '@event-driven-io/emmett';
 import { v4 as uuid } from 'uuid';
 import { afterEach, beforeEach, describe, it } from 'vitest';
 import { sqlite3EventStoreDriver } from '../../sqlite3';
@@ -12,8 +16,12 @@ import type { SQLiteProcessor } from './sqliteProcessor';
 
 void describe('SQLite event store consumer', () => {
   const dummyProcessor: SQLiteProcessor = {
+    type: MessageProcessorType.REACTOR,
     id: uuid(),
+    instanceId: uuid(),
+    init: () => Promise.resolve(),
     start: () => Promise.resolve('BEGINNING'),
+    close: () => Promise.resolve(),
     handle: () => Promise.resolve(),
     isActive: false,
   };

--- a/src/packages/emmett-sqlite/src/eventStore/schema/migrations/migration.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/schema/migrations/migration.int.spec.ts
@@ -223,7 +223,7 @@ void describe('Schema migrations tests', () => {
       partition: undefined,
     });
 
-    assertDeepEqual(shoppingCartCheckpoint.lastProcessedPosition, null);
+    assertDeepEqual(shoppingCartCheckpoint.lastProcessedCheckpoint, null);
 
     const orderProcessorId = `processor-order-${order.streamId}`;
 
@@ -232,6 +232,6 @@ void describe('Schema migrations tests', () => {
       partition: undefined,
     });
 
-    assertDeepEqual(orderCheckpoint, { lastProcessedPosition: null });
+    assertDeepEqual(orderCheckpoint, { lastProcessedCheckpoint: null });
   };
 });

--- a/src/packages/emmett-sqlite/src/eventStore/schema/readProcessorCheckpoint.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/schema/readProcessorCheckpoint.ts
@@ -1,4 +1,5 @@
 import { SQL, type SQLExecutor, singleOrNull } from '@event-driven-io/dumbo';
+import type { ProcessorCheckpoint } from '@event-driven-io/emmett';
 import { defaultTag, processorsTable } from './typing';
 const { identifier } = SQL;
 
@@ -7,7 +8,7 @@ type ReadProcessorCheckpointSqlResult = {
 };
 
 export type ReadProcessorCheckpointResult = {
-  lastProcessedPosition: bigint | null;
+  lastProcessedCheckpoint: ProcessorCheckpoint | null;
 };
 
 export const readProcessorCheckpoint = async (
@@ -24,7 +25,9 @@ export const readProcessorCheckpoint = async (
   );
 
   return {
-    lastProcessedPosition:
-      result !== null ? BigInt(result.last_processed_checkpoint) : null,
+    lastProcessedCheckpoint:
+      result !== null
+        ? (result.last_processed_checkpoint as ProcessorCheckpoint)
+        : null,
   };
 };

--- a/src/packages/emmett-sqlite/src/eventStore/schema/storeProcessorCheckpoint.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/schema/storeProcessorCheckpoint.ts
@@ -97,10 +97,10 @@ async function storeSubscriptionCheckpointSQLite(
   }
 }
 
-export type StoreLastProcessedProcessorPositionResult =
+export type StoreProcessorCheckpointResult =
   | {
       success: true;
-      newPosition: ProcessorCheckpoint | null;
+      newCheckpoint: ProcessorCheckpoint | null;
     }
   | { success: false; reason: 'IGNORED' | 'MISMATCH' };
 
@@ -112,8 +112,9 @@ export async function storeProcessorCheckpoint(
     newCheckpoint: ProcessorCheckpoint | null;
     lastProcessedCheckpoint: ProcessorCheckpoint | null;
     partition?: string;
+    processorInstanceId?: string;
   },
-): Promise<StoreLastProcessedProcessorPositionResult> {
+): Promise<StoreProcessorCheckpointResult> {
   try {
     const result = await storeSubscriptionCheckpointSQLite(
       execute,
@@ -125,7 +126,7 @@ export async function storeProcessorCheckpoint(
     );
 
     return result === 1
-      ? { success: true, newPosition: options.newCheckpoint }
+      ? { success: true, newCheckpoint: options.newCheckpoint }
       : { success: false, reason: result === 0 ? 'IGNORED' : 'MISMATCH' };
   } catch (error) {
     console.log(error);

--- a/src/packages/emmett-sqlite/src/eventStore/schema/tables.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/schema/tables.ts
@@ -73,6 +73,16 @@ export const schemaSQL: SQL[] = [
   projectionsTableSQL,
 ];
 
+export type CreateEventStoreSchemaOptions = {
+  dryRun?: boolean | undefined;
+  ignoreMigrationHashMismatch?: boolean | undefined;
+  migrationTimeoutMs?: number | undefined;
+};
+
+export type EventStoreSchemaMigrationOptions = {
+  migrationOptions?: CreateEventStoreSchemaOptions;
+};
+
 export const createEventStoreSchema = async (
   pool: AnySQLiteConnection,
   hooks?: SQLiteEventStoreOptions['hooks'],


### PR DESCRIPTION
That should enhance resiliency, benefiting from recent improvements made in other places, especially PostgreSQL. 

This will also make it easier to maintain in the future.

For now, that means also duplication, but that's fine. In the future, I might add `emmett-relationaldb` package to group common code like that. Still, baby steps.

@LuccaHellriegel @SamHatoum @davecosec FYI