### PR TITLE
Fixed reading last message global position from PostgreSQL and SQLite event stores

### DIFF
--- a/src/packages/emmett-postgresql/src/eventStore/schema/readLastMessageGlobalPosition.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/readLastMessageGlobalPosition.int.spec.ts
@@ -1,0 +1,140 @@
+import { dumbo, SQL } from '@event-driven-io/dumbo';
+import { pgDumboDriver, type PgPool } from '@event-driven-io/dumbo/pg';
+import {
+  assertEqual,
+  assertIsNotNull,
+  assertIsNull,
+  assertTrue,
+  type Event,
+} from '@event-driven-io/emmett';
+import { getPostgreSQLStartedContainer } from '@event-driven-io/emmett-testcontainers';
+import type { StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { v4 as uuid } from 'uuid';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import { createEventStoreSchema, readLastMessageGlobalPosition } from '.';
+import { appendToStream } from './appendToStream';
+import { messagesTable } from './typing';
+
+export type PricedProductItem = {
+  productId: string;
+  quantity: number;
+  price: number;
+};
+
+export type ProductItemAdded = Event<
+  'ProductItemAdded',
+  { productItem: PricedProductItem },
+  { meta: string }
+>;
+
+void describe('readLastMessageGlobalPosition', () => {
+  let postgres: StartedPostgreSqlContainer;
+  let pool: PgPool;
+
+  beforeAll(async () => {
+    postgres = await getPostgreSQLStartedContainer();
+    const connectionString = postgres.getConnectionUri();
+    pool = dumbo({
+      connectionString,
+      driver: pgDumboDriver,
+    });
+
+    await createEventStoreSchema(connectionString, pool);
+  });
+
+  beforeEach(async () => {
+    await pool.execute.command(
+      SQL`TRUNCATE TABLE ${SQL.identifier(messagesTable.name)}`,
+    );
+  });
+
+  afterAll(async () => {
+    try {
+      await pool.close();
+      await postgres.stop();
+    } catch (error) {
+      console.log(error);
+    }
+  });
+
+  const events: ProductItemAdded[] = Array.from({ length: 3 }, (_, i) => ({
+    type: 'ProductItemAdded',
+    data: { productItem: { productId: String(i + 1), quantity: i, price: 30 } },
+    metadata: { meta: `data${i + 1}` },
+  }));
+
+  void it('returns global position of last existing event of single event', async () => {
+    // Given
+    const result = await appendToStream(
+      pool,
+      uuid(),
+      'shopping_cart',
+      events.slice(0, 1),
+      {
+        expectedStreamVersion: 0n,
+      },
+    );
+    assertTrue(result.success);
+    const lastGlobalPosition =
+      result.globalPositions[result.globalPositions.length - 1]!;
+
+    // When
+    const { currentGlobalPosition } = await readLastMessageGlobalPosition(
+      pool.execute,
+    );
+
+    // Then
+    assertIsNotNull(currentGlobalPosition);
+    assertEqual(currentGlobalPosition, lastGlobalPosition);
+  });
+
+  void it('returns global position of last existing event of single existing stream', async () => {
+    // Given
+    const result = await appendToStream(pool, uuid(), 'shopping_cart', events, {
+      expectedStreamVersion: 0n,
+    });
+    assertTrue(result.success);
+    const lastGlobalPosition =
+      result.globalPositions[result.globalPositions.length - 1]!;
+
+    // When
+    const { currentGlobalPosition } = await readLastMessageGlobalPosition(
+      pool.execute,
+    );
+
+    // Then
+    assertIsNotNull(currentGlobalPosition);
+    assertEqual(currentGlobalPosition, lastGlobalPosition);
+  });
+
+  void it('returns global position of last existing event of multiple existing streams', async () => {
+    // Given
+    await appendToStream(pool, uuid(), 'shopping_cart', events, {
+      expectedStreamVersion: 0n,
+    });
+    const result = await appendToStream(pool, uuid(), 'shopping_cart', events);
+    assertTrue(result.success);
+    const lastGlobalPosition =
+      result.globalPositions[result.globalPositions.length - 1]!;
+
+    // When
+    const { currentGlobalPosition } = await readLastMessageGlobalPosition(
+      pool.execute,
+    );
+
+    // Then
+    assertIsNotNull(currentGlobalPosition);
+    assertEqual(currentGlobalPosition, lastGlobalPosition);
+  });
+
+  void it('returns null value for current position for empty event store', async () => {
+    // Given
+    // When
+    const { currentGlobalPosition } = await readLastMessageGlobalPosition(
+      pool.execute,
+    );
+
+    // Then
+    assertIsNull(currentGlobalPosition);
+  });
+});

--- a/src/packages/emmett-postgresql/src/eventStore/schema/readLastMessageGlobalPosition.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/readLastMessageGlobalPosition.ts
@@ -18,7 +18,7 @@ export const readLastMessageGlobalPosition = async (
       SQL`SELECT global_position
            FROM ${SQL.identifier(messagesTable.name)}
            WHERE partition = ${options?.partition ?? defaultTag} AND is_archived = FALSE AND transaction_id < pg_snapshot_xmin(pg_current_snapshot())
-           ORDER BY transaction_id, global_position
+           ORDER BY transaction_id DESC, global_position DESC
            LIMIT 1`,
     ),
   );

