### PR TITLE
Humanizing projections documentation

### DIFF
--- a/src/docs/.vitepress/config.mts
+++ b/src/docs/.vitepress/config.mts
@@ -27,7 +27,7 @@ export default defineConfig({
       {
         text: 'Guides',
         items: [
-          { text: 'Projections', link: '/guides/projections' },
+          { text: 'Read Models', link: '/guides/projections' },
           { text: 'Testing', link: '/guides/testing' },
           { text: 'Error Handling', link: '/guides/error-handling' },
           { text: 'Workflows', link: '/guides/workflows' },
@@ -69,7 +69,7 @@ export default defineConfig({
       {
         text: 'Guides',
         items: [
-          { text: 'Projections', link: '/guides/projections' },
+          { text: 'Read Models', link: '/guides/projections' },
           { text: 'Testing', link: '/guides/testing' },
           { text: 'Error Handling', link: '/guides/error-handling' },
           { text: 'Workflows', link: '/guides/workflows' },

--- a/src/docs/api-reference/event.md
+++ b/src/docs/api-reference/event.md
@@ -297,4 +297,4 @@ type ProductItemAdded = Event<
 - [Getting Started - Events](/getting-started#events)
 - [Command](/api-reference/command) - Requests to change state
 - [Decider](/api-reference/decider) - Pattern using events and commands
-- [Projections](/guides/projections) - Building read models from events
+- [Read Models](/guides/projections) - Building read models from events

--- a/src/docs/api-reference/projections.md
+++ b/src/docs/api-reference/projections.md
@@ -449,7 +449,7 @@ const handle = async (events, context) => {
 
 ## See Also
 
-- [Projections Guide](/guides/projections) - Detailed patterns and strategies
+- [Read Models Guide](/guides/projections) - Detailed patterns and strategies
 - [PostgreSQL Event Store](/event-stores/postgresql) - Pongo projections
 - [Testing Patterns](/guides/testing) - Testing projections
 - [Writing and testing event-driven projections](https://event-driven.io/en/emmett_projections_testing/)

--- a/src/docs/event-stores/mongodb.md
+++ b/src/docs/event-stores/mongodb.md
@@ -333,5 +333,5 @@ For complete API reference and advanced usage, see the [package README](https://
 ## See Also
 
 - [Choosing an Event Store](/guides/choosing-event-store)
-- [Projections Guide](/guides/projections)
+- [Read Models Guide](/guides/projections)
 - [How to build MongoDB Event Store](https://event-driven.io/en/how_to_build_mongodb_event_store/)

--- a/src/docs/event-stores/postgresql.md
+++ b/src/docs/event-stores/postgresql.md
@@ -286,6 +286,6 @@ For complete API reference and advanced usage, see the [package README](https://
 ## See Also
 
 - [Choosing an Event Store](/guides/choosing-event-store)
-- [Projections Guide](/guides/projections)
+- [Read Models Guide](/guides/projections)
 - [Testing Patterns](/guides/testing)
 - [Getting Started](/getting-started) - Full tutorial with PostgreSQL

--- a/src/docs/event-stores/sqlite.md
+++ b/src/docs/event-stores/sqlite.md
@@ -351,4 +351,4 @@ For complete API reference and advanced usage, see the [package README](https://
 
 - [Choosing an Event Store](/guides/choosing-event-store)
 - [Testing Patterns](/guides/testing)
-- [Projections Guide](/guides/projections)
+- [Read Models Guide](/guides/projections)

--- a/src/docs/guides/projections.md
+++ b/src/docs/guides/projections.md
@@ -92,187 +92,37 @@ This pattern works both for single and multi stream projections.
 
 ### Deletion Pattern
 
-Return `null` to delete the document:
+Return `null` from the `evolve` function to delete the document:
 
-```typescript
-evolve: (document, event) => {
-  switch (event.type) {
-    case 'ProductItemAdded':
-      return {
-        /* updated document */
-      };
-    case 'ShoppingCartConfirmed':
-      // Delete the pending cart document
-      return null;
-  }
-};
-```
+<<< ./projections/projectionPatterns.snippet.ts#deletion-pattern{18-20}
 
 ### Selective Handling
 
-Only handle events relevant to your read model:
-
-```typescript
-const projection = pongoSingleStreamProjection({
-  collectionName: 'cart_totals',
-  // Only care about price-affecting events
-  canHandle: ['ProductItemAdded', 'ProductItemRemoved', 'DiscountApplied'],
-  evolve: (document, event) => {
-    // ShoppingCartConfirmed won't reach here
-  },
-});
-```
+Use the `canHandle` option to filter which events reach your `evolve` function. Events not listed in `canHandle` are ignored by the projection. See the `canHandle` usage in both [single-stream](#single-stream-projections) and [multi-stream](#multi-stream-projections) projections above.
 
 ### Metadata Usage
 
-Access event metadata for cross-stream correlation:
-
-```typescript
-const projection = pongoMultiStreamProjection({
-  collectionName: 'daily_sales',
-  canHandle: ['ShoppingCartConfirmed'],
-  getDocumentId: (event) => {
-    const date = event.metadata.timestamp.toISOString().split('T')[0];
-    return `sales-${date}`;
-  },
-  evolve: (document, event) => ({
-    date: document?.date ?? event.metadata.timestamp,
-    totalSales: (document?.totalSales ?? 0) + event.data.totalAmount,
-    orderCount: (document?.orderCount ?? 0) + 1,
-  }),
-});
-```
+Access event metadata for cross-stream correlation through the `getDocumentId` and `evolve` functions. The [multi-stream projection](#multi-stream-projections) example above shows how `event.metadata.clientId` determines which document to update.
 
 ## Querying Read Models
 
 ### With Pongo (PostgreSQL)
 
-```typescript
-import { pongoClient } from '@event-driven-io/pongo';
+Projected read models are stored in Pongo collections. Query them using the `PongoDb` instance:
 
-const pongo = pongoClient(connectionString);
-const cartSummaries = pongo
-  .db()
-  .collection<ShoppingCartSummary>('cart_summaries');
-
-// Find by ID
-const cart = await cartSummaries.findOne({ _id: 'cart-123' });
-
-// Query with filters
-const largeCarts = await cartSummaries
-  .find({ totalAmount: { $gte: 1000 } })
-  .toArray();
-
-// With sorting and pagination
-const recentCarts = await cartSummaries
-  .find({})
-  .sort({ lastUpdated: -1 })
-  .limit(10)
-  .toArray();
-```
+<<< ./projections/queryingReadModels.snippet.ts#querying-read-models
 
 ### In API Routes
 
-```typescript
-router.get(
-  '/carts/:cartId/summary',
-  on(async (request) => {
-    const cartId = request.params.cartId;
-    const summary = await cartSummaries.findOne({ _id: cartId });
+Use read model query functions in your Express route handlers:
 
-    if (!summary) {
-      return notFound({ detail: 'Cart not found' });
-    }
-
-    return ok(summary);
-  }),
-);
-
-router.get(
-  '/carts',
-  on(async (request) => {
-    const minAmount = parseFloat(request.query.minAmount ?? '0');
-
-    const carts = await cartSummaries
-      .find({ totalAmount: { $gte: minAmount } })
-      .toArray();
-
-    return ok({ carts });
-  }),
-);
-```
+<<< ./projections/queryingReadModels.snippet.ts#api-routes
 
 ## Testing Projections
 
-Use the `PostgreSQLProjectionSpec` for BDD-style tests:
+Use the `PostgreSQLProjectionSpec` for BDD-style tests with the `given`/`when`/`then` pattern:
 
-```typescript
-import {
-  PostgreSQLProjectionSpec,
-  expectPongoDocuments,
-  eventsInStream,
-  newEventsInStream,
-} from '@event-driven-io/emmett-postgresql';
-
-describe('Cart Summary Projection', () => {
-  let given: PostgreSQLProjectionSpec<ShoppingCartEvent>;
-
-  beforeAll(async () => {
-    const postgres = await new PostgreSqlContainer().start();
-
-    given = PostgreSQLProjectionSpec.for({
-      projection: cartSummaryProjection,
-      connectionString: postgres.getConnectionUri(),
-    });
-  });
-
-  it('creates summary from first event', () =>
-    given([])
-      .when([
-        {
-          type: 'ProductItemAdded',
-          data: { productId: 'shoes', quantity: 2, price: 100 },
-          metadata: { streamName: 'cart-123' },
-        },
-      ])
-      .then(
-        expectPongoDocuments
-          .fromCollection<ShoppingCartSummary>('cart_summaries')
-          .withId('cart-123')
-          .toBeEqual({
-            productItemsCount: 2,
-            totalAmount: 200,
-          }),
-      ));
-
-  it('accumulates across events', () =>
-    given(
-      eventsInStream('cart-123', [
-        {
-          type: 'ProductItemAdded',
-          data: { productId: 'shoes', quantity: 2, price: 100 },
-        },
-      ]),
-    )
-      .when(
-        newEventsInStream('cart-123', [
-          {
-            type: 'ProductItemAdded',
-            data: { productId: 'shirt', quantity: 1, price: 50 },
-          },
-        ]),
-      )
-      .then(
-        expectPongoDocuments
-          .fromCollection<ShoppingCartSummary>('cart_summaries')
-          .withId('cart-123')
-          .toBeEqual({
-            productItemsCount: 3,
-            totalAmount: 250,
-          }),
-      ));
-});
-```
+<<< ./projections/testingProjections.snippet.ts#testing-projection
 
 ## Best Practices
 
@@ -305,15 +155,7 @@ await productSales.find({}).sort({ totalQuantitySold: -1 }).limit(10);
 
 ### 3. Handle Missing Documents
 
-```typescript
-evolve: (document, event) => {
-  // Always handle null case
-  const current = document ?? defaultState();
-
-  // Now safely update
-  return { ...current /* updates */ };
-};
-```
+Use the [Initial State Pattern](#initial-state-pattern) to provide a default state, or handle the `null` case explicitly in `evolve` as shown in the [single-stream projection](#single-stream-projections) example above.
 
 ### 4. Version Your Projections
 

--- a/src/docs/guides/projections.md
+++ b/src/docs/guides/projections.md
@@ -5,126 +5,97 @@ outline: deep
 
 # Projections
 
-::: warning
-We created this page with the help of the GenAI tool.
-
-We're currently double-checking it to ensure the information is 100% correct and free of hallucinations.
-:::
-
-Projections transform event streams into read models optimized for queries. This guide covers patterns, implementation, and best practices.
+This guide shows you how to build projections — event handlers that transform events into read models you can query directly.
 
 ## Why Projections?
 
-In Event Sourcing, rebuilding state from events works well for single entities. But queries like "show all shopping carts" would require reading thousands of streams and rebuilding each cart in memory.
+In Event Sourcing, rebuilding state from events works well for a single entity — a shopping cart might have 10-50 events. But showing a list of all shopping carts? You'd need to read events from thousands of streams and rebuild each cart in memory on every page load.
 
-**Projections solve this by:**
+Projections solve this by applying events as they happen and storing the result in a database table you can query directly. Each projection is a different interpretation of the same facts — a shopping cart summary for the menu bar, a client analytics dashboard, a product sales report. Same events, different read models shaped for different questions.
 
-- Pre-computing query results as events occur
-- Storing optimized read models in queryable formats
-- Updating incrementally rather than recomputing
+## Project Events into Read Models
 
-## Types of Projections
-
-### Single-Stream Projections
+### From a Single Stream
 
 One event stream maps to one document. The document ID equals the stream ID.
 
-**Use when:** Your read model represents a single entity (shopping cart, order, user profile).
+**Use when:** your read model represents a single entity — a shopping cart summary, an order status, a user profile.
 
 <<< ./projections/singleStreamProjection.snippet.ts#single-stream-projection
 
-### Multi-Stream Projections
+### From Multiple Streams
 
 Events from multiple streams combine into documents with custom IDs.
 
-**Use when:** Your read model aggregates across entities (customer analytics, product statistics, dashboards) or multiple streams of the same type.
+**Use when:** your read model aggregates across entities — a client's total spending across all their carts, product statistics from all orders, system-wide dashboards.
 
 <<< ./projections/multiStreamProjection.snippet.ts#multi-stream-projection{11,15}
 
-## Inline vs Async Projections
+## Choose Between Inline and Async Registration
 
 ### Inline Projections
 
-Execute within the same transaction as the event append.
+Inline projections run in the same database transaction as the event append. Either both succeed or both fail — your read model is always consistent with your events.
 
-**Pros:**
+Use inline when consistency matters more than write speed. For single-stream projections this is often the right default — the overhead is small and you avoid dealing with eventual consistency.
 
-- Strong consistency - read model is always up to date with events,
-- No eventual consistency delays,
-- Simpler mental model.
-
-**Cons:**
-
-- Slower appends (projection runs synchronously adding additonal operations during append),
-- Multi-stream projection can override their data in high contention scenarios,
-- Can't project to external systems.
+Be careful with inline multi-stream projections under high write load. When multiple streams update the same document concurrently, they can overwrite each other's changes. If that's a concern, switch to async.
 
 <<< ./projections/projectionSetup.snippet.ts#inline-projection-setup
 
 ### Async Projections
 
-Process events in background process. We recommend to run multi-stream projections asynchronously.
+Async projections process events in a background process, decoupled from the append.
 
-**Pros:**
-
-- Faster appends (no overhead for updating read models),
-- Can project to external systems,
-- Better scalability,
-- Enable batching of operations,
-- Multi-stream projection won't override their data in high contention scenarios,
-
-**Cons:**
-
-- Eventual consistency,
-- Require stateful service running async projections,
+Use async when you need faster appends, when you're projecting to external systems, or when you have multi-stream projections that would suffer from concurrent write conflicts. The tradeoff is eventual consistency — your read model may lag behind by a short window.
 
 <<< ./projections/projectionSetup.snippet.ts#async-projection-setup
 
-## Projection Patterns
+## Common Patterns
 
-### Initial State Pattern
+### Provide a Default State
 
-Provide a default state instead of handling null:
+If you'd rather not deal with `null` in your `evolve` function, provide an `initialState`. Emmett will use it when the document doesn't exist yet:
 
 <<< ./projections/multiStreamProjection.snippet.ts#projection-with-default
 
-This pattern works both for single and multi stream projections.
+This works for both single-stream and multi-stream projections.
 
-### Deletion Pattern
+### Delete a Document from a Projection
 
-Return `null` from the `evolve` function to delete the document:
+Return `null` from `evolve` to delete the document. This is useful when a process completes and the read model should be cleared — for example, removing a pending cart summary after confirmation, so the next shopping session starts fresh:
 
 <<< ./projections/projectionPatterns.snippet.ts#deletion-pattern{18-20}
 
-### Selective Handling
+### Filter Which Events Your Projection Handles
 
-Use the `canHandle` option to filter which events reach your `evolve` function. Events not listed in `canHandle` are ignored by the projection:
+Your projection doesn't need to handle every event type in the stream. List the event types you care about in `canHandle` — everything else is silently ignored. A shopping cart summary only needs product additions and removals; it doesn't need to know about confirmation or cancellation:
 
 <<< ./projections/projectionOptions.snippet.ts#can-handle{3-10}
 
-### Metadata Usage
+### Route Events Using Metadata
 
-Access event metadata for cross-stream correlation through the `getDocumentId` and `evolve` functions:
+When building a multi-stream projection, you need a way to correlate events from different streams into the right document. If your read model groups data by client, but the client ID isn't in every event's data payload, you can pull it from event metadata. Be careful not to turn metadata into a bag for random data — but context like client ID, tenant, or correlation ID is a reasonable fit, especially if it's already available in your request pipeline for authorisation or routing:
 
 <<< ./projections/projectionOptions.snippet.ts#metadata-usage{3-5}
 
-## Querying Read Models
+## Query Read Models
 
 ### With Pongo (PostgreSQL)
 
-Projected read models are stored in Pongo collections. Query them using the `PongoDb` instance:
+Projected read models are stored in Pongo collections — PostgreSQL tables with a JSONB column for your document data. Query them using the Pongo client with MongoDB-like syntax:
 
 <<< ./projections/queryingReadModels.snippet.ts#querying-read-models
 
 ### In API Routes
 
-Use read model query functions in your Express route handlers:
+Wire Pongo queries into your Express route handlers to serve the read models:
 
 <<< ./projections/queryingReadModels.snippet.ts#api-routes
 
-## Testing Projections
+## Test a Projection
 
-Use the `PostgreSQLProjectionSpec` for BDD-style tests with the `given`/`when`/`then` pattern:
+Projection tests should run against a real database. Both querying behaviour and JSON serialisation can surprise you, so in-memory fakes won't give you enough confidence. Use `PostgreSQLProjectionSpec` with a test container for BDD-style given/when/then tests:
 
 <<< ./projections/testingProjections.snippet.ts#testing-projection
 
@@ -132,30 +103,13 @@ Use the `PostgreSQLProjectionSpec` for BDD-style tests with the `given`/`when`/`
 
 ### 1. Keep Projections Focused
 
-```typescript
-// ✅ Good: Single responsibility
-const cartSummaryProjection = /* totals only */;
-const cartDetailsProjection = /* full item list */;
-const cartStatusProjection = /* status tracking */;
+Each projection should serve one query need. A shopping cart summary for the menu bar only needs item count and total amount — it doesn't need the full product list or the cart status. If you need cart details for a different view, create a separate projection. The same events can feed multiple projections, each shaped for a different purpose.
 
-// ❌ Bad: Kitchen sink projection
-const cartEverythingProjection = /* all data combined */;
-```
+Multiple focused projections are easier to maintain and rebuild than one that tries to answer every question.
 
 ### 2. Design for Queries
 
-```typescript
-// ✅ Good: Matches query patterns
-interface ProductSalesReport {
-  productId: string;
-  totalQuantitySold: number;
-  totalRevenue: number;
-  lastSoldAt: Date;
-}
-
-// Query: "Show me best-selling products"
-await productSales.find({}).sort({ totalQuantitySold: -1 }).limit(10);
-```
+Start from the query your UI or API needs to serve, then shape your read model to match. If you're showing a "best-selling products" list, your read model should have fields you can sort and filter directly — total quantity sold, revenue, last sold date. Don't store raw event data and try to query it later; the whole point of a projection is to pre-shape data for the questions you'll ask.
 
 ### 3. Handle Missing Documents
 
@@ -163,49 +117,44 @@ Provide a default state with `initialState` so `evolve` never receives `null`:
 
 <<< ./projections/multiStreamProjection.snippet.ts#projection-with-default{5-16}
 
-Or handle the `null` case explicitly in `evolve` as shown in the [single-stream projection](#single-stream-projections) example above.
+Or handle the `null` case explicitly in `evolve` as shown in the [single-stream projection](#from-a-single-stream) example above.
 
 ### 4. Version Your Projections
 
-When projection logic changes, you may need to rebuild:
+When your projection logic changes — new fields, different calculations, a bug fix — existing documents were built with the old logic. You can't just update the code. Version the collection name and rebuild from events:
 
 ```typescript
 const projection = pongoSingleStreamProjection({
-  collectionName: 'cart_summaries_v2', // Version in name
-  // ... new logic
+  collectionName: 'cart_summaries_v2',
+  evolve,
+  canHandle: ['ProductItemAdded', 'ProductItemRemoved', 'DiscountApplied'],
 });
 ```
 
 ### 5. Consider Rebuild Strategy
 
-For production changes:
+Events are your source of truth; read models are secondary data you can always rebuild. For production changes without downtime, use a blue-green approach:
 
-1. Deploy new projection alongside old
-2. Rebuild from event history
-3. Switch reads to new projection
-4. Remove old projection
+1. Deploy the new projection writing to a new collection alongside the old one
+2. Let it catch up by processing the event history
+3. Once it's current, switch your queries to the new collection
+4. Remove the old projection
+
+If you can afford a brief window of incomplete data, the simpler path is to truncate the old collection and replay all events through the updated projection logic.
 
 ## Troubleshooting
 
 ### Projection Not Updating
 
-1. Check `canHandle` includes the event type
-2. Verify event metadata has required fields
-3. Check for errors in `evolve` function
-4. Confirm projection is registered with event store
+If your read model isn't reflecting new events, the most common cause is a missing event type in `canHandle`. The projection silently ignores any event type not listed there. For multi-stream projections, also verify that `getDocumentId` returns the correct ID — if it pulls from metadata, make sure the metadata is actually being set when events are appended.
 
-### Inconsistent State
+### Stale Data in Multi-Stream Projections
 
-1. Inline projections: Check transaction boundaries
-2. Async projections: Check checkpoint progress
-3. Look for duplicate event processing
+If your multi-stream projection shows outdated data under concurrent writes, you're likely hitting write conflicts. When two streams both update the same document inline, the second write can overwrite the first. Switch the projection to async registration, which processes events sequentially and avoids this.
 
-### Performance Issues
+### Data Inconsistent After Redeployment
 
-1. Reduce events handled per projection
-2. Use async projections for complex logic
-3. Add indexes to read model collections
-4. Consider batching in async projectors
+If you changed your projection logic but existing documents still reflect the old calculations, you need to rebuild. Existing documents were created with the previous logic — they won't update themselves. Version your collection name and replay from the event history. See [Version Your Projections](#_4-version-your-projections) above.
 
 ## Further Reading
 

--- a/src/docs/guides/projections.md
+++ b/src/docs/guides/projections.md
@@ -3,7 +3,7 @@ documentationType: how-to-guide
 outline: deep
 ---
 
-# Read Models
+# Read Models {#read-models}
 
 In Event Sourcing, rebuilding state from events works well for a single entity (a shopping cart might have 10-50 events). But showing a list of all shopping carts? You'd need to read events from thousands of streams and rebuild each cart in memory on every page load.
 
@@ -11,9 +11,9 @@ Read models solve this. They are queryable representations of your data, stored 
 
 This guide shows you how to build projections and query the read models they produce.
 
-## Project Events into Read Models
+## Project Events into Read Models {#project-events}
 
-### From a Single Stream
+### From a Single Stream {#single-stream}
 
 One event stream maps to one document. The document ID equals the stream ID.
 
@@ -21,7 +21,7 @@ One event stream maps to one document. The document ID equals the stream ID.
 
 <<< ./projections/singleStreamProjection.snippet.ts#single-stream-projection
 
-### From Multiple Streams
+### From Multiple Streams {#multiple-streams}
 
 Events from multiple streams combine into documents with custom IDs.
 
@@ -29,9 +29,9 @@ Events from multiple streams combine into documents with custom IDs.
 
 <<< ./projections/multiStreamProjection.snippet.ts#multi-stream-projection{11,15}
 
-## Choose Between Inline and Async Registration
+## Inline vs. Async Registration {#inline-vs-async}
 
-### Inline Projections
+### Inline Projections {#inline}
 
 Use inline when consistency matters more than write speed. Inline projections run in the same database transaction as the event append. Either both succeed or both fail, so your read model is always consistent with your events. For single-stream projections this is often the right default.
 
@@ -39,77 +39,81 @@ Be careful with inline multi-stream projections under high write load. When mult
 
 <<< ./projections/projectionSetup.snippet.ts#inline-projection-setup
 
-### Async Projections
+### Async Projections {#async}
 
 Use async when you need faster appends, when you're projecting to external systems, or when you have multi-stream projections that would suffer from concurrent write conflicts. Async projections process events in a background process, decoupled from the append. The tradeoff is eventual consistency: your read model may lag behind by a short window.
 
 <<< ./projections/projectionSetup.snippet.ts#async-projection-setup
 
-## Common Patterns
+## Common Patterns {#patterns}
 
-### Provide a Default State
+### Provide a Default State {#default-state}
 
 If you'd rather not deal with `null` in your `evolve` function, provide an `initialState`. Emmett will use it when the document doesn't exist yet:
 
-<<< ./projections/multiStreamProjection.snippet.ts#projection-with-default
+<<< ./projections/multiStreamProjection.snippet.ts#projection-with-default{5-7,14-16}
 
 This works for both single-stream and multi-stream projections.
 
-### Delete a Document from a Projection
+### Delete a Document {#delete-document}
 
 Return `null` from `evolve` to delete the document. This is useful when a process completes and the read model should be cleared. For example, removing a pending cart summary after confirmation, so the next shopping session starts fresh:
 
-<<< ./projections/projectionPatterns.snippet.ts#deletion-pattern{18-20}
+<<< ./projections/projectionPatterns.snippet.ts#deletion-pattern{22-25}
 
-### Filter Which Events Your Projection Handles
+### Filter Events {#filter-events}
 
 Your projection doesn't need to handle every event type in the stream. List the event types you care about in `canHandle`. Everything else is silently ignored. A shopping cart summary only needs product additions and removals; it doesn't need to know about confirmation or cancellation:
 
 <<< ./projections/projectionOptions.snippet.ts#can-handle{3-10}
 
-### Route Events Using Metadata
+### Use Event Metadata {#event-metadata}
 
 When building a multi-stream projection, you need a way to correlate events from different streams into the right document. If your read model groups data by client, but the client ID isn't in every event's data payload, you can pull it from event metadata. Be careful not to turn metadata into a bag for random data. Context like client ID, tenant, or correlation ID is a reasonable fit, especially if it's already available in your request pipeline for authorisation or routing:
 
 <<< ./projections/projectionOptions.snippet.ts#metadata-usage{3-5}
 
-## Query Read Models
+## Query Read Models {#query}
 
-### With Pongo (PostgreSQL)
+### With Pongo (PostgreSQL) {#pongo}
 
 Projected read models are stored in Pongo collections, PostgreSQL tables with a JSONB column for your document data. Query them using the Pongo client with MongoDB-like syntax:
 
 <<< ./projections/queryingReadModels.snippet.ts#querying-read-models
 
-### In API Routes
+### In API Routes {#api-routes}
 
 Wire Pongo queries into your Express route handlers to serve the read models:
 
 <<< ./projections/queryingReadModels.snippet.ts#api-routes
 
-## Test a Projection
+## Test a Projection {#test}
 
 Projection tests should run against a real database. Both querying behaviour and JSON serialisation can surprise you, so in-memory fakes won't give you enough confidence. Use `PostgreSQLProjectionSpec` with a test container for BDD-style given/when/then tests:
 
 <<< ./projections/testingProjections.snippet.ts#testing-projection
 
-## Best Practices
+## Best Practices {#best-practices}
 
-### 1. One Projection Per Query
+### Shape Read Models for Queries {#shape-for-queries}
 
-A shopping cart summary for the menu bar only needs item count and total amount. It doesn't need the full product list or the cart status. If you need cart details for a different view, create a separate projection. The same events can feed multiple projections, each shaped for a different purpose. Multiple focused projections are easier to maintain and rebuild than one that tries to answer every question.
+Start from the query your UI or API needs to serve, then shape your read model to match. If you're showing a "best-selling products" list, your read model should have fields you can sort and filter directly: total quantity sold, revenue, last sold date.
 
-### 2. Shape Read Models for Queries
+We recommend starting with one read model, so one projection per query.
 
-Start from the query your UI or API needs to serve, then shape your read model to match. If you're showing a "best-selling products" list, your read model should have fields you can sort and filter directly: total quantity sold, revenue, last sold date. Don't store raw event data and try to query it later; the whole point of a projection is to pre-shape data for the questions you'll ask.
+A shopping cart summary for the menu bar only needs item count and total amount. If you need cart details for a different view, create a separate projection. Multiple focused projections are easier to maintain and rebuild than one that tries to answer every question:
 
-### 3. Version Your Projections
+<<< ./projections/bestPractices.snippet.ts#one-per-query
 
-When your projection logic changes (new fields, different calculations, a bug fix), existing documents were built with the old logic. You can't just update the code. Version the collection name and rebuild from events:
+The whole point of a projection is to pre-shape data for the questions you'll ask. The `CartSummary` vs `CartDetails` example above shows this: the summary pre-computes count and total for the menu bar, while the details projection keeps the full product list for the cart page.
 
-<<< ./projections/projectionOptions.snippet.ts#versioning{2}
+### Version Your Projections {#version}
 
-### 4. Rebuild From Events
+When your projection logic changes (new fields, different calculations, a bug fix), existing documents were built with the old logic. You can't just update the code. Set the `version` property and rebuild from events. Emmett appends it to the collection name automatically:
+
+<<< ./projections/projectionOptions.snippet.ts#versioning{3-5}
+
+### Rebuild From Events {#rebuild}
 
 Events are your source of truth; read models are derived data you can always rebuild. For production changes without downtime, use a blue-green approach:
 
@@ -120,25 +124,28 @@ Events are your source of truth; read models are derived data you can always reb
 
 If you can afford a brief window of incomplete data, the simpler path is to truncate the old collection and replay all events through the updated projection logic.
 
-## Troubleshooting
+<<< ./projections/rebuildProjection.snippet.ts#rebuild-projection
 
-### Projection Not Updating
+## Troubleshooting {#troubleshooting}
+
+### Projection Not Updating {#not-updating}
 
 If your read model isn't reflecting new events, the most common cause is a missing event type in `canHandle`. The projection silently ignores any event type not listed there. For multi-stream projections, also verify that `getDocumentId` returns the correct ID. If it pulls from metadata, make sure the metadata is actually being set when events are appended.
 
-### Stale Data in Multi-Stream Projections
+### Stale Multi-Stream Data {#stale-data}
 
 If your multi-stream projection shows outdated data under concurrent writes, you're likely hitting write conflicts. When two streams both update the same document inline, the second write can overwrite the first. Switch the projection to async registration, which processes events sequentially and avoids this.
 
-### Data Inconsistent After Redeployment
+### Inconsistent After Redeployment {#inconsistent-data}
 
-If you changed your projection logic but existing documents still reflect the old calculations, you need to rebuild. Existing documents were created with the previous logic and won't update themselves. Version your collection name and replay from the event history. See [Version Your Projections](#_3-version-your-projections) above.
+If you changed your projection logic but existing documents still reflect the old calculations, you need to rebuild. Existing documents were created with the previous logic and won't update themselves. Version your collection name and replay from the event history. See [Version Your Projections](#version) above.
 
-## See Also
+## Further Readings {#readings}
 
 - [Getting Started - Read Models](/getting-started#read-models)
 - [Testing Patterns](/guides/testing) - Testing projections in detail
 - [PostgreSQL Event Store](/event-stores/postgresql) - Pongo projections
 - [API Reference: Projections](/api-reference/projections)
+- [Guide to Projections and Read Models in Event-Driven Architecture](https://event-driven.io/en/projections_and_read_models_in_event_driven_architecture/)
 - [Writing and testing event-driven projections](https://event-driven.io/en/emmett_projections_testing/)
 - [Using event metadata in projections](https://event-driven.io/en/projections_and_event_metadata/)

--- a/src/docs/guides/projections.md
+++ b/src/docs/guides/projections.md
@@ -3,15 +3,13 @@ documentationType: how-to-guide
 outline: deep
 ---
 
-# Projections
+# Read Models
 
-This guide shows you how to build projections — event handlers that transform events into read models you can query directly.
+In Event Sourcing, rebuilding state from events works well for a single entity (a shopping cart might have 10-50 events). But showing a list of all shopping carts? You'd need to read events from thousands of streams and rebuild each cart in memory on every page load.
 
-## Why Projections?
+Read models solve this. They are queryable representations of your data, stored in the database of your choice and shaped for specific questions your application needs to answer. A projection is the event handler that builds a read model. It takes events and transforms them into the stored result. Each projection is a different interpretation of the same facts: a shopping cart summary for the menu bar, a client analytics dashboard, a product sales report. Same events, different read models shaped for different questions.
 
-In Event Sourcing, rebuilding state from events works well for a single entity — a shopping cart might have 10-50 events. But showing a list of all shopping carts? You'd need to read events from thousands of streams and rebuild each cart in memory on every page load.
-
-Projections solve this by applying events as they happen and storing the result in a database table you can query directly. Each projection is a different interpretation of the same facts — a shopping cart summary for the menu bar, a client analytics dashboard, a product sales report. Same events, different read models shaped for different questions.
+This guide shows you how to build projections and query the read models they produce.
 
 ## Project Events into Read Models
 
@@ -19,7 +17,7 @@ Projections solve this by applying events as they happen and storing the result 
 
 One event stream maps to one document. The document ID equals the stream ID.
 
-**Use when:** your read model represents a single entity — a shopping cart summary, an order status, a user profile.
+**Use when:** your read model represents a single entity, like a shopping cart summary, an order status, or a user profile.
 
 <<< ./projections/singleStreamProjection.snippet.ts#single-stream-projection
 
@@ -27,7 +25,7 @@ One event stream maps to one document. The document ID equals the stream ID.
 
 Events from multiple streams combine into documents with custom IDs.
 
-**Use when:** your read model aggregates across entities — a client's total spending across all their carts, product statistics from all orders, system-wide dashboards.
+**Use when:** your read model aggregates across entities, like a client's total spending across all their carts, product statistics from all orders, or system-wide dashboards.
 
 <<< ./projections/multiStreamProjection.snippet.ts#multi-stream-projection{11,15}
 
@@ -35,9 +33,7 @@ Events from multiple streams combine into documents with custom IDs.
 
 ### Inline Projections
 
-Inline projections run in the same database transaction as the event append. Either both succeed or both fail — your read model is always consistent with your events.
-
-Use inline when consistency matters more than write speed. For single-stream projections this is often the right default — the overhead is small and you avoid dealing with eventual consistency.
+Use inline when consistency matters more than write speed. Inline projections run in the same database transaction as the event append. Either both succeed or both fail, so your read model is always consistent with your events. For single-stream projections this is often the right default.
 
 Be careful with inline multi-stream projections under high write load. When multiple streams update the same document concurrently, they can overwrite each other's changes. If that's a concern, switch to async.
 
@@ -45,9 +41,7 @@ Be careful with inline multi-stream projections under high write load. When mult
 
 ### Async Projections
 
-Async projections process events in a background process, decoupled from the append.
-
-Use async when you need faster appends, when you're projecting to external systems, or when you have multi-stream projections that would suffer from concurrent write conflicts. The tradeoff is eventual consistency — your read model may lag behind by a short window.
+Use async when you need faster appends, when you're projecting to external systems, or when you have multi-stream projections that would suffer from concurrent write conflicts. Async projections process events in a background process, decoupled from the append. The tradeoff is eventual consistency: your read model may lag behind by a short window.
 
 <<< ./projections/projectionSetup.snippet.ts#async-projection-setup
 
@@ -63,19 +57,19 @@ This works for both single-stream and multi-stream projections.
 
 ### Delete a Document from a Projection
 
-Return `null` from `evolve` to delete the document. This is useful when a process completes and the read model should be cleared — for example, removing a pending cart summary after confirmation, so the next shopping session starts fresh:
+Return `null` from `evolve` to delete the document. This is useful when a process completes and the read model should be cleared. For example, removing a pending cart summary after confirmation, so the next shopping session starts fresh:
 
 <<< ./projections/projectionPatterns.snippet.ts#deletion-pattern{18-20}
 
 ### Filter Which Events Your Projection Handles
 
-Your projection doesn't need to handle every event type in the stream. List the event types you care about in `canHandle` — everything else is silently ignored. A shopping cart summary only needs product additions and removals; it doesn't need to know about confirmation or cancellation:
+Your projection doesn't need to handle every event type in the stream. List the event types you care about in `canHandle`. Everything else is silently ignored. A shopping cart summary only needs product additions and removals; it doesn't need to know about confirmation or cancellation:
 
 <<< ./projections/projectionOptions.snippet.ts#can-handle{3-10}
 
 ### Route Events Using Metadata
 
-When building a multi-stream projection, you need a way to correlate events from different streams into the right document. If your read model groups data by client, but the client ID isn't in every event's data payload, you can pull it from event metadata. Be careful not to turn metadata into a bag for random data — but context like client ID, tenant, or correlation ID is a reasonable fit, especially if it's already available in your request pipeline for authorisation or routing:
+When building a multi-stream projection, you need a way to correlate events from different streams into the right document. If your read model groups data by client, but the client ID isn't in every event's data payload, you can pull it from event metadata. Be careful not to turn metadata into a bag for random data. Context like client ID, tenant, or correlation ID is a reasonable fit, especially if it's already available in your request pipeline for authorisation or routing:
 
 <<< ./projections/projectionOptions.snippet.ts#metadata-usage{3-5}
 
@@ -83,7 +77,7 @@ When building a multi-stream projection, you need a way to correlate events from
 
 ### With Pongo (PostgreSQL)
 
-Projected read models are stored in Pongo collections — PostgreSQL tables with a JSONB column for your document data. Query them using the Pongo client with MongoDB-like syntax:
+Projected read models are stored in Pongo collections, PostgreSQL tables with a JSONB column for your document data. Query them using the Pongo client with MongoDB-like syntax:
 
 <<< ./projections/queryingReadModels.snippet.ts#querying-read-models
 
@@ -101,39 +95,23 @@ Projection tests should run against a real database. Both querying behaviour and
 
 ## Best Practices
 
-### 1. Keep Projections Focused
+### 1. One Projection Per Query
 
-Each projection should serve one query need. A shopping cart summary for the menu bar only needs item count and total amount — it doesn't need the full product list or the cart status. If you need cart details for a different view, create a separate projection. The same events can feed multiple projections, each shaped for a different purpose.
+A shopping cart summary for the menu bar only needs item count and total amount. It doesn't need the full product list or the cart status. If you need cart details for a different view, create a separate projection. The same events can feed multiple projections, each shaped for a different purpose. Multiple focused projections are easier to maintain and rebuild than one that tries to answer every question.
 
-Multiple focused projections are easier to maintain and rebuild than one that tries to answer every question.
+### 2. Shape Read Models for Queries
 
-### 2. Design for Queries
+Start from the query your UI or API needs to serve, then shape your read model to match. If you're showing a "best-selling products" list, your read model should have fields you can sort and filter directly: total quantity sold, revenue, last sold date. Don't store raw event data and try to query it later; the whole point of a projection is to pre-shape data for the questions you'll ask.
 
-Start from the query your UI or API needs to serve, then shape your read model to match. If you're showing a "best-selling products" list, your read model should have fields you can sort and filter directly — total quantity sold, revenue, last sold date. Don't store raw event data and try to query it later; the whole point of a projection is to pre-shape data for the questions you'll ask.
+### 3. Version Your Projections
 
-### 3. Handle Missing Documents
+When your projection logic changes (new fields, different calculations, a bug fix), existing documents were built with the old logic. You can't just update the code. Version the collection name and rebuild from events:
 
-Provide a default state with `initialState` so `evolve` never receives `null`:
+<<< ./projections/projectionOptions.snippet.ts#versioning{2}
 
-<<< ./projections/multiStreamProjection.snippet.ts#projection-with-default{5-16}
+### 4. Rebuild From Events
 
-Or handle the `null` case explicitly in `evolve` as shown in the [single-stream projection](#from-a-single-stream) example above.
-
-### 4. Version Your Projections
-
-When your projection logic changes — new fields, different calculations, a bug fix — existing documents were built with the old logic. You can't just update the code. Version the collection name and rebuild from events:
-
-```typescript
-const projection = pongoSingleStreamProjection({
-  collectionName: 'cart_summaries_v2',
-  evolve,
-  canHandle: ['ProductItemAdded', 'ProductItemRemoved', 'DiscountApplied'],
-});
-```
-
-### 5. Consider Rebuild Strategy
-
-Events are your source of truth; read models are secondary data you can always rebuild. For production changes without downtime, use a blue-green approach:
+Events are your source of truth; read models are derived data you can always rebuild. For production changes without downtime, use a blue-green approach:
 
 1. Deploy the new projection writing to a new collection alongside the old one
 2. Let it catch up by processing the event history
@@ -146,7 +124,7 @@ If you can afford a brief window of incomplete data, the simpler path is to trun
 
 ### Projection Not Updating
 
-If your read model isn't reflecting new events, the most common cause is a missing event type in `canHandle`. The projection silently ignores any event type not listed there. For multi-stream projections, also verify that `getDocumentId` returns the correct ID — if it pulls from metadata, make sure the metadata is actually being set when events are appended.
+If your read model isn't reflecting new events, the most common cause is a missing event type in `canHandle`. The projection silently ignores any event type not listed there. For multi-stream projections, also verify that `getDocumentId` returns the correct ID. If it pulls from metadata, make sure the metadata is actually being set when events are appended.
 
 ### Stale Data in Multi-Stream Projections
 
@@ -154,16 +132,13 @@ If your multi-stream projection shows outdated data under concurrent writes, you
 
 ### Data Inconsistent After Redeployment
 
-If you changed your projection logic but existing documents still reflect the old calculations, you need to rebuild. Existing documents were created with the previous logic — they won't update themselves. Version your collection name and replay from the event history. See [Version Your Projections](#_4-version-your-projections) above.
-
-## Further Reading
-
-- [Writing and testing event-driven projections](https://event-driven.io/en/emmett_projections_testing/)
-- [Using event metadata in projections](https://event-driven.io/en/projections_and_event_metadata/)
-- [Getting Started - Read Models](/getting-started#read-models)
+If you changed your projection logic but existing documents still reflect the old calculations, you need to rebuild. Existing documents were created with the previous logic and won't update themselves. Version your collection name and replay from the event history. See [Version Your Projections](#_3-version-your-projections) above.
 
 ## See Also
 
+- [Getting Started - Read Models](/getting-started#read-models)
 - [Testing Patterns](/guides/testing) - Testing projections in detail
 - [PostgreSQL Event Store](/event-stores/postgresql) - Pongo projections
 - [API Reference: Projections](/api-reference/projections)
+- [Writing and testing event-driven projections](https://event-driven.io/en/emmett_projections_testing/)
+- [Using event metadata in projections](https://event-driven.io/en/projections_and_event_metadata/)

--- a/src/docs/guides/projections.md
+++ b/src/docs/guides/projections.md
@@ -98,11 +98,15 @@ Return `null` from the `evolve` function to delete the document:
 
 ### Selective Handling
 
-Use the `canHandle` option to filter which events reach your `evolve` function. Events not listed in `canHandle` are ignored by the projection. See the `canHandle` usage in both [single-stream](#single-stream-projections) and [multi-stream](#multi-stream-projections) projections above.
+Use the `canHandle` option to filter which events reach your `evolve` function. Events not listed in `canHandle` are ignored by the projection:
+
+<<< ./projections/projectionOptions.snippet.ts#can-handle{3-10}
 
 ### Metadata Usage
 
-Access event metadata for cross-stream correlation through the `getDocumentId` and `evolve` functions. The [multi-stream projection](#multi-stream-projections) example above shows how `event.metadata.clientId` determines which document to update.
+Access event metadata for cross-stream correlation through the `getDocumentId` and `evolve` functions:
+
+<<< ./projections/projectionOptions.snippet.ts#metadata-usage{3-5}
 
 ## Querying Read Models
 
@@ -155,7 +159,11 @@ await productSales.find({}).sort({ totalQuantitySold: -1 }).limit(10);
 
 ### 3. Handle Missing Documents
 
-Use the [Initial State Pattern](#initial-state-pattern) to provide a default state, or handle the `null` case explicitly in `evolve` as shown in the [single-stream projection](#single-stream-projections) example above.
+Provide a default state with `initialState` so `evolve` never receives `null`:
+
+<<< ./projections/multiStreamProjection.snippet.ts#projection-with-default{5-16}
+
+Or handle the `null` case explicitly in `evolve` as shown in the [single-stream projection](#single-stream-projections) example above.
 
 ### 4. Version Your Projections
 

--- a/src/docs/guides/projections/bestPractices.snippet.ts
+++ b/src/docs/guides/projections/bestPractices.snippet.ts
@@ -1,0 +1,135 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import type { Event } from '@event-driven-io/emmett';
+import { pongoSingleStreamProjection } from '@event-driven-io/emmett-postgresql';
+
+type ProductItemAddedToShoppingCart = Event<
+  'ProductItemAddedToShoppingCart',
+  {
+    shoppingCartId: string;
+    productItem: { productId: string; quantity: number; unitPrice: number };
+    addedAt: Date;
+  }
+>;
+
+type ProductItemRemovedFromShoppingCart = Event<
+  'ProductItemRemovedFromShoppingCart',
+  {
+    shoppingCartId: string;
+    productItem: { productId: string; quantity: number; unitPrice: number };
+    removedAt: Date;
+  }
+>;
+
+type ShoppingCartConfirmed = Event<
+  'ShoppingCartConfirmed',
+  {
+    shoppingCartId: string;
+    totalAmount: number;
+    confirmedAt: Date;
+  }
+>;
+
+type ShoppingCartEvent =
+  | ProductItemAddedToShoppingCart
+  | ProductItemRemovedFromShoppingCart
+  | ShoppingCartConfirmed;
+
+// #region one-per-query
+// Read model for the menu bar: just count and total
+type CartSummary = {
+  productItemsCount: number;
+  totalAmount: number;
+};
+
+const cartSummaryProjection = pongoSingleStreamProjection({
+  collectionName: 'cart_summaries',
+  canHandle: [
+    'ProductItemAddedToShoppingCart',
+    'ProductItemRemovedFromShoppingCart',
+  ],
+  evolve: (
+    document: CartSummary,
+    { type, data: event }: ShoppingCartEvent,
+  ): CartSummary => {
+    switch (type) {
+      case 'ProductItemAddedToShoppingCart':
+        return {
+          productItemsCount:
+            document.productItemsCount + event.productItem.quantity,
+          totalAmount:
+            document.totalAmount +
+            event.productItem.unitPrice * event.productItem.quantity,
+        };
+      case 'ProductItemRemovedFromShoppingCart':
+        return {
+          productItemsCount:
+            document.productItemsCount - event.productItem.quantity,
+          totalAmount:
+            document.totalAmount -
+            event.productItem.unitPrice * event.productItem.quantity,
+        };
+      default:
+        return document;
+    }
+  },
+  initialState: () => ({ productItemsCount: 0, totalAmount: 0 }),
+});
+
+// Read model for the cart detail page: full product list
+type CartDetails = {
+  productItems: Map<
+    string,
+    { productId: string; quantity: number; unitPrice: number }
+  >;
+  status: 'open' | 'confirmed';
+  confirmedAt: Date | null;
+};
+
+const cartDetailsProjection = pongoSingleStreamProjection({
+  collectionName: 'cart_details',
+  canHandle: [
+    'ProductItemAddedToShoppingCart',
+    'ProductItemRemovedFromShoppingCart',
+    'ShoppingCartConfirmed',
+  ],
+  evolve: (
+    document: CartDetails,
+    { type, data: event }: ShoppingCartEvent,
+  ): CartDetails => {
+    switch (type) {
+      case 'ProductItemAddedToShoppingCart': {
+        const existing = document.productItems.get(event.productItem.productId);
+        document.productItems.set(event.productItem.productId, {
+          productId: event.productItem.productId,
+          unitPrice: event.productItem.unitPrice,
+          quantity: (existing?.quantity ?? 0) + event.productItem.quantity,
+        });
+        return document;
+      }
+      case 'ProductItemRemovedFromShoppingCart': {
+        const existing = document.productItems.get(event.productItem.productId);
+        if (existing) {
+          existing.quantity -= event.productItem.quantity;
+          if (existing.quantity <= 0) {
+            document.productItems.delete(event.productItem.productId);
+          }
+        }
+        return document;
+      }
+      case 'ShoppingCartConfirmed':
+        return {
+          ...document,
+          status: 'confirmed',
+          confirmedAt: event.confirmedAt,
+        };
+      default:
+        return document;
+    }
+  },
+  initialState: () => ({
+    productItems: new Map(),
+    status: 'open' as const,
+    confirmedAt: null,
+  }),
+});
+// #endregion one-per-query

--- a/src/docs/guides/projections/projectionOptions.snippet.ts
+++ b/src/docs/guides/projections/projectionOptions.snippet.ts
@@ -97,6 +97,42 @@ const shoppingCartShortInfoProjection = pongoSingleStreamProjection({
 });
 // #endregion can-handle
 
+// #region versioning
+const cartSummariesV2 = pongoSingleStreamProjection({
+  collectionName: 'cart_summaries_v2',
+  evolve: (
+    document: ShoppingCartShortInfo,
+    { type, data: event }: ShoppingCartEvent,
+  ): ShoppingCartShortInfo => {
+    switch (type) {
+      case 'ProductItemAddedToShoppingCart':
+        return {
+          totalAmount:
+            document.totalAmount +
+            event.productItem.unitPrice * event.productItem.quantity,
+          productItemsCount:
+            document.productItemsCount + event.productItem.quantity,
+        };
+      case 'ProductItemRemovedFromShoppingCart':
+        return {
+          totalAmount:
+            document.totalAmount -
+            event.productItem.unitPrice * event.productItem.quantity,
+          productItemsCount:
+            document.productItemsCount - event.productItem.quantity,
+        };
+      default:
+        return document;
+    }
+  },
+  canHandle: [
+    'ProductItemAddedToShoppingCart',
+    'ProductItemRemovedFromShoppingCart',
+  ],
+  initialState: () => ({ productItemsCount: 0, totalAmount: 0 }),
+});
+// #endregion versioning
+
 type ClientShoppingSummary = {
   clientId: string;
   totalOrders: number;

--- a/src/docs/guides/projections/projectionOptions.snippet.ts
+++ b/src/docs/guides/projections/projectionOptions.snippet.ts
@@ -99,7 +99,14 @@ const shoppingCartShortInfoProjection = pongoSingleStreamProjection({
 
 // #region versioning
 const cartSummariesV2 = pongoSingleStreamProjection({
-  collectionName: 'cart_summaries_v2',
+  collectionName: 'cart_summaries',
+  // Emmett appends the version to the collection name automatically,
+  // creating 'cart_summaries_v2' in the database
+  version: 2,
+  canHandle: [
+    'ProductItemAddedToShoppingCart',
+    'ProductItemRemovedFromShoppingCart',
+  ],
   evolve: (
     document: ShoppingCartShortInfo,
     { type, data: event }: ShoppingCartEvent,
@@ -125,10 +132,6 @@ const cartSummariesV2 = pongoSingleStreamProjection({
         return document;
     }
   },
-  canHandle: [
-    'ProductItemAddedToShoppingCart',
-    'ProductItemRemovedFromShoppingCart',
-  ],
   initialState: () => ({ productItemsCount: 0, totalAmount: 0 }),
 });
 // #endregion versioning

--- a/src/docs/guides/projections/projectionOptions.snippet.ts
+++ b/src/docs/guides/projections/projectionOptions.snippet.ts
@@ -1,0 +1,128 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import type { Event } from '@event-driven-io/emmett';
+import {
+  pongoMultiStreamProjection,
+  pongoSingleStreamProjection,
+} from '@event-driven-io/emmett-postgresql';
+
+type ProductItemAddedToShoppingCart = Event<
+  'ProductItemAddedToShoppingCart',
+  {
+    shoppingCartId: string;
+    productItem: { productId: string; quantity: number; unitPrice: number };
+    addedAt: Date;
+  }
+>;
+
+type ProductItemRemovedFromShoppingCart = Event<
+  'ProductItemRemovedFromShoppingCart',
+  {
+    shoppingCartId: string;
+    productItem: { productId: string; quantity: number; unitPrice: number };
+    removedAt: Date;
+  }
+>;
+
+type ShoppingCartConfirmed = Event<
+  'ShoppingCartConfirmed',
+  {
+    shoppingCartId: string;
+    totalAmount: number;
+    confirmedAt: Date;
+  },
+  {
+    clientId: string;
+  }
+>;
+
+type ShoppingCartCancelled = Event<
+  'ShoppingCartCancelled',
+  {
+    shoppingCartId: string;
+    cancelledAt: Date;
+  },
+  {
+    clientId: string;
+  }
+>;
+
+type ShoppingCartEvent =
+  | ProductItemAddedToShoppingCart
+  | ProductItemRemovedFromShoppingCart
+  | ShoppingCartConfirmed
+  | ShoppingCartCancelled;
+
+type ShoppingCartShortInfo = {
+  productItemsCount: number;
+  totalAmount: number;
+};
+
+// #region can-handle
+const shoppingCartShortInfoProjection = pongoSingleStreamProjection({
+  collectionName: 'shoppingCartShortInfo',
+  // Only events listed here will reach the evolve function.
+  // All other event types in the stream are ignored.
+  canHandle: [
+    'ProductItemAddedToShoppingCart',
+    'ProductItemRemovedFromShoppingCart',
+    'ShoppingCartConfirmed',
+    'ShoppingCartCancelled',
+  ],
+  evolve: (
+    document: ShoppingCartShortInfo,
+    { type, data: event }: ShoppingCartEvent,
+  ): ShoppingCartShortInfo => {
+    switch (type) {
+      case 'ProductItemAddedToShoppingCart':
+        return {
+          totalAmount:
+            document.totalAmount +
+            event.productItem.unitPrice * event.productItem.quantity,
+          productItemsCount:
+            document.productItemsCount + event.productItem.quantity,
+        };
+      case 'ProductItemRemovedFromShoppingCart':
+        return {
+          totalAmount:
+            document.totalAmount -
+            event.productItem.unitPrice * event.productItem.quantity,
+          productItemsCount:
+            document.productItemsCount - event.productItem.quantity,
+        };
+      default:
+        return document;
+    }
+  },
+  initialState: () => ({ productItemsCount: 0, totalAmount: 0 }),
+});
+// #endregion can-handle
+
+type ClientShoppingSummary = {
+  clientId: string;
+  totalOrders: number;
+  totalSpent: number;
+};
+
+// #region metadata-usage
+const clientShoppingSummaryProjection = pongoMultiStreamProjection({
+  collectionName: 'clientShoppingSummary',
+  // Use event metadata to route events from different streams
+  // into the same document, grouped by client
+  getDocumentId: (event) => event.metadata.clientId,
+  canHandle: ['ShoppingCartConfirmed'],
+  evolve: (
+    document: ClientShoppingSummary,
+    event: ShoppingCartConfirmed,
+  ): ClientShoppingSummary => ({
+    ...document,
+    clientId: event.metadata.clientId,
+    totalOrders: document.totalOrders + 1,
+    totalSpent: document.totalSpent + event.data.totalAmount,
+  }),
+  initialState: () => ({
+    clientId: '',
+    totalOrders: 0,
+    totalSpent: 0,
+  }),
+});
+// #endregion metadata-usage

--- a/src/docs/guides/projections/projectionPatterns.snippet.ts
+++ b/src/docs/guides/projections/projectionPatterns.snippet.ts
@@ -1,0 +1,101 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import type { Event } from '@event-driven-io/emmett';
+import { pongoSingleStreamProjection } from '@event-driven-io/emmett-postgresql';
+
+export interface ProductItem {
+  productId: string;
+  quantity: number;
+}
+
+export type PricedProductItem = ProductItem & {
+  unitPrice: number;
+};
+
+type ProductItemAddedToShoppingCart = Event<
+  'ProductItemAddedToShoppingCart',
+  {
+    shoppingCartId: string;
+    productItem: PricedProductItem;
+    addedAt: Date;
+  }
+>;
+
+type ProductItemRemovedFromShoppingCart = Event<
+  'ProductItemRemovedFromShoppingCart',
+  {
+    shoppingCartId: string;
+    productItem: PricedProductItem;
+    removedAt: Date;
+  }
+>;
+
+type ShoppingCartConfirmed = Event<
+  'ShoppingCartConfirmed',
+  {
+    shoppingCartId: string;
+    confirmedAt: Date;
+  }
+>;
+
+type ShoppingCartCancelled = Event<
+  'ShoppingCartCancelled',
+  {
+    shoppingCartId: string;
+    cancelledAt: Date;
+  }
+>;
+
+type ShoppingCartEvent =
+  | ProductItemAddedToShoppingCart
+  | ProductItemRemovedFromShoppingCart
+  | ShoppingCartConfirmed
+  | ShoppingCartCancelled;
+
+type ShoppingCartShortInfo = {
+  productItemsCount: number;
+  totalAmount: number;
+};
+
+// #region deletion-pattern
+const evolve = (
+  document: ShoppingCartShortInfo,
+  { type, data: event }: ShoppingCartEvent,
+): ShoppingCartShortInfo | null => {
+  switch (type) {
+    case 'ProductItemAddedToShoppingCart':
+      return {
+        totalAmount:
+          document.totalAmount +
+          event.productItem.unitPrice * event.productItem.quantity,
+        productItemsCount:
+          document.productItemsCount + event.productItem.quantity,
+      };
+    case 'ProductItemRemovedFromShoppingCart':
+      return {
+        totalAmount:
+          document.totalAmount -
+          event.productItem.unitPrice * event.productItem.quantity,
+        productItemsCount:
+          document.productItemsCount - event.productItem.quantity,
+      };
+    case 'ShoppingCartConfirmed':
+    case 'ShoppingCartCancelled':
+      // Delete the pending cart document
+      return null;
+    default:
+      return document;
+  }
+};
+// #endregion deletion-pattern
+
+const shoppingCartShortInfoProjection = pongoSingleStreamProjection({
+  collectionName: 'shoppingCartShortInfo',
+  evolve,
+  canHandle: [
+    'ProductItemAddedToShoppingCart',
+    'ProductItemRemovedFromShoppingCart',
+    'ShoppingCartConfirmed',
+    'ShoppingCartCancelled',
+  ],
+  initialState: () => ({ productItemsCount: 0, totalAmount: 0 }),
+});

--- a/src/docs/guides/projections/queryingReadModels.snippet.ts
+++ b/src/docs/guides/projections/queryingReadModels.snippet.ts
@@ -1,0 +1,80 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {
+  NoContent,
+  NotFound,
+  OK,
+  on,
+  type WebApiSetup,
+} from '@event-driven-io/emmett-expressjs';
+import type { PongoDb } from '@event-driven-io/pongo';
+import type { Request, Router } from 'express';
+
+type ShoppingCartShortInfo = {
+  productItemsCount: number;
+  totalAmount: number;
+};
+
+type ShoppingCartDetails = {
+  clientId: string;
+  productItemsCount: number;
+  totalAmount: number;
+  status: 'Opened' | 'Confirmed' | 'Cancelled';
+  openedAt: Date;
+  confirmedAt?: Date | undefined;
+  cancelledAt?: Date | undefined;
+};
+
+const shoppingCartShortInfoCollectionName = 'shoppingCartShortInfo';
+const shoppingCartDetailsCollectionName = 'shoppingCartDetails';
+
+// #region querying-read-models
+const getShortInfoById = (
+  db: PongoDb,
+  shoppingCartId: string,
+): Promise<ShoppingCartShortInfo | null> =>
+  db
+    .collection<ShoppingCartShortInfo>(shoppingCartShortInfoCollectionName)
+    .findOne({ _id: shoppingCartId });
+
+const getDetailsById = (
+  db: PongoDb,
+  shoppingCartId: string,
+): Promise<ShoppingCartDetails | null> =>
+  db
+    .collection<ShoppingCartDetails>(shoppingCartDetailsCollectionName)
+    .findOne({ _id: shoppingCartId });
+// #endregion querying-read-models
+
+// #region api-routes
+const shoppingCartApi =
+  (readStore: PongoDb): WebApiSetup =>
+  (router: Router) => {
+    router.get(
+      '/clients/:clientId/shopping-carts/current',
+      on(async (request: Request) => {
+        const shoppingCartId = `shopping_cart:${request.params.clientId}:current`;
+
+        const result = await getDetailsById(readStore, shoppingCartId);
+
+        if (result === null) return NotFound();
+
+        if (result.status !== 'Opened') return NotFound();
+
+        return OK({ body: result });
+      }),
+    );
+
+    router.get(
+      '/clients/:clientId/shopping-carts/current/short-info',
+      on(async (request: Request) => {
+        const shoppingCartId = `shopping_cart:${request.params.clientId}:current`;
+
+        const result = await getShortInfoById(readStore, shoppingCartId);
+
+        if (result === null) return NotFound();
+
+        return OK({ body: result });
+      }),
+    );
+  };
+// #endregion api-routes

--- a/src/docs/guides/projections/rebuildProjection.snippet.ts
+++ b/src/docs/guides/projections/rebuildProjection.snippet.ts
@@ -1,0 +1,21 @@
+import { SQL } from '@event-driven-io/dumbo';
+import {
+  postgreSQLRawSQLProjection,
+  rebuildPostgreSQLProjections,
+} from '@event-driven-io/emmett-postgresql';
+
+const connectionString = 'dummy-connection-string';
+const projection = postgreSQLRawSQLProjection({
+  canHandle: ['EventType'],
+  evolve: () => SQL`SELECT 1`,
+  name: 'TestProjection',
+});
+
+// #region rebuild-projection
+const consumer = rebuildPostgreSQLProjections({
+  connectionString,
+  projection,
+});
+
+await consumer.start();
+// #endregion rebuild-projection

--- a/src/docs/guides/projections/testingProjections.snippet.ts
+++ b/src/docs/guides/projections/testingProjections.snippet.ts
@@ -1,0 +1,155 @@
+import type { Event } from '@event-driven-io/emmett';
+import {
+  eventInStream,
+  eventsInStream,
+  expectPongoDocuments,
+  newEventsInStream,
+  pongoSingleStreamProjection,
+  PostgreSQLProjectionSpec,
+} from '@event-driven-io/emmett-postgresql';
+import { getPostgreSQLStartedContainer } from '@event-driven-io/emmett-testcontainers';
+import type { StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { v4 as uuid } from 'uuid';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+
+type ProductItemAdded = Event<
+  'ProductItemAdded',
+  {
+    productItem: { price: number; productId: string; quantity: number };
+  }
+>;
+
+type DiscountApplied = Event<
+  'DiscountApplied',
+  {
+    percent: number;
+    couponId: string;
+  }
+>;
+
+type ShoppingCartShortInfo = {
+  productItemsCount: number;
+  totalAmount: number;
+  appliedDiscounts: string[];
+};
+
+const shoppingCartShortInfoCollectionName = 'shoppingCartShortInfo';
+
+const evolve = (
+  document: ShoppingCartShortInfo,
+  { type, data: event }: ProductItemAdded | DiscountApplied,
+): ShoppingCartShortInfo => {
+  switch (type) {
+    case 'ProductItemAdded':
+      return {
+        ...document,
+        totalAmount:
+          document.totalAmount +
+          event.productItem.price * event.productItem.quantity,
+        productItemsCount:
+          document.productItemsCount + event.productItem.quantity,
+      };
+    case 'DiscountApplied':
+      if (document.appliedDiscounts.includes(event.couponId)) return document;
+
+      return {
+        ...document,
+        totalAmount: (document.totalAmount * (100 - event.percent)) / 100,
+        appliedDiscounts: [...document.appliedDiscounts, event.couponId],
+      };
+    default:
+      return document;
+  }
+};
+
+const shoppingCartShortInfoProjection = pongoSingleStreamProjection({
+  collectionName: shoppingCartShortInfoCollectionName,
+  evolve,
+  canHandle: ['ProductItemAdded', 'DiscountApplied'],
+  initialState: () => ({
+    productItemsCount: 0,
+    totalAmount: 0,
+    appliedDiscounts: [],
+  }),
+});
+
+// #region testing-projection
+void describe('Shopping Cart Short Info Projection', () => {
+  let postgres: StartedPostgreSqlContainer;
+  let given: PostgreSQLProjectionSpec<ProductItemAdded | DiscountApplied>;
+  let shoppingCartId: string;
+
+  beforeAll(async () => {
+    postgres = await getPostgreSQLStartedContainer();
+
+    given = PostgreSQLProjectionSpec.for({
+      projection: shoppingCartShortInfoProjection,
+      connectionString: postgres.getConnectionUri(),
+    });
+  });
+
+  beforeEach(() => (shoppingCartId = `shoppingCart:${uuid()}:${uuid()}`));
+
+  afterAll(async () => {
+    await postgres.stop();
+  });
+
+  void it('creates summary from first event', () =>
+    given([])
+      .when([
+        eventInStream(shoppingCartId, {
+          type: 'ProductItemAdded',
+          data: {
+            productItem: { price: 100, productId: 'shoes', quantity: 100 },
+          },
+        }),
+      ])
+      .then(
+        expectPongoDocuments
+          .fromCollection<ShoppingCartShortInfo>(
+            shoppingCartShortInfoCollectionName,
+          )
+          .withId(shoppingCartId)
+          .toBeEqual({
+            productItemsCount: 100,
+            totalAmount: 10000,
+            appliedDiscounts: [],
+          }),
+      ));
+
+  void it('accumulates across events', () => {
+    const couponId = uuid();
+
+    return given(
+      eventsInStream<ProductItemAdded>(shoppingCartId, [
+        {
+          type: 'ProductItemAdded',
+          data: {
+            productItem: { price: 100, productId: 'shoes', quantity: 100 },
+          },
+        },
+      ]),
+    )
+      .when(
+        newEventsInStream(shoppingCartId, [
+          {
+            type: 'DiscountApplied',
+            data: { percent: 10, couponId },
+          },
+        ]),
+      )
+      .then(
+        expectPongoDocuments
+          .fromCollection<ShoppingCartShortInfo>(
+            shoppingCartShortInfoCollectionName,
+          )
+          .withId(shoppingCartId)
+          .toBeEqual({
+            productItemsCount: 100,
+            totalAmount: 9000,
+            appliedDiscounts: [couponId],
+          }),
+      );
+  });
+});
+// #endregion testing-projection

--- a/src/docs/guides/testing.md
+++ b/src/docs/guides/testing.md
@@ -490,5 +490,5 @@ let cartId = 'shared-cart'; // Mutations leak between tests
 ## See Also
 
 - [Getting Started](/getting-started) - Full tutorial including testing
-- [Projections Guide](/guides/projections) - Testing projections in detail
+- [Read Models Guide](/guides/projections) - Testing projections in detail
 - [API Reference: DeciderSpecification](/api-reference/decider)

--- a/src/docs/guides/workflows.md
+++ b/src/docs/guides/workflows.md
@@ -428,7 +428,7 @@ describe('GroupCheckoutWorkflow', () => {
 **Don't use workflows for:**
 
 - Simple request-response operations → use [command handlers](/api-reference/commandhandler)
-- Building read models → use [projections](/guides/projections)
+- Building read models → use [projections](/guides/projections) guide
 - Simple event reactions → use reactors
 - Synchronous single-aggregate operations
 
@@ -450,5 +450,5 @@ Because workflows use event sourcing:
 ## See Also
 
 - [Command Handler](/api-reference/commandhandler) - For simpler command processing
-- [Projections](/guides/projections) - For building read models
+- [Read Models](/guides/projections) - For building read models
 - [Testing Patterns](/guides/testing) - For comprehensive testing strategies

--- a/src/docs/overview.md
+++ b/src/docs/overview.md
@@ -15,7 +15,7 @@ Welcome to Emmett's documentation!
 | **Event-Centric Modeling**    | Structured approach to modeling business processes through events                                                                                                                        |
 | **Multiple Event Stores**     | Built-in support for [PostgreSQL](/event-stores/postgresql), [EventStoreDB](/event-stores/esdb), [MongoDB](/event-stores/mongodb), [SQLite](/event-stores/sqlite), and In-Memory storage |
 | **Command Handling Patterns** | Standardized approach with the [Decider pattern](/api-reference/decider)                                                                                                                 |
-| **Projections**               | Built-in [projections](/guides/projections) to build read models from events                                                                                                             |
+| **Read Models**               | Built-in [projections](/guides/projections) to build read models from events                                                                                                             |
 | **Workflows**                 | Coordinate multi-step processes with [durable execution](/guides/workflows)                                                                                                              |
 | **Type Safety**               | First-class TypeScript support with structural typing                                                                                                                                    |
 | **Web Framework Integration** | Seamless integration with [Express.js](/frameworks/expressjs) and [Fastify](/frameworks/fastify)                                                                                         |
@@ -59,7 +59,7 @@ New to Emmett? Start here.
 
 Learn key patterns and techniques.
 
-- [Projections](/guides/projections) - Build read models
+- [Read Models](/guides/projections) - Build read models
 - [Testing](/guides/testing) - Test strategies
 - [Error Handling](/guides/error-handling) - Handle errors gracefully
 - [Workflows](/guides/workflows) - Multi-step processes
@@ -118,7 +118,7 @@ This documentation follows the [Diataxis](https://diataxis.fr) framework:
 | Type              | Purpose                          | Examples                                                       |
 | ----------------- | -------------------------------- | -------------------------------------------------------------- |
 | **Tutorials**     | Learning-oriented, step-by-step  | [Getting Started](/getting-started)                            |
-| **How-to Guides** | Task-oriented, problem-solving   | [Testing](/guides/testing), [Projections](/guides/projections) |
+| **How-to Guides** | Task-oriented, problem-solving   | [Testing](/guides/testing), [Read Models](/guides/projections) |
 | **Reference**     | Information-oriented, technical  | [API Reference](/api-reference/)                               |
 | **Explanation**   | Understanding-oriented, concepts | [Choosing an Event Store](/guides/choosing-event-store)        |
 


### PR DESCRIPTION
Updated Projections documentation, renaming it to Read Model, to make it clearer for people from outside of the EDA community. As it's a how-to guide, I made it more task-oriented, rephrased some sentences, and moved code to TypeScript snippets file, to ensure that there are no hallucinations.