### PR TITLE
Plugged Alamanac into Emmett and defined initial observability collectors

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -68,16 +68,16 @@
       }
     },
     "node_modules/@algolia/abtesting": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.16.2.tgz",
-      "integrity": "sha512-n9s6bEV6imdtIEd+BGP7WkA4pEZ5YTdgQ05JQhHwWawHg3hyjpNwC0TShGz6zWhv+jfLDGA/6FFNbySFS0P9cw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.17.0.tgz",
+      "integrity": "sha512-nuhHZdTiCtRzJEe9VSNzyqE9cOQMt01UWBzymFnjbgwrxxZpbGHQde6Oa/y9zyspTCjbUtb7Q5HQek1CLiLyeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -133,41 +133,41 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.50.2.tgz",
-      "integrity": "sha512-52iq0vHy1sphgnwoZyx5PmbEt8hsh+m7jD123LmBs6qy4GK7LbYZIeKd+nSnSipN2zvKRZ2zScS6h9PW3J7SXg==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.51.0.tgz",
+      "integrity": "sha512-PKrKlIla1U2J7mFcIQn6N3pWP4oySmkxShnbbDsj/H7818gKbET5KsUwsVoNjWIxHKTJMCTcQ7ekAJ8Ea23NMg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.50.2.tgz",
-      "integrity": "sha512-WpPIUg+cSG2aPUG0gS8Ko9DwRgbRPUZxJkolhL2aCsmSlcEEZT65dILrfg5ovcxtx0Kvr+xtBVsTMtsQWRtPDQ==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.51.0.tgz",
+      "integrity": "sha512-U+HCY1K16Km91pIRL1kN6bW6BbGFAF/WhkRSCx4wyl1aFpbrlhSFQs/dAwWbmyBiHWwVWhl7stWHQ1pum5EfMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.50.2.tgz",
-      "integrity": "sha512-Gj2MgtArGcsr82kIqRlo6/dCAFjrs2gLByEqyRENuT7ugrSMFuqg1vDzeBjRL1t3EJEJCFtT0PLX3gB8A6Hq4Q==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.51.0.tgz",
+      "integrity": "sha512-YPJ3dEuZLCRp846Az94t6Z2gwSNRazP+SmBco7p6SCa4fYrtIE820PDXYZshbNrj2Z8Qfbmv7BQ1Lecl5L3G/w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -175,151 +175,151 @@
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.50.2.tgz",
-      "integrity": "sha512-CUqoid5jDpmrc0oK3/xuZXFt6kwT0P9Lw7/nsM14YTr6puvmi+OUKmURpmebQF22S2vCG8L1DAoXXujxQUi/ug==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.51.0.tgz",
+      "integrity": "sha512-/gEwLlR7fQ7YjOW+ADRZ0NxLDtpTC61FSzlZ01Gdl1kTJfU0Rq3Y/TYqwxGxlQGcUiXtGzrpjxXWh3Y0TZD6NA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.50.2.tgz",
-      "integrity": "sha512-AndZWFoc0gbP5901OeQJ73BazgGgSGiBEba4ohdoJuZwHTO2Gio8Q4L1VLmytMBYcviVigB0iICToMvEJxI4ug==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.51.0.tgz",
+      "integrity": "sha512-nRwUN1Y2cKyOAFZyIBagkEfZSIhP05nWhT4Rjwl84lcjECssYggftrAODrZ4leakXxSGjhxs/AdaAFEIBqwVFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.50.2.tgz",
-      "integrity": "sha512-NWoL+psEkz5dIzweaByVXuEB45wS8/rk0E0AhMMnaVJdVs7TcACPH2/OURm+N0xRDITkTHqCna823rd6Uqntdg==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.51.0.tgz",
+      "integrity": "sha512-pybzYCG7VoQKppo+z5iZOKpW8XqtFxhsAIRgEaNboCnfypKukiBHJAwB+pmr7vMZXBsOHwklGYWwCG82e8qshA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.50.2.tgz",
-      "integrity": "sha512-ypSboUJ3XJoQz5DeDo82hCnrRuwq3q9ZdFhVKAik9TnZh1DvLqoQsrbBjXg7C7zQOtV/Qbge/HmyoV6V5L7MhQ==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.51.0.tgz",
+      "integrity": "sha512-DWVIlj6RqcvdhwP0gBU9OpOQPnHdcAk9jlT+z8rsNb2+liWv4eUlfQZ7saGBraFsnygEHD3PtdppIHvqwBAb5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.50.2.tgz",
-      "integrity": "sha512-VlR2FRXLw2bCB94SQo6zxg/Qi+547aOji6Pb+dKE7h1DMCCY317St+OpjpmgzE+bT2O9ALIc0V4nVIBOd7Gy+Q==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.51.0.tgz",
+      "integrity": "sha512-bA25s12iUDJi/X8M7tWlPRT8GeOhls/yDbdoUqinz27lNqsOlcM1UrAxIKdIZ6lm3sXit+ewPIz1pS2x6rXu8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.50.2.tgz",
-      "integrity": "sha512-Cmvfp2+qopzQt8OilU97rhLhosq7ZrB6uieok3EwFUqG/aalPg6DgfCmu0yJMrYe+KMC1qRVt1MTRAUwLknUMQ==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.51.0.tgz",
+      "integrity": "sha512-zj+RcE5e0NE0/ew6oEOTgOplPHry+w2oi7h0Y87lhdq4E0d7xLS31KVB8kKfCGkrG7AYtZvrcyvLOKS5d0no4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.50.2.tgz",
-      "integrity": "sha512-jrkuyKoOM7dFWQ/6Y4hQAse2SC3L/RldG6GnPjMvAj65h+7Ubb51S0pKk4ofSStF0xm4LCNe0C4T6XX4nOFDiQ==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.51.0.tgz",
+      "integrity": "sha512-/HDgccfye1Rq3bPxaSCsvSEBHzSMmtpM9ZRGRtAuC62Cv+ql/76IWnxjGTDXtqIJ+/j7ZlFYAzq9fkp95wF2SQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.50.2.tgz",
-      "integrity": "sha512-4107YLJqCudPiBUlwnk6oTSUVwU7ab+qL1SfQGEDYI8DZH5gsf1ekPt9JykXRKYXf2IfouFL5GiCY/PHTFIjYw==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.51.0.tgz",
+      "integrity": "sha512-nJdW+WBwGlXWMJbxxB7/AJPvNq0lLJSudXmIQCJbmH8jsOXQhRpAtoCD4ceLyJKv3ze9JbQu4Gqu5JDLckuFcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2"
+        "@algolia/client-common": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.50.2.tgz",
-      "integrity": "sha512-vOrd3MQpLgmf6wXAueTuZ/cA0W4uRwIHHaxNy3h+a6YcNn6bCV/gFdZuv3F13v593zRU2k5R75NmvRWLenvMrw==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.51.0.tgz",
+      "integrity": "sha512-bsBgRI/1h1mjS3eCyfGau78yGZVmiDLmT1aU6dMnk75/T0SgKqnSKNpQ53xKoDYVChGDcNnpHXWpoUSo8MH1+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2"
+        "@algolia/client-common": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.50.2.tgz",
-      "integrity": "sha512-Mu9BFtgzGqDUy5Bcs2nMyoILIFSN13GKQaklKAFIsd0K3/9CpNyfeBc+/+Qs6mFZLlxG9qzullO7h+bjcTBuGQ==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.51.0.tgz",
+      "integrity": "sha512-zPrIDVPpmKWgrjmWOqpqrhqAhNjvVkjoj+mqw2NBPxEOuKNzP0H+Qz5NJLLTOepBVj1UFedFaF3AUgxLsB9ukQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2"
+        "@algolia/client-common": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -343,7 +343,18 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@babel/generator/node_modules/@babel/helper-string-parser": {
+    "node_modules/@babel/generator/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
       "version": "8.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.3.tgz",
       "integrity": "sha512-AmwWFx1m8G/a5cXkxLxTiWl+YEoWuoFLUCwqMlNuWO1tqAYITQAbCRPUkyBHv1VOFgfjVOqEj6L3u15J5ZCzTA==",
@@ -353,7 +364,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@babel/generator/node_modules/@babel/helper-validator-identifier": {
+    "node_modules/@babel/helper-validator-identifier": {
       "version": "8.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.3.tgz",
       "integrity": "sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw==",
@@ -363,7 +374,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@babel/generator/node_modules/@babel/parser": {
+    "node_modules/@babel/parser": {
       "version": "8.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.3.tgz",
       "integrity": "sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ==",
@@ -379,7 +390,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@babel/generator/node_modules/@babel/types": {
+    "node_modules/@babel/types": {
       "version": "8.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.3.tgz",
       "integrity": "sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==",
@@ -391,67 +402,6 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@babel/generator/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.0"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@balena/dockerignore": {
@@ -468,9 +418,9 @@
       "license": "MIT"
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260420.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260420.1.tgz",
-      "integrity": "sha512-Y6HtAY+pS5INiD9HyO1JvvujZO24mD3eqRwPZlLXBkcT+wW8bTOve/8mVKErEzEtZ5LkuT3tJqG9py8TxQEBgw==",
+      "version": "1.20260421.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260421.1.tgz",
+      "integrity": "sha512-DLU5ZTZ1VHeZZnj0PuVJEMHKGisfLe2XShyImP5P/PPj/m/t7CLEJmPiI7FMxvT7ynArkckJl7m+Z5x7u4Kkdw==",
       "cpu": [
         "x64"
       ],
@@ -485,9 +435,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260420.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260420.1.tgz",
-      "integrity": "sha512-7aiRtZTc5S4aKcL6uIx+B3tCzb/bULjQmE67/03k0HtaDNzP20GnYmYpFCqleFqsdmIb4Tx8PkKPmsXI3AJLvQ==",
+      "version": "1.20260421.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260421.1.tgz",
+      "integrity": "sha512-Trotq3xRAkIcpC505WoxM8+kIH4JIvOJCNuRatyHcz9uF5S+ukgiVUFUlM+GIjw1uCM/Bda2St+vSniX1RZdpw==",
       "cpu": [
         "arm64"
       ],
@@ -502,9 +452,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260420.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260420.1.tgz",
-      "integrity": "sha512-J/DW149FPmug1wSM32zBF7My14xg+inIYwzS4bSAxyXR6tBiTxbhgFWQQz99nt08ZMstdKHRD6f6C/KQaleQcA==",
+      "version": "1.20260421.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260421.1.tgz",
+      "integrity": "sha512-938QjUv0z+QqK6BAvgwX/lCIZ2b224ZXoXtGTbhyNVMhB+mt4Dj24cj9qca4ekNXjVM7uTKp1yOHZO97fVSacw==",
       "cpu": [
         "x64"
       ],
@@ -519,9 +469,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260420.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260420.1.tgz",
-      "integrity": "sha512-a5I147McRM/L4YHu9EwOsoAyIExZndPRQoLx/33dbw/yUEnO825gvn5QZkCGXBVL2JwsPAyowB0Xliqrj+71Sw==",
+      "version": "1.20260421.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260421.1.tgz",
+      "integrity": "sha512-YI4+mLfwnJcKJ+iPyxzx+tp2Jy4o29BxBPSQGZxl/AZyvZ9eTKsmNZmtjEiT4i3O/M0tdO/B/d9ESDHbRCs2rQ==",
       "cpu": [
         "arm64"
       ],
@@ -536,9 +486,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260420.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260420.1.tgz",
-      "integrity": "sha512-ZrHqlHbJNU8P24EAOBaZ6B44G9P+po2z0DBwbAr8965aWR+vohy3cfmgE9uzNPAQfKNmvq7fmc4VwsRpERkg0w==",
+      "version": "1.20260421.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260421.1.tgz",
+      "integrity": "sha512-q1SFgwlNH9lFmw74vh7EJbJtduo92Nx51mNOfd3/u6pux6AldcwRviYzKEEv3FEbtv6OBB7J8D5f8vtZj7Z6Sg==",
       "cpu": [
         "x64"
       ],
@@ -553,9 +503,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260421.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260421.1.tgz",
-      "integrity": "sha512-PJjuz1zwwa+/WP9dkf5ORMQWL7u2m1d8aFUhG3dx6ohweGd+zMppT1JG0zhc00LUg8gFXVaiZzZ5w/0Cp4HI+g==",
+      "version": "4.20260423.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260423.1.tgz",
+      "integrity": "sha512-SHIc0NeJMtn0sW043eWtMxYFbJ9VPSLkcx+FEqCk0uZLD3HrWT+5xWhm6EYiOYDg0vnrlXNHcu2ly/01zDh3bw==",
       "devOptional": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -634,9 +584,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2536,9 +2486,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.126.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
-      "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2698,9 +2648,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
       "cpu": [
         "arm64"
       ],
@@ -2715,9 +2665,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
       "cpu": [
         "arm64"
       ],
@@ -2732,9 +2682,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
       "cpu": [
         "x64"
       ],
@@ -2749,9 +2699,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
       "cpu": [
         "x64"
       ],
@@ -2766,9 +2716,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
-      "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
       "cpu": [
         "arm"
       ],
@@ -2783,9 +2733,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
       "cpu": [
         "arm64"
       ],
@@ -2800,9 +2750,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
-      "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
       "cpu": [
         "arm64"
       ],
@@ -2817,9 +2767,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
       "cpu": [
         "ppc64"
       ],
@@ -2834,9 +2784,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
       "cpu": [
         "s390x"
       ],
@@ -2851,9 +2801,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
       "cpu": [
         "x64"
       ],
@@ -2868,9 +2818,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
-      "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
       "cpu": [
         "x64"
       ],
@@ -2885,9 +2835,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
       "cpu": [
         "arm64"
       ],
@@ -2902,9 +2852,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
-      "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
       "cpu": [
         "wasm32"
       ],
@@ -2912,29 +2862,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
         "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
-      "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
       "cpu": [
         "arm64"
       ],
@@ -2949,9 +2888,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
-      "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
       "cpu": [
         "x64"
       ],
@@ -2966,9 +2905,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
-      "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4239,17 +4178,67 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.32.tgz",
-      "integrity": "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
+      "integrity": "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@vue/shared": "3.5.32",
+        "@vue/shared": "3.5.33",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@vue/compiler-core/node_modules/estree-walker": {
@@ -4260,32 +4249,82 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz",
-      "integrity": "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
+      "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-core": "3.5.33",
+        "@vue/shared": "3.5.33"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.32.tgz",
-      "integrity": "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
+      "integrity": "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@vue/compiler-core": "3.5.32",
-        "@vue/compiler-dom": "3.5.32",
-        "@vue/compiler-ssr": "3.5.32",
-        "@vue/shared": "3.5.32",
+        "@vue/compiler-core": "3.5.33",
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/compiler-ssr": "3.5.33",
+        "@vue/shared": "3.5.33",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.8",
+        "postcss": "^8.5.10",
         "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
@@ -4296,14 +4335,14 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.32.tgz",
-      "integrity": "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
+      "integrity": "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/shared": "3.5.33"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -4332,6 +4371,23 @@
         "superjson": "^2.2.2"
       }
     },
+    "node_modules/@vue/devtools-kit/node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vue/devtools-kit/node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vue/devtools-shared": {
       "version": "7.7.9",
       "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
@@ -4343,57 +4399,57 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.32.tgz",
-      "integrity": "sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.33.tgz",
+      "integrity": "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.32"
+        "@vue/shared": "3.5.33"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.32.tgz",
-      "integrity": "sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.33.tgz",
+      "integrity": "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/reactivity": "3.5.33",
+        "@vue/shared": "3.5.33"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.32.tgz",
-      "integrity": "sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.33.tgz",
+      "integrity": "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.32",
-        "@vue/runtime-core": "3.5.32",
-        "@vue/shared": "3.5.32",
+        "@vue/reactivity": "3.5.33",
+        "@vue/runtime-core": "3.5.33",
+        "@vue/shared": "3.5.33",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.32.tgz",
-      "integrity": "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
+      "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-ssr": "3.5.33",
+        "@vue/shared": "3.5.33"
       },
       "peerDependencies": {
-        "vue": "3.5.32"
+        "vue": "3.5.33"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.32.tgz",
-      "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.33.tgz",
+      "integrity": "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4642,26 +4698,26 @@
       "peer": true
     },
     "node_modules/algoliasearch": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.50.2.tgz",
-      "integrity": "sha512-Tfp26yoNWurUjfgK4GOrVJQhSNXu9tJtHfFFNosgT2YClG+vPyUjX/gbC8rG39qLncnZg8Fj34iarQWpMkqefw==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.51.0.tgz",
+      "integrity": "sha512-u3XS8HaTzt5YN90KPsOXMRjYJUMVD1dtr6yi4NXQluMbZ5IjQNBu1MEabdAxFhYtEuexqomPMSmRIhQJUd3QSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/abtesting": "1.16.2",
-        "@algolia/client-abtesting": "5.50.2",
-        "@algolia/client-analytics": "5.50.2",
-        "@algolia/client-common": "5.50.2",
-        "@algolia/client-insights": "5.50.2",
-        "@algolia/client-personalization": "5.50.2",
-        "@algolia/client-query-suggestions": "5.50.2",
-        "@algolia/client-search": "5.50.2",
-        "@algolia/ingestion": "1.50.2",
-        "@algolia/monitoring": "1.50.2",
-        "@algolia/recommend": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/abtesting": "1.17.0",
+        "@algolia/client-abtesting": "5.51.0",
+        "@algolia/client-analytics": "5.51.0",
+        "@algolia/client-common": "5.51.0",
+        "@algolia/client-insights": "5.51.0",
+        "@algolia/client-personalization": "5.51.0",
+        "@algolia/client-query-suggestions": "5.51.0",
+        "@algolia/client-search": "5.51.0",
+        "@algolia/ingestion": "1.51.0",
+        "@algolia/monitoring": "1.51.0",
+        "@algolia/recommend": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -4789,56 +4845,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
-      }
-    },
-    "node_modules/ast-kit/node_modules/@babel/helper-string-parser": {
-      "version": "8.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.3.tgz",
-      "integrity": "sha512-AmwWFx1m8G/a5cXkxLxTiWl+YEoWuoFLUCwqMlNuWO1tqAYITQAbCRPUkyBHv1VOFgfjVOqEj6L3u15J5ZCzTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/ast-kit/node_modules/@babel/helper-validator-identifier": {
-      "version": "8.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.3.tgz",
-      "integrity": "sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/ast-kit/node_modules/@babel/parser": {
-      "version": "8.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.3.tgz",
-      "integrity": "sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^8.0.0-rc.3"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/ast-kit/node_modules/@babel/types": {
-      "version": "8.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.3.tgz",
-      "integrity": "sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^8.0.0-rc.3",
-        "@babel/helper-validator-identifier": "^8.0.0-rc.3"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/async": {
@@ -4971,9 +4977,9 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.8.7",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
-      "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.0.tgz",
+      "integrity": "sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==",
       "license": "Apache-2.0",
       "engines": {
         "bare": ">=1.14.0"
@@ -5063,9 +5069,9 @@
       }
     },
     "node_modules/birpc": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
-      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-4.0.0.tgz",
+      "integrity": "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -5267,6 +5273,16 @@
       "peer": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
+      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -7326,9 +7342,9 @@
       }
     },
     "node_modules/hookable": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