--- a/src/packages/emmett-sqlite/src/eventStore/schema/readLastMessageGlobalPosition.d1.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/schema/readLastMessageGlobalPosition.d1.int.spec.ts
@@ -1,0 +1,150 @@
+import type { D1Database } from '@cloudflare/workers-types';
+import { JSONSerializer, SQL } from '@event-driven-io/dumbo';
+import { d1Connection } from '@event-driven-io/dumbo/cloudflare';
+import type { AnySQLiteConnection } from '@event-driven-io/dumbo/sqlite3';
+import {
+  assertEqual,
+  assertIsNotNull,
+  assertIsNull,
+  assertTrue,
+  type Event,
+} from '@event-driven-io/emmett';
+import { Miniflare } from 'miniflare';
+import { v4 as uuid } from 'uuid';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import { createEventStoreSchema, readLastMessageGlobalPosition } from '.';
+import { appendToStream } from './appendToStream';
+
+export type PricedProductItem = {
+  productId: string;
+  quantity: number;
+  price: number;
+};
+
+export type ProductItemAdded = Event<
+  'ProductItemAdded',
+  { productItem: PricedProductItem },
+  { meta: string }
+>;
+
+void describe('readLastMessageGlobalPosition', () => {
+  let connection: AnySQLiteConnection;
+  let mf: Miniflare;
+  let database: D1Database;
+
+  beforeAll(async () => {
+    mf = new Miniflare({
+      modules: true,
+      script: 'export default { fetch() { return new Response("ok"); } }',
+      d1Databases: { DB: 'test-db-id' },
+    });
+    database = await mf.getD1Database('DB');
+    connection = d1Connection({
+      database,
+      serializer: JSONSerializer,
+      transactionOptions: {
+        allowNestedTransactions: true,
+        mode: 'session_based',
+      },
+    });
+    await createEventStoreSchema(connection);
+  });
+
+  beforeEach(async () => {
+    await connection.execute.command(SQL`DELETE FROM emt_messages;`);
+  });
+
+  afterAll(async () => {
+    await connection.close();
+    await mf.dispose();
+  });
+
+  const events: ProductItemAdded[] = Array.from({ length: 3 }, (_, i) => ({
+    type: 'ProductItemAdded',
+    data: { productItem: { productId: String(i + 1), quantity: i, price: 30 } },
+    metadata: { meta: `data${i + 1}` },
+  }));
+
+  void it('returns global position of last existing event of single event', async () => {
+    // Given
+    const result = await appendToStream(
+      connection,
+      uuid(),
+      'shopping_cart',
+      events.slice(0, 1),
+      {
+        expectedStreamVersion: 0n,
+      },
+    );
+    assertTrue(result.success);
+    const { lastGlobalPosition } = result;
+
+    // When
+    const { currentGlobalPosition } = await readLastMessageGlobalPosition(
+      connection.execute,
+    );
+
+    // Then
+    assertIsNotNull(currentGlobalPosition);
+    assertEqual(currentGlobalPosition, lastGlobalPosition);
+  });
+
+  void it('returns global position of last existing event of single existing stream', async () => {
+    // Given
+    const result = await appendToStream(
+      connection,
+      uuid(),
+      'shopping_cart',
+      events,
+      {
+        expectedStreamVersion: 0n,
+      },
+    );
+    assertTrue(result.success);
+    const { lastGlobalPosition } = result;
+
+    // When
+    const { currentGlobalPosition } = await readLastMessageGlobalPosition(
+      connection.execute,
+    );
+
+    // Then
+    assertIsNotNull(currentGlobalPosition);
+    assertEqual(currentGlobalPosition, lastGlobalPosition);
+  });
+
+  void it('returns global position of last existing event of multiple existing streams', async () => {
+    // Given
+    await appendToStream(connection, uuid(), 'shopping_cart', events, {
+      expectedStreamVersion: 0n,
+    });
+    const result = await appendToStream(
+      connection,
+      uuid(),
+      'shopping_cart',
+      events,
+    );
+    assertTrue(result.success);
+    const { lastGlobalPosition } = result;
+
+    // When
+    const { currentGlobalPosition } = await readLastMessageGlobalPosition(
+      connection.execute,
+    );
+
+    // Then
+    assertIsNotNull(currentGlobalPosition);
+    assertEqual(currentGlobalPosition, lastGlobalPosition);
+  });
+
+  void it('returns null value for current position for empty event store', async () => {
+    // Given
+    // When
+    const { currentGlobalPosition } = await readLastMessageGlobalPosition(
+      connection.execute,
+    );
+
+    // Then
+    assertIsNull(currentGlobalPosition);
+  });
+});

