### PR TITLE
Fix documentDoesNotExist asserting wrong condition

### DIFF
--- a/src/packages/emmett-postgresql/src/eventStore/projections/pongo/pongoProjectionSpec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/pongo/pongoProjectionSpec.ts
@@ -3,6 +3,7 @@ import {
   assertDeepEqual,
   assertEqual,
   assertIsNotNull,
+  assertIsNull,
   assertThatArray,
 } from '@event-driven-io/emmett';
 import {
@@ -181,7 +182,7 @@ export const documentDoesNotExist =
             : options.matchingFilter,
         );
 
-        assertIsNotNull(result);
+        assertIsNull(result);
       },
       { ...options, ...assertOptions },
     );

--- a/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjection.single.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjection.single.int.spec.ts
@@ -127,6 +127,18 @@ void describe('Postgres Projections', () => {
       );
   });
 
+  void it('notToExist returns success when document does not exist', () =>
+    given([])
+      .when([])
+      .then(
+        expectPongoDocuments
+          .fromCollection<ShoppingCartShortInfo>(
+            shoppingCartShortInfoCollectionName,
+          )
+          .withId('non-existent-id')
+          .notToExist(),
+      ));
+
   void it('with idempotency check', () => {
     const couponId = uuid();
 

--- a/src/packages/emmett-sqlite/src/eventStore/projections/pongo/pongoProjection.single.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/projections/pongo/pongoProjection.single.int.spec.ts
@@ -113,6 +113,18 @@ void describe('Postgres Projections', () => {
       );
   });
 
+  void it('notToExist returns success when document does not exist', () =>
+    given([])
+      .when([])
+      .then(
+        expectPongoDocuments
+          .fromCollection<ShoppingCartShortInfo>(
+            shoppingCartShortInfoCollectionName,
+          )
+          .withId('non-existent-id')
+          .notToExist(),
+      ));
+
   void it('with idempotency check', () => {
     const couponId = uuid();
 

--- a/src/packages/emmett-sqlite/src/eventStore/projections/pongo/pongoProjectionSpec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/projections/pongo/pongoProjectionSpec.ts
@@ -4,6 +4,7 @@ import {
   assertDeepEqual,
   assertEqual,
   assertIsNotNull,
+  assertIsNull,
   assertThatArray,
 } from '@event-driven-io/emmett';
 import {
@@ -180,7 +181,7 @@ export const documentDoesNotExist =
             : options.matchingFilter,
         );
 
-        assertIsNotNull(result);
+        assertIsNull(result);
       },
       { ...options, ...assertOptions },
     );


### PR DESCRIPTION
## Summary

- documentDoesNotExist in pongo projection test helpers used `assertIsNotNull(result)`, which asserts the document exists — the opposite of the intended behavior
- Changed to `assertIsNull(result)` in both SQLite and PostgreSQL packages
- Added notToExist tests covering this case in both packages