-      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+      "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -8285,16 +8301,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260420.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260420.0.tgz",
-      "integrity": "sha512-w8s3eh2W7EEsFh2uGdddZLkbTwiPI8MCSMXKtuLSA9btW8xmQsVVSkrFuLXFyTKcX0QkstS5dhcWjQPQRJ2WKg==",
+      "version": "4.20260421.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260421.0.tgz",
+      "integrity": "sha512-7ZkNQ7brgQ2hh5ha9iQCDUjxBkLvuiG2VdDns9esRL8O8lXg+MoP6E0dO1rtp+ZY2I+vV1tPWr6td5IojkewLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "^0.34.5",
         "undici": "7.24.8",
-        "workerd": "1.20260420.1",
+        "workerd": "1.20260421.1",
         "ws": "8.18.0",
         "youch": "4.1.0-beta.10"
       },
@@ -9775,14 +9791,14 @@
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.126.0",
-        "@rolldown/pluginutils": "1.0.0-rc.16"
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -9791,21 +9807,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
     "node_modules/rolldown-plugin-dts": {
@@ -9852,66 +9868,6 @@
         "vue-tsc": {
           "optional": true
         }
-      }
-    },
-    "node_modules/rolldown-plugin-dts/node_modules/@babel/helper-string-parser": {
-      "version": "8.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.3.tgz",
-      "integrity": "sha512-AmwWFx1m8G/a5cXkxLxTiWl+YEoWuoFLUCwqMlNuWO1tqAYITQAbCRPUkyBHv1VOFgfjVOqEj6L3u15J5ZCzTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/rolldown-plugin-dts/node_modules/@babel/helper-validator-identifier": {
-      "version": "8.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.3.tgz",
-      "integrity": "sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/rolldown-plugin-dts/node_modules/@babel/parser": {
-      "version": "8.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.3.tgz",
-      "integrity": "sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^8.0.0-rc.3"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/rolldown-plugin-dts/node_modules/@babel/types": {
-      "version": "8.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.3.tgz",
-      "integrity": "sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^8.0.0-rc.3",
-        "@babel/helper-validator-identifier": "^8.0.0-rc.3"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/rolldown-plugin-dts/node_modules/birpc": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/birpc/-/birpc-4.0.0.tgz",
-      "integrity": "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/rollup": {
@@ -10903,6 +10859,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -11075,9 +11041,9 @@
       }
     },
     "node_modules/tsdown": {
-      "version": "0.21.9",
-      "resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.21.9.tgz",
-      "integrity": "sha512-tZPv2zMaMnjj9H9h0SDqpSXa9YWVZWHlG46DnSgNTFX6aq001MSI8kuBzJumr/u099nWj+1v5S7rhbnHk5jCHA==",
+      "version": "0.21.10",
+      "resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.21.10.tgz",
+      "integrity": "sha512-3wk73yBhZe/wX7REqSdivNQ84TDs1mJ+IlnzrrEREP70xlJ/AEIzqaI04l/TzMKVIdkTdC3CPaADn2Lk/0SkdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11089,14 +11055,14 @@
         "import-without-cache": "^0.3.3",
         "obug": "^2.1.1",
         "picomatch": "^4.0.4",
-        "rolldown": "1.0.0-rc.16",
+        "rolldown": "1.0.0-rc.17",
         "rolldown-plugin-dts": "^0.23.2",
         "semver": "^7.7.4",
         "tinyexec": "^1.1.1",
         "tinyglobby": "^0.2.16",
         "tree-kill": "^1.2.2",
         "unconfig-core": "^7.5.0",
-        "unrun": "^0.2.36"
+        "unrun": "^0.2.37"
       },
       "bin": {
         "tsdown": "dist/run.mjs"
@@ -11109,8 +11075,8 @@
       },
       "peerDependencies": {
         "@arethetypeswrong/core": "^0.18.1",
-        "@tsdown/css": "0.21.9",
-        "@tsdown/exe": "0.21.9",
+        "@tsdown/css": "0.21.10",
+        "@tsdown/exe": "0.21.10",
         "@vitejs/devtools": "*",
         "publint": "^0.3.0",
         "typescript": "^5.0.0 || ^6.0.0",
@@ -11138,33 +11104,6 @@
         "unplugin-unused": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tsdown/node_modules/cac": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
-      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "node_modules/tsdown/node_modules/hookable": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
-      "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tsdown/node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/tslib": {
@@ -11383,13 +11322,13 @@
       }
     },
     "node_modules/unrun": {
-      "version": "0.2.36",
-      "resolved": "https://registry.npmjs.org/unrun/-/unrun-0.2.36.tgz",
-      "integrity": "sha512-ICAGv44LHSKjCdI4B4rk99lJLHXBweutO4MUwu3cavMlYtXID0Tn5e1Kwe/Uj6BSAuHHXfi1JheFVCYhcXHfAg==",
+      "version": "0.2.37",
+      "resolved": "https://registry.npmjs.org/unrun/-/unrun-0.2.37.tgz",
+      "integrity": "sha512-AA7vDuYsgeSYVzJMm16UKA+aXFKhy7nFqW9z5l7q44K4ppFWZAMqYS58ePRZbugMLPH0fwwMzD5A8nP0avxwZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "rolldown": "1.0.0-rc.16"
+        "rolldown": "1.0.0-rc.17"
       },
       "bin": {
         "unrun": "dist/cli.mjs"
@@ -11496,16 +11435,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
-      "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.16",
+        "rolldown": "1.0.0-rc.17",
         "tinyglobby": "^0.2.16"
       },
       "bin": {
@@ -12239,28 +12178,18 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/vue": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
-      "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
+      "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.32",
-        "@vue/compiler-sfc": "3.5.32",
-        "@vue/runtime-dom": "3.5.32",
-        "@vue/server-renderer": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/compiler-sfc": "3.5.33",
+        "@vue/runtime-dom": "3.5.33",
+        "@vue/server-renderer": "3.5.33",
+        "@vue/shared": "3.5.33"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -12336,9 +12265,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260420.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260420.1.tgz",
-      "integrity": "sha512-1AOJgng169u4fiFrEd5WjrAGpdwd3A4ZJtP8PMvf+RF9NUKy+mdwrKdz4qPZ6Tt/Bya99vsLn6UX33fjAEVoaA==",
+      "version": "1.20260421.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260421.1.tgz",
+      "integrity": "sha512-zTYD+xFR4d7TUCxsyl7FTPth9a8CDgk8pM7xUWbJxo0SGUx+2e5C7Q5LrramBZwmuAErtzXmOjlQ15PtkPAhZA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -12349,11 +12278,11 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260420.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260420.1",
-        "@cloudflare/workerd-linux-64": "1.20260420.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260420.1",
-        "@cloudflare/workerd-windows-64": "1.20260420.1"
+        "@cloudflare/workerd-darwin-64": "1.20260421.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260421.1",
+        "@cloudflare/workerd-linux-64": "1.20260421.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260421.1",
+        "@cloudflare/workerd-windows-64": "1.20260421.1"
       }
     },
     "node_modules/wrap-ansi": {

--- a/src/packages/almanac/src/index.ts
+++ b/src/packages/almanac/src/index.ts
@@ -1,6 +1,6 @@
 export * from './attributes';
 export * from './configuration';
 export * from './meters';
-export * from './scopes/scope';
+export * from './scopes';
 export * from './testing';
 export * from './tracers';

--- a/src/packages/emmett-tests/tsconfig.json
+++ b/src/packages/emmett-tests/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "./dist" /* Redirect output structure to the directory. */,
     "rootDir": "./src",
     "paths": {
-      "@event-driven-io/almanac": ["../almanac/src"],
+      "@event-driven-io/almanac": ["../packages/almanac"],
       "@event-driven-io/emmett": ["../packages/emmett"],
       "@event-driven-io/emmett-esdb": ["../packages/emmett-esdb"],
       "@event-driven-io/emmett-postgresql": ["../packages/emmett-postgresql"],

--- a/src/packages/emmett/src/observability/attributes.ts
+++ b/src/packages/emmett/src/observability/attributes.ts
@@ -1,0 +1,95 @@
+export const EmmettAttributes = {
+  scope: {
+    type: 'emmett.scope.type',
+  },
+  command: {
+    type: 'emmett.command.type',
+    status: 'emmett.command.status',
+    eventCount: 'emmett.command.event_count',
+    eventTypes: 'emmett.command.event_types',
+  },
+  stream: {
+    name: 'emmett.stream.name',
+    versionBefore: 'emmett.stream.version.before',
+    versionAfter: 'emmett.stream.version.after',
+  },
+  eventStore: {
+    operation: 'emmett.eventstore.operation',
+    read: {
+      eventCount: 'emmett.eventstore.read.event_count',
+      eventTypes: 'emmett.eventstore.read.event_types',
+      status: 'emmett.eventstore.read.status',
+    },
+    append: {
+      batchSize: 'emmett.eventstore.append.batch_size',
+      status: 'emmett.eventstore.append.status',
+    },
+  },
+  event: {
+    type: 'emmett.event.type',
+  },
+  processor: {
+    id: 'emmett.processor.id',
+    type: 'emmett.processor.type',
+    status: 'emmett.processor.status',
+    batchSize: 'emmett.processor.batch_size',
+    eventTypes: 'emmett.processor.event_types',
+    checkpointBefore: 'emmett.processor.checkpoint.before',
+    checkpointAfter: 'emmett.processor.checkpoint.after',
+    lagEvents: 'emmett.processor.lag_events',
+  },
+  workflow: {
+    id: 'emmett.workflow.id',
+    type: 'emmett.workflow.type',
+    inputType: 'emmett.workflow.input.type',
+    outputs: 'emmett.workflow.outputs',
+    outputsCount: 'emmett.workflow.outputs.count',
+    streamPosition: 'emmett.workflow.stream_position',
+    stateRebuildEventCount: 'emmett.workflow.state_rebuild.event_count',
+  },
+  consumer: {
+    batchSize: 'emmett.consumer.batch_size',
+    processorCount: 'emmett.consumer.processor_count',
+    delivery: {
+      processorId: 'emmett.consumer.delivery.processor_id',
+    },
+  },
+} as const;
+
+export const EmmettMetrics = {
+  command: {
+    handlingDuration: 'emmett.command.handling.duration',
+  },
+  event: {
+    appendingCount: 'emmett.event.appending.count',
+    readingCount: 'emmett.event.reading.count',
+  },
+  stream: {
+    readingDuration: 'emmett.stream.reading.duration',
+    readingSize: 'emmett.stream.reading.size',
+    appendingDuration: 'emmett.stream.appending.duration',
+    appendingSize: 'emmett.stream.appending.size',
+  },
+  processor: {
+    processingDuration: 'emmett.processor.processing.duration',
+    lagEvents: 'emmett.processor.lag_events',
+  },
+  workflow: {
+    processingDuration: 'emmett.workflow.processing.duration',
+  },
+  consumer: {
+    pollDuration: 'emmett.consumer.poll.duration',
+    deliveryDuration: 'emmett.consumer.delivery.duration',
+  },
+} as const;
+
+export const ScopeTypes = {
+  command: 'command',
+  processor: 'processor',
+  reactor: 'reactor',
+  projector: 'projector',
+  workflow: 'workflow',
+  consumer: 'consumer',
+} as const;
+
+export const MessagingSystemName = 'emmett' as const;

--- a/src/packages/emmett/src/observability/attributes.unit.spec.ts
+++ b/src/packages/emmett/src/observability/attributes.unit.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { MessagingAttributes } from '@event-driven-io/almanac';
+import { EmmettAttributes, EmmettMetrics } from './attributes';
+
+const collectLeafValues = (obj: Record<string, unknown>): string[] => {
+  const values: string[] = [];
+  for (const value of Object.values(obj)) {
+    if (typeof value === 'string') {
+      values.push(value);
+    } else if (typeof value === 'object' && value !== null) {
+      values.push(...collectLeafValues(value as Record<string, unknown>));
+    }
+  }
+  return values;
+};
+
+describe('EmmettAttributes', () => {
+  it('all leaf values are prefixed with emmett.', () => {
+    const values = collectLeafValues(EmmettAttributes);
+    expect(values.length).toBeGreaterThan(0);
+    for (const value of values) {
+      expect(value).toMatch(/^emmett\./);
+    }
+  });
+});
+
+describe('MessagingAttributes', () => {
+  it('all values are prefixed with messaging.', () => {
+    const values = collectLeafValues(MessagingAttributes);
+    expect(values.length).toBeGreaterThan(0);
+    for (const value of values) {
+      expect(value).toMatch(/^messaging\./);
+    }
+  });
+});
+
+describe('EmmettMetrics', () => {
+  it('all leaf values are prefixed with emmett.', () => {
+    const values = collectLeafValues(EmmettMetrics);
+    expect(values.length).toBeGreaterThan(0);
+    for (const value of values) {
+      expect(value).toMatch(/^emmett\./);
+    }
+  });
+});
+
+describe('no duplicate values', () => {
+  it('within EmmettAttributes', () => {
+    const values = collectLeafValues(EmmettAttributes);
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  it('within EmmettMetrics', () => {
+    const values = collectLeafValues(EmmettMetrics);
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  it('within MessagingAttributes', () => {
+    const values = collectLeafValues(MessagingAttributes);
+    expect(new Set(values).size).toBe(values.length);
+  });
+});

--- a/src/packages/emmett/src/observability/collectors/commandHandlerCollector.ts
+++ b/src/packages/emmett/src/observability/collectors/commandHandlerCollector.ts
@@ -1,0 +1,116 @@
+import {
+  MessagingAttributes,
+  ObservabilityScope,
+  type ObservabilityScope as ObservabilityScopeType,
+} from '@event-driven-io/almanac';
+import type { Event } from '../../typing';
+import {
+  EmmettAttributes,
+  EmmettMetrics,
+  MessagingSystemName,
+  ScopeTypes,
+} from '../attributes';
+import type { ResolvedCommandObservability } from '../options';
+
+export type CommandHandlerCollectorContext = {
+  streamName: string;
+};
+
+export const commandHandlerCollector = (
+  observability: ResolvedCommandObservability,
+) => {
+  const { startScope } = ObservabilityScope({
+    ...observability,
+    attributePrefix: 'emmett',
+  });
+  const A = EmmettAttributes;
+  const M = MessagingAttributes;
+  const commandHandlingDuration = observability.meter.histogram(
+    EmmettMetrics.command.handlingDuration,
+  );
+  const eventAppendingCount = observability.meter.counter(
+    EmmettMetrics.event.appendingCount,
+  );
+
+  return {
+    startScope: <T>(
+      context: CommandHandlerCollectorContext,
+      fn: (scope: ObservabilityScopeType) => Promise<T>,
+    ): Promise<T> => {
+      const start = Date.now();
+      return startScope(
+        'command.handle',
+        async (scope) => {
+          scope.setAttributes({
+            [A.scope.type]: ScopeTypes.command,
+            [M.system]: MessagingSystemName,
+            [M.destinationName]: context.streamName,
+          });
+
+          // eslint-disable-next-line no-useless-assignment
+          let status = 'success';
+          try {
+            const result = await fn(scope);
+            status = 'success';
+            scope.setAttributes({
+              [A.command.status]: 'success',
+              error: false,
+            });
+            return result;
+          } catch (err) {
+            status = 'failure';
+            scope.setAttributes({
+              [A.command.status]: 'failure',
+              error: true,
+              'exception.message':
+                err instanceof Error ? err.message : String(err),
+              'exception.type':
+                err instanceof Error ? err.constructor.name : 'unknown',
+            });
+            scope.recordException(
+              err instanceof Error ? err : new Error(String(err)),
+            );
+            throw err;
+          } finally {
+            commandHandlingDuration.record(Date.now() - start, {
+              [A.command.status]: status,
+            });
+          }
+        },
+        {
+          attributes: {
+            [A.scope.type]: ScopeTypes.command,
+            [A.stream.name]: context.streamName,
+          },
+        },
+      );
+    },
+
+    recordEvents: (
+      scope: ObservabilityScopeType,
+      events: Event[],
+      status: string,
+    ): void => {
+      scope.setAttributes({
+        [A.command.eventCount]: events.length,
+        [A.command.eventTypes]: events.map((e) => e.type),
+        [M.batchMessageCount]: events.length,
+        [A.command.status]: status,
+      });
+      for (const event of events) {
+        eventAppendingCount.add(1, { [A.event.type]: event.type });
+      }
+    },
+
+    recordVersions: (
+      scope: ObservabilityScopeType,
+      before: bigint,
+      after: bigint,
+    ): void => {
+      scope.setAttributes({
+        [A.stream.versionBefore]: Number(before),
+        [A.stream.versionAfter]: Number(after),
+      });
+    },
+  };
+};

--- a/src/packages/emmett/src/observability/collectors/commandHandlerCollector.unit.spec.ts
+++ b/src/packages/emmett/src/observability/collectors/commandHandlerCollector.unit.spec.ts
@@ -1,0 +1,216 @@
+import {
+  collectingMeter,
+  collectingTracer,
+  ObservabilitySpec,
+} from '@event-driven-io/almanac';
+import { describe, expect, it } from 'vitest';
+import {
+  EmmettAttributes,
+  EmmettMetrics,
+  MessagingSystemName,
+} from '../attributes';
+import { resolveCommandObservability } from '../options';
+import { commandHandlerCollector } from './commandHandlerCollector';
+
+const A = EmmettAttributes;
+const M = {
+  system: 'messaging.system',
+  destinationName: 'messaging.destination.name',
+  batchMessageCount: 'messaging.batch.message_count',
+};
+
+const given = ObservabilitySpec.for();
+
+describe('commandHandlerCollector', () => {
+  it('creates a span named command.handle with emmett.scope.type=command and emmett.scope.main=true', async () => {
+    await given({})
+      .when((config) =>
+        commandHandlerCollector(config).startScope(
+          { streamName: 'test-stream' },
+          () => Promise.resolve(),
+        ),
+      )
+      .then(({ spans }) =>
+        spans.haveSpanNamed('command.handle').hasAttributes({
+          [A.scope.type]: 'command',
+          'emmett.scope.main': true,
+        }),
+      );
+  });
+
+  it('sets emmett.stream.name via creation-time attributes', async () => {
+    await given({})
+      .when((config) =>
+        commandHandlerCollector(config).startScope(
+          { streamName: 'orders-123' },
+          () => Promise.resolve(),
+        ),
+      )
+      .then(({ spans }) =>
+        spans
+          .haveSpanNamed('command.handle')
+          .hasAttribute(A.stream.name, 'orders-123'),
+      );
+  });
+
+  it('sets messaging.system and messaging.destination.name', async () => {
+    await given({})
+      .when((config) =>
+        commandHandlerCollector(config).startScope(
+          { streamName: 'orders-123' },
+          () => Promise.resolve(),
+        ),
+      )
+      .then(({ spans }) =>
+        spans.haveSpanNamed('command.handle').hasAttributes({
+          [M.system]: MessagingSystemName,
+          [M.destinationName]: 'orders-123',
+        }),
+      );
+  });
+
+  it('sets emmett.command.status to success on success', async () => {
+    await given({})
+      .when((config) =>
+        commandHandlerCollector(config).startScope({ streamName: 'test' }, () =>
+          Promise.resolve(),
+        ),
+      )
+      .then(({ spans }) =>
+        spans.haveSpanNamed('command.handle').hasAttributes({
+          [A.command.status]: 'success',
+          error: false,
+        }),
+      );
+  });
+
+  it('recordEvents sets event_count, event_types, batch_message_count and increments counter per event', async () => {
+    const events = [
+      { type: 'OrderPlaced', data: {}, kind: 'Event' as const },
+      { type: 'ItemAdded', data: {}, kind: 'Event' as const },
+    ];
+    await given({})
+      .when((config) =>
+        commandHandlerCollector(config).startScope(
+          { streamName: 'test' },
+          (scope) => {
+            commandHandlerCollector(config).recordEvents(
+              scope,
+              events,
+              'success',
+            );
+            return Promise.resolve();
+          },
+        ),
+      )
+      .then(({ spans }) =>
+        spans.haveSpanNamed('command.handle').hasAttributes({
+          [A.command.eventCount]: 2,
+          [A.command.eventTypes]: ['OrderPlaced', 'ItemAdded'],
+          [M.batchMessageCount]: 2,
+        }),
+      );
+  });
+
+  it('recordVersions sets stream version before and after', async () => {
+    await given({})
+      .when((config) =>
+        commandHandlerCollector(config).startScope(
+          { streamName: 'test' },
+          (scope) => {
+            commandHandlerCollector(config).recordVersions(scope, 3n, 5n);
+            return Promise.resolve();
+          },
+        ),
+      )
+      .then(({ spans }) =>
+        spans.haveSpanNamed('command.handle').hasAttributes({
+          [A.stream.versionBefore]: 3,
+          [A.stream.versionAfter]: 5,
+        }),
+      );
+  });
+
+  it('scope.scope creates child scopes', async () => {
+    await given({})
+      .when((config) =>
+        commandHandlerCollector(config).startScope(
+          { streamName: 'test' },
+          async (scope) => {
+            await scope.scope('decide', () => Promise.resolve());
+          },
+        ),
+      )
+      .then(({ spans }) => spans.containSpanNamed('decide'));
+  });
+
+  it('sets emmett.command.status to failure and error attributes on error', async () => {
+    const tracer = collectingTracer();
+    const obs = {
+      tracer,
+      meter: collectingMeter(),
+      attributeTarget: 'both' as const,
+      includeMessagePayloads: false,
+    };
+    await expect(
+      commandHandlerCollector(obs).startScope({ streamName: 'test' }, () =>
+        Promise.reject(new Error('boom')),
+      ),
+    ).rejects.toThrow('boom');
+    const span = tracer.spans.find((s) => s.name === 'command.handle');
+    expect(span).toBeDefined();
+    expect(span!.attributes[A.command.status]).toBe('failure');
+    expect(span!.attributes['error']).toBe(true);
+    expect(span!.attributes['exception.message']).toBe('boom');
+    expect(span!.attributes['exception.type']).toBe('Error');
+  });
+
+  it('records emmett.command.handling.duration histogram', async () => {
+    const meter = collectingMeter();
+    const obs = {
+      tracer: collectingTracer(),
+      meter,
+      attributeTarget: 'both' as const,
+      includeMessagePayloads: false,
+    };
+    await commandHandlerCollector(obs).startScope({ streamName: 'test' }, () =>
+      Promise.resolve(),
+    );
+    const entry = meter.histograms.find(
+      (h) => h.name === EmmettMetrics.command.handlingDuration,
+    );
+    expect(entry).toBeDefined();
+    expect(entry!.value).toBeGreaterThanOrEqual(0);
+  });
+
+  it('recordEvents increments counter per event', async () => {
+    const meter = collectingMeter();
+    const obs = {
+      tracer: collectingTracer(),
+      meter,
+      attributeTarget: 'both' as const,
+      includeMessagePayloads: false,
+    };
+    const events = [
+      { type: 'OrderPlaced', data: {}, kind: 'Event' as const },
+      { type: 'ItemAdded', data: {}, kind: 'Event' as const },
+    ];
+    await commandHandlerCollector(obs).startScope(
+      { streamName: 'test' },
+      (scope) => {
+        commandHandlerCollector(obs).recordEvents(scope, events, 'success');
+        return Promise.resolve();
+      },
+    );
+    const counters = meter.counters.filter(
+      (c) => c.name === EmmettMetrics.event.appendingCount,
+    );
+    expect(counters.length).toBe(2);
+  });
+
+  it('works with noop observability', async () => {
+    const o11y = resolveCommandObservability(undefined);
+    const collector = commandHandlerCollector(o11y);
+    await collector.startScope({ streamName: 'test' }, () => Promise.resolve());
+  });
+});

--- a/src/packages/emmett/src/observability/collectors/consumerCollector.ts
+++ b/src/packages/emmett/src/observability/collectors/consumerCollector.ts
@@ -1,0 +1,99 @@
+import {
+  ObservabilityScope,
+  MessagingAttributes,
+  noopScope,
+  type ObservabilityScope as ObservabilityScopeType,
+} from '@event-driven-io/almanac';
+import {
+  EmmettAttributes,
+  EmmettMetrics,
+  MessagingSystemName,
+  ScopeTypes,
+} from '../attributes';
+import type { ResolvedConsumerObservability } from '../options';
+
+export const consumerCollector = (
+  observability: ResolvedConsumerObservability,
+) => {
+  const { startScope } = ObservabilityScope({
+    ...observability,
+    attributePrefix: 'emmett',
+  });
+  const A = EmmettAttributes;
+  const M = MessagingAttributes;
+  const pollDuration = observability.meter.histogram(
+    EmmettMetrics.consumer.pollDuration,
+  );
+  const deliveryDuration = observability.meter.histogram(
+    EmmettMetrics.consumer.deliveryDuration,
+  );
+
+  return {
+    tracePoll: <T>(
+      context: {
+        processorCount: number;
+        batchSize: number;
+        empty: boolean;
+        waitMs?: number;
+      },
+      fn: (scope: ObservabilityScopeType) => Promise<T>,
+    ): Promise<T> => {
+      const skip =
+        observability.pollTracing === 'off' ||
+        (observability.pollTracing === 'active' && context.batchSize === 0);
+
+      if (skip) return fn(noopScope);
+
+      return startScope('consumer.poll', async (scope) => {
+        scope.setAttributes({
+          [A.scope.type]: ScopeTypes.consumer,
+          [A.consumer.batchSize]: context.batchSize,
+          [A.consumer.processorCount]: context.processorCount,
+          [M.system]: MessagingSystemName,
+          [M.operationType]: 'receive',
+          ...(context.empty ? { 'emmett.consumer.poll.empty': true } : {}),
+          ...(context.waitMs != null
+            ? { 'emmett.consumer.poll.wait_ms': context.waitMs }
+            : {}),
+        });
+        return fn(scope);
+      });
+    },
+
+    recordPollMetrics: (
+      durationMs: number,
+      attrs?: Record<string, unknown>,
+    ): void => {
+      pollDuration.record(durationMs, attrs);
+    },
+
+    traceDelivery: <T>(
+      scope: ObservabilityScopeType,
+      processorId: string,
+      fn: () => Promise<T>,
+    ): Promise<T> => {
+      const start = Date.now();
+      return scope.scope(
+        `consumer.deliver.${processorId}`,
+        async (child) => {
+          try {
+            const result = await fn();
+            return result;
+          } catch (error) {
+            if (error instanceof Error) child.recordException(error);
+            throw error;
+          } finally {
+            deliveryDuration.record(Date.now() - start, {
+              [A.consumer.delivery.processorId]: processorId,
+            });
+          }
+        },
+        {
+          attributes: {
+            [A.consumer.delivery.processorId]: processorId,
+          },
+        },
+      );
+    },
+  };
+};

--- a/src/packages/emmett/src/observability/collectors/consumerCollector.unit.spec.ts
+++ b/src/packages/emmett/src/observability/collectors/consumerCollector.unit.spec.ts
@@ -1,0 +1,249 @@
+import {
+  ObservabilitySpec,
+  collectingMeter,
+  collectingTracer,
+  type CollectedHistogram,
+  type CollectedSpan,
+} from '@event-driven-io/almanac';
+import { describe, it } from 'vitest';
+import {
+  assertDefined,
+  assertEqual,
+  assertTrue,
+} from '../../testing/assertions';
+import {
+  EmmettAttributes,
+  EmmettMetrics,
+  MessagingSystemName,
+} from '../attributes';
+import { resolveConsumerObservability } from '../options';
+import { consumerCollector } from './consumerCollector';
+
+const A = EmmettAttributes;
+const M = {
+  system: 'messaging.system',
+  operationType: 'messaging.operation.type',
+};
+
+const given = ObservabilitySpec.for();
+
+describe('consumerCollector', () => {
+  it('tracePoll does not create a span when pollTracing=off', async () => {
+    await given({})
+      .when((config) =>
+        consumerCollector({ ...config, pollTracing: 'off' as const }).tracePoll(
+          { batchSize: 5, processorCount: 1, empty: false },
+          () => Promise.resolve(),
+        ),
+      )
+      .then(({ spans }) => spans.haveNoSpans());
+  });
+
+  it('tracePoll propagates fn return value when pollTracing=off', async () => {
+    const result = await consumerCollector({
+      tracer: collectingTracer(),
+      meter: collectingMeter(),
+      pollTracing: 'off',
+      attributeTarget: 'both',
+    }).tracePoll({ batchSize: 5, processorCount: 1, empty: false }, () =>
+      Promise.resolve(42),
+    );
+    assertEqual(result, 42);
+  });
+
+  it('tracePoll does not create a span for empty polls when pollTracing=active', async () => {
+    await given({})
+      .when((config) =>
+        consumerCollector({
+          ...config,
+          pollTracing: 'active' as const,
+        }).tracePoll({ batchSize: 0, processorCount: 1, empty: true }, () =>
+          Promise.resolve(),
+        ),
+      )
+      .then(({ spans }) => spans.haveNoSpans());
+  });
+
+  it('tracePoll creates a span for non-empty polls when pollTracing=active', async () => {
+    await given({})
+      .when((config) =>
+        consumerCollector({
+          ...config,
+          pollTracing: 'active' as const,
+        }).tracePoll({ batchSize: 3, processorCount: 1, empty: false }, () =>
+          Promise.resolve(),
+        ),
+      )
+      .then(({ spans }) => spans.haveSpanNamed('consumer.poll'));
+  });
+
+  it('tracePoll creates consumer.poll span with emmett.scope.type=consumer and emmett.scope.main=true', async () => {
+    await given({})
+      .when((config) =>
+        consumerCollector({
+          ...config,
+          pollTracing: 'verbose' as const,
+        }).tracePoll({ batchSize: 5, processorCount: 2, empty: false }, () =>
+          Promise.resolve(),
+        ),
+      )
+      .then(({ spans }) =>
+        spans.haveSpanNamed('consumer.poll').hasAttributes({
+          [A.scope.type]: 'consumer',
+          'emmett.scope.main': true,
+        }),
+      );
+  });
+
+  it('tracePoll sets emmett.consumer.batch_size, emmett.consumer.processor_count', async () => {
+    await given({})
+      .when((config) =>
+        consumerCollector({
+          ...config,
+          pollTracing: 'verbose' as const,
+        }).tracePoll({ batchSize: 25, processorCount: 4, empty: false }, () =>
+          Promise.resolve(),
+        ),
+      )
+      .then(({ spans }) =>
+        spans.haveSpanNamed('consumer.poll').hasAttributes({
+          [A.consumer.batchSize]: 25,
+          [A.consumer.processorCount]: 4,
+        }),
+      );
+  });
+
+  it('tracePoll sets messaging.system=emmett and messaging.operation.type=receive', async () => {
+    await given({})
+      .when((config) =>
+        consumerCollector({
+          ...config,
+          pollTracing: 'verbose' as const,
+        }).tracePoll({ batchSize: 1, processorCount: 1, empty: false }, () =>
+          Promise.resolve(),
+        ),
+      )
+      .then(({ spans }) =>
+        spans.haveSpanNamed('consumer.poll').hasAttributes({
+          [M.system]: MessagingSystemName,
+          [M.operationType]: 'receive',
+        }),
+      );
+  });
+
+  it('tracePoll sets emmett.consumer.poll.empty=true for empty polls', async () => {
+    await given({})
+      .when((config) =>
+        consumerCollector({
+          ...config,
+          pollTracing: 'verbose' as const,
+        }).tracePoll({ batchSize: 0, processorCount: 1, empty: true }, () =>
+          Promise.resolve(),
+        ),
+      )
+      .then(({ spans }) =>
+        spans
+          .haveSpanNamed('consumer.poll')
+          .hasAttribute('emmett.consumer.poll.empty', true),
+      );
+  });
+
+  it('tracePoll sets emmett.consumer.poll.wait_ms for backoff timing', async () => {
+    await given({})
+      .when((config) =>
+        consumerCollector({
+          ...config,
+          pollTracing: 'verbose' as const,
+        }).tracePoll(
+          { batchSize: 0, processorCount: 1, empty: true, waitMs: 500 },
+          () => Promise.resolve(),
+        ),
+      )
+      .then(({ spans }) =>
+        spans
+          .haveSpanNamed('consumer.poll')
+          .hasAttribute('emmett.consumer.poll.wait_ms', 500),
+      );
+  });
+
+  it('traceDelivery creates child scope per processor with emmett.consumer.delivery.processor_id', async () => {
+    await given({})
+      .when((config) => {
+        const collector = consumerCollector({
+          ...config,
+          pollTracing: 'verbose' as const,
+        });
+        return collector.tracePoll(
+          { batchSize: 3, processorCount: 1, empty: false },
+          (scope) =>
+            collector.traceDelivery(scope, 'ShoppingCartProjection', () =>
+              Promise.resolve(),
+            ),
+        );
+      })
+      .then(({ spans }) =>
+        spans
+          .haveSpanNamed('consumer.deliver.ShoppingCartProjection')
+          .hasAttribute(
+            A.consumer.delivery.processorId,
+            'ShoppingCartProjection',
+          ),
+      );
+  });
+
+  it('traceDelivery records exception on failure', async () => {
+    const tracer = collectingTracer();
+    const meter = collectingMeter();
+    const collector = consumerCollector({
+      tracer,
+      meter,
+      pollTracing: 'verbose',
+      attributeTarget: 'both',
+    });
+
+    const err = new Error('delivery failed');
+    await collector.tracePoll(
+      { batchSize: 1, processorCount: 1, empty: false },
+      async (scope) => {
+        try {
+          await collector.traceDelivery(scope, 'p1', () => Promise.reject(err));
+        } catch {
+          // expected
+        }
+      },
+    );
+
+    const deliverySpan: CollectedSpan | undefined = tracer.spans.find(
+      (s) => s.name === 'consumer.deliver.p1',
+    );
+    assertDefined(deliverySpan);
+    assertTrue(deliverySpan.exceptions.includes(err));
+  });
+
+  it('recordPollMetrics records emmett.consumer.poll.duration histogram regardless of pollTracing', () => {
+    const meter = collectingMeter();
+    const collector = consumerCollector({
+      tracer: collectingTracer(),
+      meter,
+      pollTracing: 'off',
+      attributeTarget: 'both',
+    });
+
+    collector.recordPollMetrics(123);
+
+    const h: CollectedHistogram | undefined = meter.histograms.find(
+      (h) => h.name === EmmettMetrics.consumer.pollDuration,
+    );
+    assertDefined(h);
+    assertEqual(h.value, 123);
+  });
+
+  it('works with noop observability', async () => {
+    const o11y = resolveConsumerObservability(undefined);
+    const collector = consumerCollector(o11y);
+    await collector.tracePoll(
+      { batchSize: 0, processorCount: 0, empty: true },
+      () => Promise.resolve(),
+    );
+  });
+});

--- a/src/packages/emmett/src/observability/collectors/eventStoreCollector.ts
+++ b/src/packages/emmett/src/observability/collectors/eventStoreCollector.ts
@@ -1,0 +1,138 @@
+import { MessagingAttributes } from '@event-driven-io/almanac';
+import type { AnyReadEventMetadata, Event, ReadEvent } from '../../typing';
+import type { AppendToStreamResult, ReadStreamResult } from '../../eventStore';
+import {
+  EmmettAttributes,
+  EmmettMetrics,
+  MessagingSystemName,
+} from '../attributes';
+import type { ResolvedEventStoreObservability } from '../options';
+
+export const eventStoreCollector = (
+  observability: ResolvedEventStoreObservability,
+) => {
+  const A = EmmettAttributes;
+  const M = MessagingAttributes;
+  const streamReadingDuration = observability.meter.histogram(
+    EmmettMetrics.stream.readingDuration,
+  );
+  const streamReadingSize = observability.meter.histogram(
+    EmmettMetrics.stream.readingSize,
+  );
+  const eventReadingCount = observability.meter.counter(
+    EmmettMetrics.event.readingCount,
+  );
+  const streamAppendingDuration = observability.meter.histogram(
+    EmmettMetrics.stream.appendingDuration,
+  );
+  const streamAppendingSize = observability.meter.histogram(
+    EmmettMetrics.stream.appendingSize,
+  );
+  const eventAppendingCount = observability.meter.counter(
+    EmmettMetrics.event.appendingCount,
+  );
+
+  return {
+    instrumentRead: <
+      EventType extends Event,
+      ReadEventMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
+    >(
+      streamName: string,
+      fn: () => Promise<ReadStreamResult<EventType, ReadEventMetadataType>>,
+    ): Promise<ReadStreamResult<EventType, ReadEventMetadataType>> => {
+      const start = Date.now();
+      return observability.tracer.startSpan(
+        'eventStore.readStream',
+        async (span) => {
+          span.setAttributes({
+            [A.eventStore.operation]: 'readStream',
+            [A.stream.name]: streamName,
+            [M.operationType]: 'receive',
+            [M.destinationName]: streamName,
+            [M.system]: MessagingSystemName,
+          });
+
+          let status = 'success';
+          try {
+            const result = await fn();
+            const events: ReadEvent<EventType, ReadEventMetadataType>[] =
+              result.events;
+            status = 'success';
+            span.setAttributes({
+              [A.eventStore.read.status]: status,
+              [A.eventStore.read.eventCount]: events.length,
+              [A.eventStore.read.eventTypes]: [
+                ...new Set(events.map((e) => e.type)),
+              ],
+            });
+            streamReadingSize.record(events.length, {
+              [A.eventStore.read.status]: status,
+            });
+            for (const event of events) {
+              eventReadingCount.add(1, { [A.event.type]: event.type });
+            }
+            return result;
+          } catch (err) {
+            status = 'failure';
+            span.setAttributes({ [A.eventStore.read.status]: status });
+            throw err;
+          } finally {
+            streamReadingDuration.record(Date.now() - start, {
+              [A.eventStore.read.status]: status,
+            });
+          }
+        },
+      );
+    },
+
+    instrumentAppend: <
+      Result extends AppendToStreamResult,
+      EventType extends Event = Event,
+    >(
+      streamName: string,
+      events: EventType[],
+      fn: () => Promise<Result>,
+    ): Promise<Result> => {
+      const start = Date.now();
+      return observability.tracer.startSpan(
+        'eventStore.appendToStream',
+        async (span) => {
+          span.setAttributes({
+            [A.eventStore.operation]: 'appendToStream',
+            [A.stream.name]: streamName,
+            [A.eventStore.append.batchSize]: events.length,
+            [M.operationType]: 'send',
+            [M.batchMessageCount]: events.length,
+            [M.destinationName]: streamName,
+            [M.system]: MessagingSystemName,
+          });
+
+          let status = 'success';
+          try {
+            const result = await fn();
+            status = 'success';
+            span.setAttributes({
+              [A.eventStore.append.status]: status,
+              [A.stream.versionAfter]: Number(result.nextExpectedStreamVersion),
+            });
+            streamAppendingSize.record(events.length, {
+              [A.eventStore.append.status]: status,
+            });
+            for (const event of events) {
+              eventAppendingCount.add(1, { [A.event.type]: event.type });
+            }
+            return result;
+          } catch (err) {
+            status = 'failure';
+            span.setAttributes({ [A.eventStore.append.status]: status });
+            throw err;
+          } finally {
+            streamAppendingDuration.record(Date.now() - start, {
+              [A.eventStore.append.status]: status,
+            });
+          }
+        },
+      );
+    },
+  };
+};

--- a/src/packages/emmett/src/observability/collectors/eventStoreCollector.ts
+++ b/src/packages/emmett/src/observability/collectors/eventStoreCollector.ts
@@ -1,6 +1,6 @@
 import { MessagingAttributes } from '@event-driven-io/almanac';
-import type { AnyReadEventMetadata, Event, ReadEvent } from '../../typing';
 import type { AppendToStreamResult, ReadStreamResult } from '../../eventStore';
+import type { AnyReadEventMetadata, Event, ReadEvent } from '../../typing';
 import {
   EmmettAttributes,
   EmmettMetrics,
@@ -57,7 +57,6 @@ export const eventStoreCollector = (
             const result = await fn();
             const events: ReadEvent<EventType, ReadEventMetadataType>[] =
               result.events;
-            status = 'success';
             span.setAttributes({
               [A.eventStore.read.status]: status,
               [A.eventStore.read.eventCount]: events.length,
@@ -110,7 +109,6 @@ export const eventStoreCollector = (
           let status = 'success';
           try {
             const result = await fn();
-            status = 'success';
             span.setAttributes({
               [A.eventStore.append.status]: status,
               [A.stream.versionAfter]: Number(result.nextExpectedStreamVersion),

--- a/src/packages/emmett/src/observability/collectors/eventStoreCollector.unit.spec.ts
+++ b/src/packages/emmett/src/observability/collectors/eventStoreCollector.unit.spec.ts
@@ -1,0 +1,221 @@
+import {
+  collectingMeter,
+  collectingTracer,
+  ObservabilitySpec,
+} from '@event-driven-io/almanac';
+import { describe, expect, it } from 'vitest';
+import type { AnyRecordedMessageMetadata } from '../../typing';
+import {
+  EmmettAttributes,
+  EmmettMetrics,
+  MessagingSystemName,
+} from '../attributes';
+import { resolveEventStoreObservability } from '../options';
+import { eventStoreCollector } from './eventStoreCollector';
+
+const A = EmmettAttributes;
+const M = {
+  system: 'messaging.system',
+  operationType: 'messaging.operation.type',
+  batchMessageCount: 'messaging.batch.message_count',
+};
+
+const makeEvents = (types: string[]) =>
+  types.map((type) => ({
+    type,
+    data: {},
+    kind: 'Event' as const,
+    metadata: {} as AnyRecordedMessageMetadata,
+  }));
+
+const given = ObservabilitySpec.for();
+
+describe('eventStoreCollector', () => {
+  it('instrumentRead creates eventStore.readStream span with operation and messaging attributes', async () => {
+    await given({})
+      .when((config) =>
+        eventStoreCollector(config).instrumentRead('orders-123', () =>
+          Promise.resolve({
+            events: makeEvents(['OrderPlaced']),
+            currentStreamVersion: 1n,
+            streamExists: true,
+          }),
+        ),
+      )
+      .then(({ spans }) =>
+        spans.haveSpanNamed('eventStore.readStream').hasAttributes({
+          [A.eventStore.operation]: 'readStream',
+          [M.operationType]: 'receive',
+          [M.system]: MessagingSystemName,
+          [A.stream.name]: 'orders-123',
+        }),
+      );
+  });
+
+  it('instrumentAppend creates eventStore.appendToStream span with attributes', async () => {
+    const events = makeEvents(['OrderPlaced']);
+    await given({})
+      .when((config) =>
+        eventStoreCollector(config).instrumentAppend('orders-123', events, () =>
+          Promise.resolve({
+            nextExpectedStreamVersion: 1n,
+            createdNewStream: true,
+          }),
+        ),
+      )
+      .then(({ spans }) =>
+        spans.haveSpanNamed('eventStore.appendToStream').hasAttributes({
+          [A.eventStore.operation]: 'appendToStream',
+          [M.operationType]: 'send',
+          [M.batchMessageCount]: 1,
+          [A.stream.name]: 'orders-123',
+        }),
+      );
+  });
+
+  it('instrumentAppend records stream.version.after', async () => {
+    const events = makeEvents(['OrderPlaced']);
+    await given({})
+      .when((config) =>
+        eventStoreCollector(config).instrumentAppend('test', events, () =>
+          Promise.resolve({
+            nextExpectedStreamVersion: 6n,
+            createdNewStream: false,
+          }),
+        ),
+      )
+      .then(({ spans }) =>
+        spans
+          .haveSpanNamed('eventStore.appendToStream')
+          .hasAttribute(A.stream.versionAfter, 6),
+      );
+  });
+
+  it('instrumentRead records stream.reading.duration histogram on success', async () => {
+    const meter = collectingMeter();
+    const obs = {
+      tracer: collectingTracer(),
+      meter,
+      attributeTarget: 'both' as const,
+    };
+    await eventStoreCollector(obs).instrumentRead('test', () =>
+      Promise.resolve({
+        events: [],
+        currentStreamVersion: 0n,
+        streamExists: false,
+      }),
+    );
+    const h = meter.histograms.find(
+      (h) => h.name === EmmettMetrics.stream.readingDuration,
+    );
+    expect(h).toBeDefined();
+    expect(h!.value).toBeGreaterThanOrEqual(0);
+    expect(
+      (h!.attributes as Record<string, unknown>)[A.eventStore.read.status],
+    ).toBe('success');
+  });
+
+  it('instrumentRead records stream.reading.duration histogram on failure', async () => {
+    const meter = collectingMeter();
+    const obs = {
+      tracer: collectingTracer(),
+      meter,
+      attributeTarget: 'both' as const,
+    };
+    await expect(
+      eventStoreCollector(obs).instrumentRead('test', () =>
+        Promise.reject(new Error('read failed')),
+      ),
+    ).rejects.toThrow('read failed');
+    const h = meter.histograms.find(
+      (h) => h.name === EmmettMetrics.stream.readingDuration,
+    );
+    expect(h).toBeDefined();
+    expect(
+      (h!.attributes as Record<string, unknown>)[A.eventStore.read.status],
+    ).toBe('failure');
+  });
+
+  it('instrumentRead records event.reading.count counter per event type', async () => {
+    const meter = collectingMeter();
+    const obs = {
+      tracer: collectingTracer(),
+      meter,
+      attributeTarget: 'both' as const,
+    };
+    await eventStoreCollector(obs).instrumentRead('test', () =>
+      Promise.resolve({
+        events: makeEvents(['OrderPlaced', 'ItemAdded', 'OrderPlaced']),
+        currentStreamVersion: 3n,
+        streamExists: true,
+      }),
+    );
+    const counters = meter.counters.filter(
+      (c) => c.name === EmmettMetrics.event.readingCount,
+    );
+    expect(counters.length).toBe(3);
+  });
+
+  it('instrumentRead records stream.reading.size histogram', async () => {
+    const meter = collectingMeter();
+    const obs = {
+      tracer: collectingTracer(),
+      meter,
+      attributeTarget: 'both' as const,
+    };
+    await eventStoreCollector(obs).instrumentRead('test', () =>
+      Promise.resolve({
+        events: makeEvents(['A', 'B']),
+        currentStreamVersion: 2n,
+        streamExists: true,
+      }),
+    );
+    const h = meter.histograms.find(
+      (h) => h.name === EmmettMetrics.stream.readingSize,
+    );
+    expect(h).toBeDefined();
+    expect(h!.value).toBe(2);
+  });
+
+  it('instrumentAppend records appending.duration, appending.size, event.appending.count', async () => {
+    const meter = collectingMeter();
+    const obs = {
+      tracer: collectingTracer(),
+      meter,
+      attributeTarget: 'both' as const,
+    };
+    const events = makeEvents(['OrderPlaced', 'ItemAdded']);
+    await eventStoreCollector(obs).instrumentAppend('test', events, () =>
+      Promise.resolve({
+        nextExpectedStreamVersion: 2n,
+        createdNewStream: true,
+      }),
+    );
+    expect(
+      meter.histograms.find(
+        (h) => h.name === EmmettMetrics.stream.appendingDuration,
+      ),
+    ).toBeDefined();
+    const sizeH = meter.histograms.find(
+      (h) => h.name === EmmettMetrics.stream.appendingSize,
+    );
+    expect(sizeH).toBeDefined();
+    expect(sizeH!.value).toBe(2);
+    const counters = meter.counters.filter(
+      (c) => c.name === EmmettMetrics.event.appendingCount,
+    );
+    expect(counters.length).toBe(2);
+  });
+
+  it('works with noop observability', async () => {
+    const o11y = resolveEventStoreObservability(undefined);
+    const collector = eventStoreCollector(o11y);
+    await collector.instrumentRead('test', () =>
+      Promise.resolve({
+        events: [],
+        currentStreamVersion: 0n,
+        streamExists: false,
+      }),
+    );
+  });
+});

--- a/src/packages/emmett/src/observability/collectors/index.ts
+++ b/src/packages/emmett/src/observability/collectors/index.ts
@@ -1,0 +1,5 @@
+export * from './commandHandlerCollector';
+export * from './eventStoreCollector';
+export * from './processorCollector';
+export * from './workflowCollector';
+export * from './consumerCollector';

--- a/src/packages/emmett/src/observability/collectors/processorCollector.ts
+++ b/src/packages/emmett/src/observability/collectors/processorCollector.ts
@@ -1,0 +1,149 @@
+import {
+  MessagingAttributes,
+  ObservabilityScope,
+  type ObservabilityScope as ObservabilityScopeType,
+  type SpanContext,
+  type SpanLink,
+} from '@event-driven-io/almanac';
+import type { ProcessorCheckpoint } from '../../processors';
+import type {
+  AnyReadEventMetadata,
+  Message,
+  RecordedMessage,
+} from '../../typing';
+import {
+  EmmettAttributes,
+  EmmettMetrics,
+  MessagingSystemName,
+  ScopeTypes,
+} from '../attributes';
+import type { ResolvedProcessorObservability } from '../options';
+
+export type ProcessorCollectorContext = {
+  processorId: string;
+  type: string;
+  checkpoint: ProcessorCheckpoint | null;
+};
+
+export const processorCollector = (
+  observability: ResolvedProcessorObservability,
+) => {
+  const { startScope } = ObservabilityScope({
+    ...observability,
+    attributePrefix: 'emmett',
+  });
+  const A = EmmettAttributes;
+  const M = MessagingAttributes;
+  const processingDuration = observability.meter.histogram(
+    EmmettMetrics.processor.processingDuration,
+  );
+  const lagEvents = observability.meter.gauge(
+    EmmettMetrics.processor.lagEvents,
+  );
+
+  return {
+    startScope: <
+      MessageType extends Message = Message,
+      MessageMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
+      T = void,
+    >(
+      context: ProcessorCollectorContext,
+      messages: RecordedMessage<MessageType, MessageMetadataType>[],
+      fn: (scope: ObservabilityScopeType) => Promise<T>,
+    ): Promise<T> => {
+      const sourceLinks: SpanLink[] = messages
+        .filter(
+          (m) =>
+            (m.metadata as Record<string, unknown>)?.traceId &&
+            (m.metadata as Record<string, unknown>)?.spanId,
+        )
+        .reduce<SpanLink[]>((acc, m) => {
+          const meta = m.metadata as Record<string, unknown>;
+          const link = {
+            traceId: meta.traceId as string,
+            spanId: meta.spanId as string,
+          };
+          return acc.some(
+            (l) => l.traceId === link.traceId && l.spanId === link.spanId,
+          )
+            ? acc
+            : [...acc, link];
+        }, []);
+
+      const start = Date.now();
+      return startScope(
+        'processor.handle',
+        async (scope) => {
+          scope.setAttributes({
+            [A.scope.type]: ScopeTypes.processor,
+            [A.processor.id]: context.processorId,
+            [A.processor.type]: context.type,
+            [A.processor.batchSize]: messages.length,
+            [A.processor.eventTypes]: [...new Set(messages.map((m) => m.type))],
+            [M.system]: MessagingSystemName,
+            [M.batchMessageCount]: messages.length,
+            ...(context.checkpoint
+              ? { [A.processor.checkpointBefore]: context.checkpoint }
+              : {}),
+          });
+
+          let status = 'success';
+          try {
+            const result = await fn(scope);
+            status = 'success';
+            return result;
+          } catch (err) {
+            status = 'failure';
+            throw err;
+          } finally {
+            processingDuration.record(Date.now() - start, {
+              [A.processor.id]: context.processorId,
+              [A.processor.type]: context.type,
+              [A.processor.status]: status,
+            });
+          }
+        },
+        { links: sourceLinks },
+      );
+    },
+
+    startMessageScope: <
+      MessageType extends Message = Message,
+      MessageMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
+      T = void,
+    >(
+      context: ProcessorCollectorContext & { archetypeType: string },
+      message: RecordedMessage<MessageType, MessageMetadataType>,
+      batchCtx: SpanContext,
+      fn: (scope: ObservabilityScopeType) => Promise<T>,
+    ): Promise<T> => {
+      const meta = message.metadata as Record<string, unknown>;
+      const parent =
+        meta?.traceId && meta?.spanId
+          ? { traceId: meta.traceId as string, spanId: meta.spanId as string }
+          : undefined;
+      const links: SpanLink[] = batchCtx.traceId ? [batchCtx] : [];
+
+      return startScope(
+        `processor.message.${message.type}`,
+        async (scope) => {
+          scope.setAttributes({
+            [A.scope.type]: context.archetypeType,
+            [A.processor.id]: context.processorId,
+            [A.processor.type]: context.type,
+            [M.operationType]: 'process',
+            ...(meta?.messageId
+              ? { [M.messageId]: meta.messageId as string }
+              : {}),
+          });
+          return fn(scope);
+        },
+        { parent, links },
+      );
+    },
+
+    recordLag: (processorId: string, lag: number): void => {
+      lagEvents.record(lag, { [A.processor.id]: processorId });
+    },
+  };
+};

--- a/src/packages/emmett/src/observability/collectors/processorCollector.ts
+++ b/src/packages/emmett/src/observability/collectors/processorCollector.ts
@@ -90,7 +90,6 @@ export const processorCollector = (
           let status = 'success';
           try {
             const result = await fn(scope);
-            status = 'success';
             return result;
           } catch (err) {
             status = 'failure';
@@ -132,9 +131,7 @@ export const processorCollector = (
             [A.processor.id]: context.processorId,
             [A.processor.type]: context.type,
             [M.operationType]: 'process',
-            ...(meta?.messageId
-              ? { [M.messageId]: meta.messageId as string }
-              : {}),
+            ...(meta?.messageId ? { [M.messageId]: meta.messageId } : {}),
           });
           return fn(scope);
         },

--- a/src/packages/emmett/src/observability/collectors/processorCollector.unit.spec.ts
+++ b/src/packages/emmett/src/observability/collectors/processorCollector.unit.spec.ts
@@ -1,0 +1,268 @@
+import {
+  collectingMeter,
+  collectingTracer,
+  ObservabilitySpec,
+} from '@event-driven-io/almanac';
+import { describe, expect, it } from 'vitest';
+import type { AnyRecordedMessageMetadata } from '../../typing';
+import {
+  EmmettAttributes,
+  EmmettMetrics,
+  MessagingSystemName,
+} from '../attributes';
+import { resolveProcessorObservability } from '../options';
+import { processorCollector } from './processorCollector';
+
+const A = EmmettAttributes;
+const M = {
+  system: 'messaging.system',
+  batchMessageCount: 'messaging.batch.message_count',
+  operationType: 'messaging.operation.type',
+  messageId: 'messaging.message.id',
+};
+
+const makeMessage = (type: string, meta: Record<string, unknown> = {}) => ({
+  type,
+  data: {},
+  kind: 'Event' as const,
+  metadata: meta as unknown as AnyRecordedMessageMetadata,
+});
+
+const given = ObservabilitySpec.for();
+
+describe('processorCollector', () => {
+  it('creates processor.handle span with emmett.scope.type=processor and emmett.scope.main=true', async () => {
+    await given({})
+      .when((config) =>
+        processorCollector(config).startScope(
+          { processorId: 'p1', type: 'reactor', checkpoint: null },
+          [],
+          () => Promise.resolve(),
+        ),
+      )
+      .then(({ spans }) =>
+        spans.haveSpanNamed('processor.handle').hasAttributes({
+          [A.scope.type]: 'processor',
+          'emmett.scope.main': true,
+        }),
+      );
+  });
+
+  it('sets emmett.processor.id, emmett.processor.type, emmett.processor.batch_size', async () => {
+    const messages = [makeMessage('OrderPlaced'), makeMessage('ItemAdded')];
+    await given({})
+      .when((config) =>
+        processorCollector(config).startScope(
+          { processorId: 'my-processor', type: 'projector', checkpoint: null },
+          messages,
+          () => Promise.resolve(),
+        ),
+      )
+      .then(({ spans }) =>
+        spans.haveSpanNamed('processor.handle').hasAttributes({
+          [A.processor.id]: 'my-processor',
+          [A.processor.type]: 'projector',
+          [A.processor.batchSize]: 2,
+        }),
+      );
+  });
+
+  it('sets messaging.system and messaging.batch.message_count', async () => {
+    const messages = [makeMessage('OrderPlaced')];
+    await given({})
+      .when((config) =>
+        processorCollector(config).startScope(
+          { processorId: 'p1', type: 'reactor', checkpoint: null },
+          messages,
+          () => Promise.resolve(),
+        ),
+      )
+      .then(({ spans }) =>
+        spans.haveSpanNamed('processor.handle').hasAttributes({
+          [M.system]: MessagingSystemName,
+          [M.batchMessageCount]: 1,
+        }),
+      );
+  });
+
+  it('sets emmett.processor.event_types, deduplicating repeated types', async () => {
+    const messages = [
+      makeMessage('OrderPlaced'),
+      makeMessage('OrderPlaced'),
+      makeMessage('ItemAdded'),
+    ];
+    await given({})
+      .when((config) =>
+        processorCollector(config).startScope(
+          { processorId: 'p1', type: 'reactor', checkpoint: null },
+          messages,
+          () => Promise.resolve(),
+        ),
+      )
+      .then(({ spans }) =>
+        spans
+          .haveSpanNamed('processor.handle')
+          .hasAttribute(A.processor.eventTypes, ['OrderPlaced', 'ItemAdded']),
+      );
+  });
+
+  it('root span carries source links from message trace context', async () => {
+    const messages = [
+      makeMessage('OrderPlaced', { traceId: 'trace-A', spanId: 'span-x' }),
+      makeMessage('ItemAdded', { traceId: 'trace-B', spanId: 'span-y' }),
+    ];
+    await given({ propagation: 'links' })
+      .when((config) =>
+        processorCollector(config).startScope(
+          { processorId: 'p1', type: 'reactor', checkpoint: null },
+          messages,
+          () => Promise.resolve(),
+        ),
+      )
+      .then(({ spans }) =>
+        spans.haveSpanNamed('processor.handle').hasCreationLinks([
+          { traceId: 'trace-A', spanId: 'span-x' },
+          { traceId: 'trace-B', spanId: 'span-y' },
+        ]),
+      );
+  });
+
+  it('deduplicates source links when messages share the same trace context', async () => {
+    const messages = [
+      makeMessage('OrderPlaced', { traceId: 'trace-1', spanId: 'span-1' }),
+      makeMessage('ItemAdded', { traceId: 'trace-1', spanId: 'span-1' }),
+      makeMessage('OrderShipped', { traceId: 'trace-2', spanId: 'span-2' }),
+    ];
+    await given({ propagation: 'links' })
+      .when((config) =>
+        processorCollector(config).startScope(
+          { processorId: 'p1', type: 'reactor', checkpoint: null },
+          messages,
+          () => Promise.resolve(),
+        ),
+      )
+      .then(({ spans }) =>
+        spans.haveSpanNamed('processor.handle').hasCreationLinks([
+          { traceId: 'trace-1', spanId: 'span-1' },
+          { traceId: 'trace-2', spanId: 'span-2' },
+        ]),
+      );
+  });
+
+  it('creates child scopes per message with messaging.operation.type=process', async () => {
+    const messages = [makeMessage('OrderPlaced'), makeMessage('ItemAdded')];
+    await given({})
+      .when((config) =>
+        processorCollector(config).startScope(
+          { processorId: 'p1', type: 'reactor', checkpoint: null },
+          messages,
+          async (scope) => {
+            for (const msg of messages) {
+              await scope.scope(
+                `processor.message.${msg.type}`,
+                () => Promise.resolve(),
+                { attributes: { [M.operationType]: 'process' } },
+              );
+            }
+          },
+        ),
+      )
+      .then(({ spans }) =>
+        spans
+          .containSpanNamed('processor.message.OrderPlaced')
+          .containSpanNamed('processor.message.ItemAdded'),
+      );
+  });
+
+  it('per-message child scopes carry messaging.operation.type and messaging.message.id', async () => {
+    const messages = [makeMessage('OrderPlaced', { messageId: 'msg-42' })];
+    await given({})
+      .when((config) =>
+        processorCollector(config).startScope(
+          { processorId: 'p1', type: 'reactor', checkpoint: null },
+          messages,
+          async (scope) => {
+            for (const msg of messages) {
+              const meta = msg.metadata as unknown as Record<string, unknown>;
+              await scope.scope(
+                `processor.message.${msg.type}`,
+                () => Promise.resolve(),
+                {
+                  attributes: {
+                    [M.operationType]: 'process',
+                    [M.messageId]: meta.messageId as string,
+                  },
+                },
+              );
+            }
+          },
+        ),
+      )
+      .then(({ spans }) =>
+        spans.haveSpanNamed('processor.message.OrderPlaced').hasAttributes({
+          [M.operationType]: 'process',
+          [M.messageId]: 'msg-42',
+        }),
+      );
+  });
+
+  it('records emmett.processor.processing.duration histogram with processor attributes', async () => {
+    const tracer = collectingTracer();
+    const meter = collectingMeter();
+    const obs = {
+      tracer,
+      meter,
+      propagation: 'links' as const,
+      attributeTarget: 'both' as const,
+      includeMessagePayloads: false,
+    };
+    const collector = processorCollector(obs);
+    await collector.startScope(
+      { processorId: 'p1', type: 'reactor', checkpoint: null },
+      [],
+      () => Promise.resolve(),
+    );
+    const h = meter.histograms.find(
+      (h) => h.name === EmmettMetrics.processor.processingDuration,
+    );
+    expect(h).toBeDefined();
+    expect(h!.value).toBeGreaterThanOrEqual(0);
+    expect((h!.attributes as Record<string, unknown>)[A.processor.id]).toBe(
+      'p1',
+    );
+    expect((h!.attributes as Record<string, unknown>)[A.processor.type]).toBe(
+      'reactor',
+    );
+  });
+
+  it('records emmett.processor.lag_events gauge via recordLag', () => {
+    const meter = collectingMeter();
+    const obs = {
+      tracer: collectingTracer(),
+      meter,
+      propagation: 'links' as const,
+      attributeTarget: 'both' as const,
+      includeMessagePayloads: false,
+    };
+    const collector = processorCollector(obs);
+    collector.recordLag('p1', 42);
+    const g = meter.gauges.find(
+      (g) => g.name === EmmettMetrics.processor.lagEvents,
+    );
+    expect(g).toBeDefined();
+    expect(g!.value).toBe(42);
+    expect((g!.attributes as Record<string, unknown>)[A.processor.id]).toBe(
+      'p1',
+    );
+  });
+
+  it('works with noop observability', async () => {
+    const o11y = resolveProcessorObservability(undefined);
+    const collector = processorCollector(o11y);
+    await collector.startScope(
+      { processorId: 'p1', type: 'reactor', checkpoint: null },
+      [],
+      () => Promise.resolve(),
+    );
+  });
+});

--- a/src/packages/emmett/src/observability/collectors/workflowCollector.ts
+++ b/src/packages/emmett/src/observability/collectors/workflowCollector.ts
@@ -1,0 +1,93 @@
+import {
+  ObservabilityScope,
+  MessagingAttributes,
+  type ObservabilityScope as ObservabilityScopeType,
+} from '@event-driven-io/almanac';
+import {
+  EmmettAttributes,
+  EmmettMetrics,
+  MessagingSystemName,
+  ScopeTypes,
+} from '../attributes';
+import type { ResolvedWorkflowObservability } from '../options';
+
+export type WorkflowCollectorContext = {
+  workflowId: string;
+  workflowType: string;
+  inputType: string;
+};
+
+export const workflowCollector = (
+  observability: ResolvedWorkflowObservability,
+) => {
+  const { startScope } = ObservabilityScope({
+    ...observability,
+    attributePrefix: 'emmett',
+  });
+  const A = EmmettAttributes;
+  const M = MessagingAttributes;
+  const processingDuration = observability.meter.histogram(
+    EmmettMetrics.workflow.processingDuration,
+  );
+
+  return {
+    startScope: <T>(
+      context: WorkflowCollectorContext,
+      fn: (scope: ObservabilityScopeType) => Promise<T>,
+    ): Promise<T> => {
+      const start = Date.now();
+      return startScope(
+        'workflow.handle',
+        async (scope) => {
+          scope.setAttributes({
+            [A.scope.type]: ScopeTypes.workflow,
+            [A.workflow.id]: context.workflowId,
+            [A.workflow.type]: context.workflowType,
+            [A.workflow.inputType]: context.inputType,
+            [M.system]: MessagingSystemName,
+          });
+
+          let status = 'success';
+          try {
+            const result = await fn(scope);
+            status = 'success';
+            return result;
+          } catch (err) {
+            status = 'failure';
+            throw err;
+          } finally {
+            processingDuration.record(Date.now() - start, {
+              [A.workflow.type]: context.workflowType,
+              status,
+            });
+          }
+        },
+        {
+          attributes: {
+            [A.scope.type]: ScopeTypes.workflow,
+            [A.workflow.type]: context.workflowType,
+          },
+        },
+      );
+    },
+
+    recordOutputs: (
+      scope: ObservabilityScopeType,
+      outputs: { type: string }[],
+    ): void => {
+      scope.setAttributes({
+        [A.workflow.outputs]: outputs.map((o) => o.type),
+        [A.workflow.outputsCount]: outputs.length,
+      });
+    },
+
+    recordStateRebuild: (
+      scope: ObservabilityScopeType,
+      eventCount: number,
+    ): void => {
+      scope.setAttributes({
+        [A.workflow.stateRebuildEventCount]: eventCount,
+      });
+    },
+  };
+};

--- a/src/packages/emmett/src/observability/collectors/workflowCollector.ts
+++ b/src/packages/emmett/src/observability/collectors/workflowCollector.ts
@@ -1,6 +1,6 @@
 import {
-  ObservabilityScope,
   MessagingAttributes,
+  ObservabilityScope,
   type ObservabilityScope as ObservabilityScopeType,
 } from '@event-driven-io/almanac';
 import {
@@ -50,7 +50,6 @@ export const workflowCollector = (
           let status = 'success';
           try {
             const result = await fn(scope);
-            status = 'success';
             return result;
           } catch (err) {
             status = 'failure';

--- a/src/packages/emmett/src/observability/collectors/workflowCollector.unit.spec.ts
+++ b/src/packages/emmett/src/observability/collectors/workflowCollector.unit.spec.ts
@@ -1,0 +1,150 @@
+import {
+  collectingMeter,
+  collectingTracer,
+  ObservabilitySpec,
+} from '@event-driven-io/almanac';
+import { describe, expect, it } from 'vitest';
+import {
+  EmmettAttributes,
+  EmmettMetrics,
+  MessagingSystemName,
+} from '../attributes';
+import { resolveWorkflowObservability } from '../options';
+import { workflowCollector } from './workflowCollector';
+
+const A = EmmettAttributes;
+const M = { system: 'messaging.system' };
+
+const defaultContext = {
+  workflowId: 'wf-1',
+  workflowType: 'OrderWorkflow',
+  inputType: 'PlaceOrder',
+};
+
+const given = ObservabilitySpec.for();
+
+describe('workflowCollector', () => {
+  it('creates workflow.handle scope with emmett.scope.type=workflow and emmett.scope.main=true', async () => {
+    await given({})
+      .when((config) =>
+        workflowCollector(config).startScope(defaultContext, () =>
+          Promise.resolve(),
+        ),
+      )
+      .then(({ spans }) =>
+        spans.haveSpanNamed('workflow.handle').hasAttributes({
+          [A.scope.type]: 'workflow',
+          'emmett.scope.main': true,
+        }),
+      );
+  });
+
+  it('sets emmett.workflow.id, emmett.workflow.type, emmett.workflow.input.type', async () => {
+    await given({})
+      .when((config) =>
+        workflowCollector(config).startScope(
+          {
+            workflowId: 'wf-42',
+            workflowType: 'ShippingWorkflow',
+            inputType: 'ShipOrder',
+          },
+          () => Promise.resolve(),
+        ),
+      )
+      .then(({ spans }) =>
+        spans.haveSpanNamed('workflow.handle').hasAttributes({
+          [A.workflow.id]: 'wf-42',
+          [A.workflow.type]: 'ShippingWorkflow',
+          [A.workflow.inputType]: 'ShipOrder',
+        }),
+      );
+  });
+
+  it('sets emmett.workflow.outputs and emmett.workflow.outputs.count via recordOutputs', async () => {
+    const outputs = [{ type: 'OrderShipped' }, { type: 'NotificationSent' }];
+    await given({})
+      .when((config) =>
+        workflowCollector(config).startScope(defaultContext, (scope) => {
+          workflowCollector(config).recordOutputs(scope, outputs);
+          return Promise.resolve();
+        }),
+      )
+      .then(({ spans }) =>
+        spans.haveSpanNamed('workflow.handle').hasAttributes({
+          [A.workflow.outputs]: ['OrderShipped', 'NotificationSent'],
+          [A.workflow.outputsCount]: 2,
+        }),
+      );
+  });
+
+  it('creates child scopes for evolve and decide', async () => {
+    await given({})
+      .when((config) =>
+        workflowCollector(config).startScope(defaultContext, async (scope) => {
+          await scope.scope('workflow.evolve', () => Promise.resolve());
+          await scope.scope('workflow.decide', () => Promise.resolve());
+        }),
+      )
+      .then(({ spans }) =>
+        spans
+          .containSpanNamed('workflow.evolve')
+          .containSpanNamed('workflow.decide'),
+      );
+  });
+
+  it('sets messaging.system', async () => {
+    await given({})
+      .when((config) =>
+        workflowCollector(config).startScope(defaultContext, () =>
+          Promise.resolve(),
+        ),
+      )
+      .then(({ spans }) =>
+        spans
+          .haveSpanNamed('workflow.handle')
+          .hasAttribute(M.system, MessagingSystemName),
+      );
+  });
+
+  it('sets emmett.workflow.state_rebuild.event_count via recordStateRebuild', async () => {
+    await given({})
+      .when((config) =>
+        workflowCollector(config).startScope(defaultContext, (scope) => {
+          workflowCollector(config).recordStateRebuild(scope, 7);
+          return Promise.resolve();
+        }),
+      )
+      .then(({ spans }) =>
+        spans
+          .haveSpanNamed('workflow.handle')
+          .hasAttribute(A.workflow.stateRebuildEventCount, 7),
+      );
+  });
+
+  it('records emmett.workflow.processing.duration histogram with workflow type', async () => {
+    const meter = collectingMeter();
+    const obs = {
+      tracer: collectingTracer(),
+      meter,
+      propagation: 'links' as const,
+      attributeTarget: 'both' as const,
+      includeMessagePayloads: false,
+    };
+    const collector = workflowCollector(obs);
+    await collector.startScope(defaultContext, () => Promise.resolve());
+    const h = meter.histograms.find(
+      (h) => h.name === EmmettMetrics.workflow.processingDuration,
+    );
+    expect(h).toBeDefined();
+    expect(h!.value).toBeGreaterThanOrEqual(0);
+    expect((h!.attributes as Record<string, unknown>)[A.workflow.type]).toBe(
+      'OrderWorkflow',
+    );
+  });
+
+  it('works with noop observability', async () => {
+    const o11y = resolveWorkflowObservability(undefined);
+    const collector = workflowCollector(o11y);
+    await collector.startScope(defaultContext, () => Promise.resolve());
+  });
+});

--- a/src/packages/emmett/src/observability/index.ts
+++ b/src/packages/emmett/src/observability/index.ts
@@ -1,0 +1,5 @@
+export * from '@event-driven-io/almanac';
+export * from './attributes';
+export * from './options';
+export * from './tracer';
+export * from './collectors';

--- a/src/packages/emmett/src/observability/options.ts
+++ b/src/packages/emmett/src/observability/options.ts
@@ -1,12 +1,12 @@
 import type {
-  Tracer,
-  Meter,
-  TracePropagation,
   AttributeTarget,
+  Meter,
   ObservabilityConfig,
   ObservabilityScope,
+  TracePropagation,
+  Tracer,
 } from '@event-driven-io/almanac';
-import { noopTracer, noopMeter } from '@event-driven-io/almanac';
+import { noopMeter, noopTracer } from '@event-driven-io/almanac';
 
 export type WithObservabilityScope<Context> = Context & {
   observabilityScope: ObservabilityScope;

--- a/src/packages/emmett/src/observability/options.ts
+++ b/src/packages/emmett/src/observability/options.ts
@@ -1,0 +1,207 @@
+import type {
+  Tracer,
+  Meter,
+  TracePropagation,
+  AttributeTarget,
+  ObservabilityConfig,
+  ObservabilityScope,
+} from '@event-driven-io/almanac';
+import { noopTracer, noopMeter } from '@event-driven-io/almanac';
+
+export type WithObservabilityScope<Context> = Context & {
+  observabilityScope: ObservabilityScope;
+};
+
+export type PollTracing = 'off' | 'active' | 'verbose';
+
+export type EmmettObservabilityConfig = ObservabilityConfig<'emmett'> & {
+  pollTracing?: PollTracing;
+  includeMessagePayloads?: boolean;
+};
+
+export type EmmettObservabilityOptions = {
+  observability?: EmmettObservabilityConfig;
+};
+
+export type CommandObservabilityConfig = Pick<
+  EmmettObservabilityConfig,
+  'tracer' | 'meter' | 'attributeTarget' | 'includeMessagePayloads'
+>;
+
+export type ProcessorObservabilityConfig = Pick<
+  EmmettObservabilityConfig,
+  | 'tracer'
+  | 'meter'
+  | 'propagation'
+  | 'attributeTarget'
+  | 'includeMessagePayloads'
+>;
+
+export type ConsumerObservabilityConfig = Pick<
+  EmmettObservabilityConfig,
+  'tracer' | 'meter' | 'pollTracing' | 'attributeTarget'
+>;
+
+export type EventStoreObservabilityConfig = Pick<
+  EmmettObservabilityConfig,
+  'tracer' | 'meter' | 'attributeTarget'
+>;
+
+export type WorkflowObservabilityConfig = Pick<
+  EmmettObservabilityConfig,
+  | 'tracer'
+  | 'meter'
+  | 'propagation'
+  | 'attributeTarget'
+  | 'includeMessagePayloads'
+>;
+
+export type ResolvedCommandObservability = {
+  tracer: Tracer;
+  meter: Meter;
+  attributeTarget: AttributeTarget;
+  includeMessagePayloads: boolean;
+};
+
+export type ResolvedProcessorObservability = {
+  tracer: Tracer;
+  meter: Meter;
+  propagation: TracePropagation;
+  attributeTarget: AttributeTarget;
+  includeMessagePayloads: boolean;
+};
+
+export type ResolvedConsumerObservability = {
+  tracer: Tracer;
+  meter: Meter;
+  pollTracing: PollTracing;
+  attributeTarget: AttributeTarget;
+};
+
+export type ResolvedEventStoreObservability = {
+  tracer: Tracer;
+  meter: Meter;
+  attributeTarget: AttributeTarget;
+};
+
+export type ResolvedWorkflowObservability = {
+  tracer: Tracer;
+  meter: Meter;
+  propagation: TracePropagation;
+  attributeTarget: AttributeTarget;
+  includeMessagePayloads: boolean;
+};
+
+export const resolveCommandObservability = (
+  options: { observability?: CommandObservabilityConfig } | undefined,
+  parent?: EmmettObservabilityOptions,
+): ResolvedCommandObservability => ({
+  tracer:
+    options?.observability?.tracer ??
+    parent?.observability?.tracer ??
+    noopTracer(),
+  meter:
+    options?.observability?.meter ??
+    parent?.observability?.meter ??
+    noopMeter(),
+  attributeTarget:
+    options?.observability?.attributeTarget ??
+    parent?.observability?.attributeTarget ??
+    'both',
+  includeMessagePayloads:
+    options?.observability?.includeMessagePayloads ??
+    parent?.observability?.includeMessagePayloads ??
+    false,
+});
+
+export const resolveProcessorObservability = (
+  options: { observability?: ProcessorObservabilityConfig } | undefined,
+  parent?: EmmettObservabilityOptions,
+): ResolvedProcessorObservability => ({
+  tracer:
+    options?.observability?.tracer ??
+    parent?.observability?.tracer ??
+    noopTracer(),
+  meter:
+    options?.observability?.meter ??
+    parent?.observability?.meter ??
+    noopMeter(),
+  propagation:
+    options?.observability?.propagation ??
+    parent?.observability?.propagation ??
+    'links',
+  attributeTarget:
+    options?.observability?.attributeTarget ??
+    parent?.observability?.attributeTarget ??
+    'both',
+  includeMessagePayloads:
+    options?.observability?.includeMessagePayloads ??
+    parent?.observability?.includeMessagePayloads ??
+    false,
+});
+
+export const resolveConsumerObservability = (
+  options: { observability?: ConsumerObservabilityConfig } | undefined,
+  parent?: EmmettObservabilityOptions,
+): ResolvedConsumerObservability => ({
+  tracer:
+    options?.observability?.tracer ??
+    parent?.observability?.tracer ??
+    noopTracer(),
+  meter:
+    options?.observability?.meter ??
+    parent?.observability?.meter ??
+    noopMeter(),
+  pollTracing:
+    options?.observability?.pollTracing ??
+    parent?.observability?.pollTracing ??
+    'off',
+  attributeTarget:
+    options?.observability?.attributeTarget ??
+    parent?.observability?.attributeTarget ??
+    'both',
+});
+
+export const resolveEventStoreObservability = (
+  options: { observability?: EventStoreObservabilityConfig } | undefined,
+  parent?: EmmettObservabilityOptions,
+): ResolvedEventStoreObservability => ({
+  tracer:
+    options?.observability?.tracer ??
+    parent?.observability?.tracer ??
+    noopTracer(),
+  meter:
+    options?.observability?.meter ??
+    parent?.observability?.meter ??
+    noopMeter(),
+  attributeTarget:
+    options?.observability?.attributeTarget ??
+    parent?.observability?.attributeTarget ??
+    'both',
+});
+
+export const resolveWorkflowObservability = (
+  options: { observability?: WorkflowObservabilityConfig } | undefined,
+  parent?: EmmettObservabilityOptions,
+): ResolvedWorkflowObservability => ({
+  tracer:
+    options?.observability?.tracer ??
+    parent?.observability?.tracer ??
+    noopTracer(),
+  meter:
+    options?.observability?.meter ??
+    parent?.observability?.meter ??
+    noopMeter(),
+  propagation:
+    options?.observability?.propagation ??
+    parent?.observability?.propagation ??
+    'links',
+  attributeTarget:
+    options?.observability?.attributeTarget ??
+    parent?.observability?.attributeTarget ??
+    'both',
+  includeMessagePayloads:
+    options?.observability?.includeMessagePayloads ??
+    parent?.observability?.includeMessagePayloads ??
+    false,
+});

--- a/src/packages/emmett/src/observability/options.unit.spec.ts
+++ b/src/packages/emmett/src/observability/options.unit.spec.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest';
+import { collectingTracer, collectingMeter } from '@event-driven-io/almanac';
+import {
+  resolveCommandObservability,
+  resolveProcessorObservability,
+  resolveConsumerObservability,
+  resolveWorkflowObservability,
+} from './options';
+
+describe('resolveCommandObservability', () => {
+  it('returns noop tracer, meter, attributeTarget=both when no options', () => {
+    const resolved = resolveCommandObservability(undefined);
+    expect(resolved.tracer).toBeDefined();
+    expect(resolved.meter).toBeDefined();
+    expect(resolved.attributeTarget).toBe('both');
+  });
+
+  it('uses provided tracer and meter', () => {
+    const tracer = collectingTracer();
+    const meter = collectingMeter();
+    const resolved = resolveCommandObservability({
+      observability: { tracer, meter },
+    });
+    expect(resolved.tracer).toBe(tracer);
+    expect(resolved.meter).toBe(meter);
+  });
+
+  it('uses provided attributeTarget', () => {
+    const resolved = resolveCommandObservability({
+      observability: { attributeTarget: 'mainSpan' },
+    });
+    expect(resolved.attributeTarget).toBe('mainSpan');
+  });
+
+  it('falls back to parent options', () => {
+    const tracer = collectingTracer();
+    const resolved = resolveCommandObservability(undefined, {
+      observability: { tracer },
+    });
+    expect(resolved.tracer).toBe(tracer);
+  });
+
+  it('child overrides parent', () => {
+    const parentTracer = collectingTracer();
+    const childTracer = collectingTracer();
+    const resolved = resolveCommandObservability(
+      { observability: { tracer: childTracer } },
+      { observability: { tracer: parentTracer } },
+    );
+    expect(resolved.tracer).toBe(childTracer);
+  });
+
+  it('defaults includeMessagePayloads to false', () => {
+    const resolved = resolveCommandObservability(undefined);
+    expect(resolved.includeMessagePayloads).toBe(false);
+  });
+
+  it('uses provided includeMessagePayloads', () => {
+    const resolved = resolveCommandObservability({
+      observability: { includeMessagePayloads: true },
+    });
+    expect(resolved.includeMessagePayloads).toBe(true);
+  });
+
+  it('falls back to parent includeMessagePayloads', () => {
+    const resolved = resolveCommandObservability(undefined, {
+      observability: { includeMessagePayloads: true },
+    });
+    expect(resolved.includeMessagePayloads).toBe(true);
+  });
+});
+
+describe('resolveProcessorObservability', () => {
+  it('returns noop tracer, meter, propagation=links, attributeTarget=both when no options', () => {
+    const resolved = resolveProcessorObservability(undefined);
+    expect(resolved.tracer).toBeDefined();
+    expect(resolved.meter).toBeDefined();
+    expect(resolved.propagation).toBe('links');
+    expect(resolved.attributeTarget).toBe('both');
+  });
+
+  it('uses provided propagation', () => {
+    const resolved = resolveProcessorObservability({
+      observability: { propagation: 'propagate' },
+    });
+    expect(resolved.propagation).toBe('propagate');
+  });
+
+  it('uses provided attributeTarget', () => {
+    const resolved = resolveProcessorObservability({
+      observability: { attributeTarget: 'currentSpan' },
+    });
+    expect(resolved.attributeTarget).toBe('currentSpan');
+  });
+
+  it('falls back to parent', () => {
+    const resolved = resolveProcessorObservability(undefined, {
+      observability: { propagation: 'propagate' },
+    });
+    expect(resolved.propagation).toBe('propagate');
+  });
+
+  it('child overrides parent', () => {
+    const resolved = resolveProcessorObservability(
+      { observability: { propagation: 'propagate' } },
+      { observability: { propagation: 'links' } },
+    );
+    expect(resolved.propagation).toBe('propagate');
+  });
+
+  it('defaults includeMessagePayloads to false', () => {
+    const resolved = resolveProcessorObservability(undefined);
+    expect(resolved.includeMessagePayloads).toBe(false);
+  });
+
+  it('uses provided includeMessagePayloads', () => {
+    const resolved = resolveProcessorObservability({
+      observability: { includeMessagePayloads: true },
+    });
+    expect(resolved.includeMessagePayloads).toBe(true);
+  });
+});
+
+describe('resolveConsumerObservability', () => {
+  it('returns noop tracer, meter, pollTracing=off, attributeTarget=both when no options', () => {
+    const resolved = resolveConsumerObservability(undefined);
+    expect(resolved.tracer).toBeDefined();
+    expect(resolved.meter).toBeDefined();
+    expect(resolved.pollTracing).toBe('off');
+    expect(resolved.attributeTarget).toBe('both');
+  });
+
+  it('uses provided pollTracing', () => {
+    const resolved = resolveConsumerObservability({
+      observability: { pollTracing: 'active' },
+    });
+    expect(resolved.pollTracing).toBe('active');
+  });
+
+  it('uses provided pollTracing=verbose', () => {
+    const resolved = resolveConsumerObservability({
+      observability: { pollTracing: 'verbose' },
+    });
+    expect(resolved.pollTracing).toBe('verbose');
+  });
+
+  it('falls back to parent pollTracing', () => {
+    const resolved = resolveConsumerObservability(undefined, {
+      observability: { pollTracing: 'active' },
+    });
+    expect(resolved.pollTracing).toBe('active');
+  });
+
+  it('uses provided attributeTarget', () => {
+    const resolved = resolveConsumerObservability({
+      observability: { attributeTarget: 'mainSpan' },
+    });
+    expect(resolved.attributeTarget).toBe('mainSpan');
+  });
+
+  it('falls back to parent attributeTarget', () => {
+    const resolved = resolveConsumerObservability(undefined, {
+      observability: { attributeTarget: 'currentSpan' },
+    });
+    expect(resolved.attributeTarget).toBe('currentSpan');
+  });
+});
+
+describe('resolveWorkflowObservability', () => {
+  it('returns noop tracer, meter, propagation=links, attributeTarget=both when no options', () => {
+    const resolved = resolveWorkflowObservability(undefined);
+    expect(resolved.tracer).toBeDefined();
+    expect(resolved.meter).toBeDefined();
+    expect(resolved.propagation).toBe('links');
+    expect(resolved.attributeTarget).toBe('both');
+  });
+
+  it('uses provided propagation and attributeTarget', () => {
+    const resolved = resolveWorkflowObservability({
+      observability: { propagation: 'propagate', attributeTarget: 'mainSpan' },
+    });
+    expect(resolved.propagation).toBe('propagate');
+    expect(resolved.attributeTarget).toBe('mainSpan');
+  });
+
+  it('falls back to parent', () => {
+    const resolved = resolveWorkflowObservability(undefined, {
+      observability: { propagation: 'propagate' },
+    });
+    expect(resolved.propagation).toBe('propagate');
+  });
+
+  it('defaults includeMessagePayloads to false', () => {
+    const resolved = resolveWorkflowObservability(undefined);
+    expect(resolved.includeMessagePayloads).toBe(false);
+  });
+
+  it('uses provided includeMessagePayloads', () => {
+    const resolved = resolveWorkflowObservability({
+      observability: { includeMessagePayloads: true },
+    });
+    expect(resolved.includeMessagePayloads).toBe(true);
+  });
+});

--- a/src/packages/emmett/src/observability/tracer.ts
+++ b/src/packages/emmett/src/observability/tracer.ts
@@ -1,0 +1,140 @@
+import { JSONSerializer } from '../serialization';
+
+export const tracer = () => {};
+
+export type LogLevel = 'DISABLED' | 'INFO' | 'LOG' | 'WARN' | 'ERROR';
+
+export const LogLevel = {
+  DISABLED: 'DISABLED' as LogLevel,
+  INFO: 'INFO' as LogLevel,
+  LOG: 'LOG' as LogLevel,
+  WARN: 'WARN' as LogLevel,
+  ERROR: 'ERROR' as LogLevel,
+};
+
+export type LogType = 'CONSOLE';
+
+export type LogStyle = 'RAW' | 'PRETTY';
+
+export const LogStyle = {
+  RAW: 'RAW' as LogStyle,
+  PRETTY: 'PRETTY' as LogStyle,
+};
+
+const getEnvVariable = (name: string): string | undefined => {
+  try {
+    if (typeof process !== 'undefined' && process.env) {
+      return process.env[name];
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const shouldLog = (logLevel: LogLevel): boolean => {
+  const definedLogLevel = getEnvVariable('DUMBO_LOG_LEVEL') ?? LogLevel.ERROR;
+
+  if (definedLogLevel === LogLevel.ERROR && logLevel === LogLevel.ERROR)
+    return true;
+
+  if (
+    definedLogLevel === LogLevel.WARN &&
+    [LogLevel.ERROR, LogLevel.WARN].includes(logLevel)
+  )
+    return true;
+
+  if (
+    definedLogLevel === LogLevel.LOG &&
+    [LogLevel.ERROR, LogLevel.WARN, LogLevel.LOG].includes(logLevel)
+  )
+    return true;
+
+  if (
+    definedLogLevel === LogLevel.INFO &&
+    [LogLevel.ERROR, LogLevel.WARN, LogLevel.LOG, LogLevel.INFO].includes(
+      logLevel,
+    )
+  )
+    return true;
+
+  return false;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type TraceEventRecorder = (message?: any, ...optionalParams: any[]) => void;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type TraceEventFormatter = (event: any) => string;
+
+const nulloTraceEventRecorder: TraceEventRecorder = () => {};
+
+const getTraceEventFormatter =
+  (logStyle: LogStyle, serializer?: JSONSerializer): TraceEventFormatter =>
+  (event) => {
+    serializer = serializer ?? JSONSerializer.from();
+    switch (logStyle) {
+      case 'RAW':
+        return serializer.serialize(event);
+      case 'PRETTY':
+        // TODO: Add pretty print
+        return serializer.serialize(event);
+    }
+  };
+
+const getTraceEventRecorder = (
+  logLevel: LogLevel,
+  logStyle: LogStyle,
+): TraceEventRecorder => {
+  const format = getTraceEventFormatter(logStyle);
+  switch (logLevel) {
+    case 'DISABLED':
+      return nulloTraceEventRecorder;
+    case 'INFO':
+      return (event) => console.info(format(event));
+    case 'LOG':
+      return (event) => console.log(format(event));
+    case 'WARN':
+      return (event) => console.warn(format(event));
+    case 'ERROR':
+      return (event) => console.error(format(event));
+  }
+};
+
+const recordTraceEvent = (
+  logLevel: LogLevel,
+  eventName: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  attributes?: Record<string, any>,
+) => {
+  if (!shouldLog(LogLevel.LOG)) return;
+
+  const event = {
+    name: eventName,
+    timestamp: new Date().getTime(),
+    ...attributes,
+  };
+
+  const record = getTraceEventRecorder(
+    logLevel,
+    (getEnvVariable('DUMBO_LOG_STYLE') as LogStyle | undefined) ?? 'RAW',
+  );
+
+  record(event);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+tracer.info = (eventName: string, attributes?: Record<string, any>) =>
+  recordTraceEvent(LogLevel.INFO, eventName, attributes);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+tracer.warn = (eventName: string, attributes?: Record<string, any>) =>
+  recordTraceEvent(LogLevel.WARN, eventName, attributes);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+tracer.log = (eventName: string, attributes?: Record<string, any>) =>
+  recordTraceEvent(LogLevel.LOG, eventName, attributes);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+tracer.error = (eventName: string, attributes?: Record<string, any>) =>
+  recordTraceEvent(LogLevel.ERROR, eventName, attributes);

--- a/src/packages/emmett/src/testing/assertions.ts
+++ b/src/packages/emmett/src/testing/assertions.ts
@@ -161,12 +161,15 @@ export const assertThat = <T>(item: T) => {
   };
 };
 
-export const assertDefined = (
-  value: unknown,
+export function assertDefined<T>(
+  value: T,
   message?: string | Error,
-): asserts value => {
-  assertOk(value, message instanceof Error ? message.message : message);
-};
+): asserts value is NonNullable<T> {
+  if (value === undefined || value === null) {
+    const msg = message instanceof Error ? message.message : message;
+    throw new AssertionError(msg ?? 'Value is not defined');
+  }
+}
 
 export function assertFalse(
   condition: boolean,

--- a/src/packages/emmett/tsconfig.json
+++ b/src/packages/emmett/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "./dist" /* Redirect output structure to the directory. */,
     "rootDir": "./src",
     "paths": {
-      "@event-driven-io/almanac": ["../almanac/src"]
+      "@event-driven-io/almanac": ["../packages/almanac"]
     }
   },
   "references": [


### PR DESCRIPTION
A follow-up to https://github.com/event-driven-io/emmett/pull/332 that ensures alamanc is correctly plugged into Emmett on the build side.

It doesn't yet plug collectors, but takes what's in https://github.com/event-driven-io/emmett/pull/324.

Collectors will be plugged into the follow-up PRs, also grouped and refactored correctly.