--- a/src/packages/emmett-sqlite/src/eventStore/schema/readLastMessageGlobalPosition.sqlite3.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/schema/readLastMessageGlobalPosition.sqlite3.int.spec.ts
@@ -1,0 +1,138 @@
+import { JSONSerializer, SQL } from '@event-driven-io/dumbo';
+import {
+  InMemorySQLiteDatabase,
+  sqlite3Connection,
+  type AnySQLiteConnection,
+} from '@event-driven-io/dumbo/sqlite3';
+import {
+  assertEqual,
+  assertIsNotNull,
+  assertIsNull,
+  assertTrue,
+  type Event,
+} from '@event-driven-io/emmett';
+import { v4 as uuid } from 'uuid';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import { createEventStoreSchema, readLastMessageGlobalPosition } from '.';
+import { appendToStream } from './appendToStream';
+
+export type PricedProductItem = {
+  productId: string;
+  quantity: number;
+  price: number;
+};
+
+export type ProductItemAdded = Event<
+  'ProductItemAdded',
+  { productItem: PricedProductItem },
+  { meta: string }
+>;
+
+void describe('readLastMessageGlobalPosition', () => {
+  let connection: AnySQLiteConnection;
+
+  beforeAll(async () => {
+    connection = sqlite3Connection({
+      fileName: InMemorySQLiteDatabase,
+      serializer: JSONSerializer,
+    });
+    await createEventStoreSchema(connection);
+  });
+
+  beforeEach(async () => {
+    await connection.execute.command(SQL`DELETE FROM emt_messages;`);
+  });
+
+  afterAll(async () => {
+    await connection.close();
+  });
+
+  const events: ProductItemAdded[] = Array.from({ length: 3 }, (_, i) => ({
+    type: 'ProductItemAdded',
+    data: { productItem: { productId: String(i + 1), quantity: i, price: 30 } },
+    metadata: { meta: `data${i + 1}` },
+  }));
+
+  void it('returns global position of last existing event of single event', async () => {
+    // Given
+    const result = await appendToStream(
+      connection,
+      uuid(),
+      'shopping_cart',
+      events.slice(0, 1),
+      {
+        expectedStreamVersion: 0n,
+      },
+    );
+    assertTrue(result.success);
+    const { lastGlobalPosition } = result;
+
+    // When
+    const { currentGlobalPosition } = await readLastMessageGlobalPosition(
+      connection.execute,
+    );
+
+    // Then
+    assertIsNotNull(currentGlobalPosition);
+    assertEqual(currentGlobalPosition, lastGlobalPosition);
+  });
+
+  void it('returns global position of last existing event of single existing stream', async () => {
+    // Given
+    const result = await appendToStream(
+      connection,
+      uuid(),
+      'shopping_cart',
+      events,
+      {
+        expectedStreamVersion: 0n,
+      },
+    );
+    assertTrue(result.success);
+    const { lastGlobalPosition } = result;
+
+    // When
+    const { currentGlobalPosition } = await readLastMessageGlobalPosition(
+      connection.execute,
+    );
+
+    // Then
+    assertIsNotNull(currentGlobalPosition);
+    assertEqual(currentGlobalPosition, lastGlobalPosition);
+  });
+
+  void it('returns global position of last existing event of multiple existing streams', async () => {
+    // Given
+    await appendToStream(connection, uuid(), 'shopping_cart', events, {
+      expectedStreamVersion: 0n,
+    });
+    const result = await appendToStream(
+      connection,
+      uuid(),
+      'shopping_cart',
+      events,
+    );
+    assertTrue(result.success);
+    const { lastGlobalPosition } = result;
+
+    // When
+    const { currentGlobalPosition } = await readLastMessageGlobalPosition(
+      connection.execute,
+    );
+
+    // Then
+    assertIsNotNull(currentGlobalPosition);
+    assertEqual(currentGlobalPosition, lastGlobalPosition);
+  });
+
+  void it('returns null value for current position for empty event store', async () => {
+    // Given
+    // When
+    const { currentGlobalPosition } = await readLastMessageGlobalPosition(
+      connection.execute,
+    );
+
+    // Then
+    assertIsNull(currentGlobalPosition);
+  });
+});

--- a/src/packages/emmett-sqlite/src/eventStore/schema/readLastMessageGlobalPosition.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/schema/readLastMessageGlobalPosition.ts
@@ -20,7 +20,7 @@ export const readLastMessageGlobalPosition = async (
          SELECT global_position
          FROM ${identifier(messagesTable.name)}
          WHERE partition = ${options?.partition ?? defaultTag} AND is_archived = FALSE
-         ORDER BY global_position
+         ORDER BY global_position DESC
          LIMIT 1`,
     ),
   );

--- a/src/packages/emmett/src/testing/assertions.ts
+++ b/src/packages/emmett/src/testing/assertions.ts
@@ -214,16 +214,16 @@ export function assertNotEqual<T>(
     );
 }
 
-export function assertIsNotNull<T extends object | bigint>(
-  result: T | null,
-): asserts result is T {
+export function assertIsNotNull<
+  T extends object | string | bigint | boolean | number,
+>(result: T | null): asserts result is T {
   assertNotEqual(result, null);
   assertOk(result);
 }
 
-export function assertIsNull<T extends object>(
-  result: T | null,
-): asserts result is null {
+export function assertIsNull<
+  T extends object | string | bigint | boolean | number,
+>(result: T | null): asserts result is null {
   assertEqual(result, null);
 }
 


### PR DESCRIPTION
I accidentally forgot to add `DESC` when sorting messages, which ended in getting the first message instead...

Added also missing tests.

Thanks go to @nordfjord for catching this up.