### PR TITLE
Fixed acquiring the processor lock of crashed processor

### DIFF
--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.handling.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.handling.int.spec.ts
@@ -1,4 +1,11 @@
-import { assertThatArray, type Event } from '@event-driven-io/emmett';
+import { dumbo, type Dumbo } from '@event-driven-io/dumbo';
+import {
+  assertThatArray,
+  assertThrowsAsync,
+  EmmettError,
+  type Event,
+} from '@event-driven-io/emmett';
+import { getPostgreSQLStartedContainer } from '@event-driven-io/emmett-testcontainers';
 import { StartedPostgreSqlContainer } from '@testcontainers/postgresql';
 import { after, before, beforeEach, describe, it } from 'node:test';
 import { v4 as uuid } from 'uuid';
@@ -6,9 +13,10 @@ import {
   getPostgreSQLEventStore,
   type PostgresEventStore,
 } from '../postgreSQLEventStore';
+import { postgreSQLProcessorLock } from '../projections/locks';
+import { defaultTag, storeProcessorCheckpoint } from '../schema';
 import { postgreSQLEventStoreConsumer } from './postgreSQLEventStoreConsumer';
 import type { PostgreSQLReactorOptions } from './postgreSQLProcessor';
-import { getPostgreSQLStartedContainer } from '@event-driven-io/emmett-testcontainers';
 
 const withDeadline = { timeout: 30000 };
 
@@ -16,12 +24,14 @@ void describe('PostgreSQL event store started consumer', () => {
   let postgres: StartedPostgreSqlContainer;
   let connectionString: string;
   let eventStore: PostgresEventStore;
+  let pool: Dumbo;
 
   before(async () => {
     postgres = await getPostgreSQLStartedContainer();
     connectionString = postgres.getConnectionUri();
     eventStore = getPostgreSQLEventStore(connectionString);
     await eventStore.schema.migrate();
+    pool = dumbo({ connectionString });
   });
 
   beforeEach(async () => {
@@ -33,6 +43,7 @@ void describe('PostgreSQL event store started consumer', () => {
 
   after(async () => {
     try {
+      await pool.close();
       await eventStore.close();
       await postgres.stop();
     } catch (error) {
@@ -432,6 +443,403 @@ void describe('PostgreSQL event store started consumer', () => {
           ]);
         } finally {
           await consumer.close();
+        }
+      },
+    );
+  });
+
+  void describe('processor lock', () => {
+    void it(
+      'fails to start when another instance holds the processor lock',
+      withDeadline,
+      async () => {
+        const processorId = uuid();
+
+        const otherInstanceLock = postgreSQLProcessorLock({
+          processorId,
+          version: 1,
+          partition: defaultTag,
+          processorInstanceId: 'other-crashed-instance',
+        });
+        await pool.withConnection((connection) =>
+          otherInstanceLock.tryAcquire({ execute: connection.execute }),
+        );
+
+        const consumer = postgreSQLEventStoreConsumer({ connectionString });
+        consumer.reactor<GuestStayEvent>({
+          processorId,
+          startFrom: 'CURRENT',
+          eachMessage: () => {},
+        });
+
+        await assertThrowsAsync<EmmettError>(
+          () => consumer.start(),
+          (error) => error.message.includes(processorId),
+        );
+
+        await consumer.close().catch(() => {});
+      },
+    );
+
+    void it(
+      'resumes from saved checkpoint after crash when lockTimeoutSeconds is 0',
+      withDeadline,
+      async () => {
+        const processorId = uuid();
+        const guestId = uuid();
+        const streamName = `guestStay-${guestId}`;
+
+        const { lastEventGlobalPosition: firstPosition } =
+          await eventStore.appendToStream(streamName, [
+            { type: 'GuestCheckedIn', data: { guestId } },
+          ]);
+
+        const { lastEventGlobalPosition: secondPosition } =
+          await eventStore.appendToStream(streamName, [
+            { type: 'GuestCheckedOut', data: { guestId } },
+          ]);
+
+        const crashedInstanceLock = postgreSQLProcessorLock({
+          processorId,
+          version: 1,
+          partition: defaultTag,
+          processorInstanceId: 'crashed-instance',
+        });
+        await pool.withConnection((connection) =>
+          crashedInstanceLock.tryAcquire({ execute: connection.execute }),
+        );
+        await storeProcessorCheckpoint(pool.execute, {
+          processorId,
+          version: 1,
+          newCheckpoint: firstPosition,
+          lastProcessedCheckpoint: 0n,
+          partition: defaultTag,
+          processorInstanceId: 'crashed-instance',
+        });
+
+        const result: GuestStayEvent[] = [];
+
+        const consumer = postgreSQLEventStoreConsumer({ connectionString });
+        consumer.reactor<GuestStayEvent>({
+          processorId,
+          stopAfter: (event) =>
+            event.metadata.globalPosition === secondPosition,
+          lock: { timeoutSeconds: 0 },
+          eachMessage: (event) => {
+            result.push(event);
+          },
+        });
+
+        try {
+          await consumer.start();
+
+          assertThatArray(result).containsOnlyElementsMatching([
+            { type: 'GuestCheckedOut', data: { guestId } },
+          ]);
+        } finally {
+          await consumer.close();
+        }
+      },
+    );
+
+    void it(
+      'second consumer with same processorId fails while first consumer is running',
+      withDeadline,
+      async () => {
+        const processorId = uuid();
+        const guestId = uuid();
+
+        await eventStore.appendToStream(`guestStay-${guestId}`, [
+          { type: 'GuestCheckedIn', data: { guestId } },
+        ]);
+
+        let resolveConsumer1HasLock!: () => void;
+        const consumer1HasLock = new Promise<void>((resolve) => {
+          resolveConsumer1HasLock = resolve;
+        });
+
+        const consumer1 = postgreSQLEventStoreConsumer({ connectionString });
+        consumer1.reactor<GuestStayEvent>({
+          processorId,
+          startFrom: 'CURRENT',
+          eachMessage: () => {
+            resolveConsumer1HasLock();
+          },
+        });
+
+        const consumer1Promise = consumer1.start();
+        await consumer1HasLock;
+
+        const consumer2 = postgreSQLEventStoreConsumer({ connectionString });
+        consumer2.reactor<GuestStayEvent>({
+          processorId,
+          startFrom: 'CURRENT',
+          eachMessage: () => {},
+        });
+
+        try {
+          await assertThrowsAsync<EmmettError>(
+            () => consumer2.start(),
+            (error) => error.message.includes(processorId),
+          );
+        } finally {
+          await consumer1.stop();
+          await consumer1Promise.catch(() => {});
+          await consumer2.close().catch(() => {});
+        }
+      },
+    );
+
+    void it(
+      'new consumer with same processorId starts after previous consumer stops gracefully',
+      withDeadline,
+      async () => {
+        const processorId = uuid();
+        const guestId = uuid();
+        const streamName = `guestStay-${guestId}`;
+
+        const { lastEventGlobalPosition } = await eventStore.appendToStream(
+          streamName,
+          [{ type: 'GuestCheckedIn', data: { guestId } }],
+        );
+
+        const consumer1 = postgreSQLEventStoreConsumer({ connectionString });
+        consumer1.reactor<GuestStayEvent>({
+          processorId,
+          stopAfter: (event) =>
+            event.metadata.globalPosition === lastEventGlobalPosition,
+          eachMessage: () => {},
+        });
+        try {
+          await consumer1.start();
+        } finally {
+          await consumer1.stop();
+        }
+
+        const consumer2 = postgreSQLEventStoreConsumer({ connectionString });
+        consumer2.reactor<GuestStayEvent>({
+          processorId,
+          stopAfter: (event) =>
+            event.metadata.globalPosition === lastEventGlobalPosition,
+          eachMessage: () => {},
+        });
+
+        try {
+          await consumer2.start();
+        } finally {
+          await consumer2.close();
+        }
+      },
+    );
+
+    void it(
+      'new consumer resumes from checkpoint saved by previous consumer after graceful stop',
+      withDeadline,
+      async () => {
+        const processorId = uuid();
+        const guestId = uuid();
+        const streamName = `guestStay-${guestId}`;
+
+        const { lastEventGlobalPosition: firstPosition } =
+          await eventStore.appendToStream(streamName, [
+            { type: 'GuestCheckedIn', data: { guestId } },
+          ]);
+
+        const consumer1 = postgreSQLEventStoreConsumer({ connectionString });
+        consumer1.reactor<GuestStayEvent>({
+          processorId,
+          stopAfter: (event) => event.metadata.globalPosition === firstPosition,
+          eachMessage: () => {},
+        });
+        try {
+          await consumer1.start();
+        } finally {
+          await consumer1.stop();
+        }
+
+        const { lastEventGlobalPosition: secondPosition } =
+          await eventStore.appendToStream(streamName, [
+            { type: 'GuestCheckedOut', data: { guestId } },
+          ]);
+
+        const result: GuestStayEvent[] = [];
+        const consumer2 = postgreSQLEventStoreConsumer({ connectionString });
+        consumer2.reactor<GuestStayEvent>({
+          processorId,
+          stopAfter: (event) =>
+            event.metadata.globalPosition === secondPosition,
+          eachMessage: (event) => {
+            result.push(event);
+          },
+        });
+
+        try {
+          await consumer2.start();
+
+          assertThatArray(result).containsOnlyElementsMatching([
+            { type: 'GuestCheckedOut', data: { guestId } },
+          ]);
+        } finally {
+          await consumer2.close();
+        }
+      },
+    );
+
+    void it(
+      'consumer with explicit processorInstanceId reclaims its own stale lock',
+      withDeadline,
+      async () => {
+        const processorId = uuid();
+        const processorInstanceId = `reconnecting-instance-${uuid()}`;
+        const guestId = uuid();
+        const streamName = `guestStay-${guestId}`;
+
+        const staleInstanceLock = postgreSQLProcessorLock({
+          processorId,
+          version: 1,
+          partition: defaultTag,
+          processorInstanceId,
+        });
+        await pool.withConnection((connection) =>
+          staleInstanceLock.tryAcquire({ execute: connection.execute }),
+        );
+
+        const { lastEventGlobalPosition } = await eventStore.appendToStream(
+          streamName,
+          [{ type: 'GuestCheckedIn', data: { guestId } }],
+        );
+
+        const result: GuestStayEvent[] = [];
+        const consumer = postgreSQLEventStoreConsumer({ connectionString });
+        consumer.reactor<GuestStayEvent>({
+          processorId,
+          processorInstanceId,
+          startFrom: 'CURRENT',
+          stopAfter: (event) =>
+            event.metadata.globalPosition === lastEventGlobalPosition,
+          eachMessage: (event) => {
+            result.push(event);
+          },
+        });
+
+        try {
+          await consumer.start();
+
+          assertThatArray(result).containsElementsMatching([
+            { type: 'GuestCheckedIn', data: { guestId } },
+          ]);
+        } finally {
+          await consumer.close();
+        }
+      },
+    );
+
+    void it(
+      'consumer waits for lock timeout before taking over a crashed processor',
+      withDeadline,
+      async () => {
+        const processorId = uuid();
+        const guestId = uuid();
+        const streamName = `guestStay-${guestId}`;
+
+        const { lastEventGlobalPosition: firstPosition } =
+          await eventStore.appendToStream(streamName, [
+            { type: 'GuestCheckedIn', data: { guestId } },
+          ]);
+        const { lastEventGlobalPosition: secondPosition } =
+          await eventStore.appendToStream(streamName, [
+            { type: 'GuestCheckedOut', data: { guestId } },
+          ]);
+
+        const crashedInstanceLock = postgreSQLProcessorLock({
+          processorId,
+          version: 1,
+          partition: defaultTag,
+          processorInstanceId: 'crashed-instance',
+        });
+        await pool.withConnection((connection) =>
+          crashedInstanceLock.tryAcquire({ execute: connection.execute }),
+        );
+        await storeProcessorCheckpoint(pool.execute, {
+          processorId,
+          version: 1,
+          newCheckpoint: firstPosition,
+          lastProcessedCheckpoint: 0n,
+          partition: defaultTag,
+          processorInstanceId: 'crashed-instance',
+        });
+
+        const result: GuestStayEvent[] = [];
+        const consumer = postgreSQLEventStoreConsumer({ connectionString });
+        consumer.reactor<GuestStayEvent>({
+          processorId,
+          stopAfter: (event) =>
+            event.metadata.globalPosition === secondPosition,
+          lock: {
+            timeoutSeconds: 1,
+            acquisitionPolicy: {
+              type: 'retry',
+              retries: 10,
+              minTimeout: 200,
+              maxTimeout: 1000,
+            },
+          },
+          eachMessage: (event) => {
+            result.push(event);
+          },
+        });
+
+        try {
+          await consumer.start();
+
+          assertThatArray(result).containsOnlyElementsMatching([
+            { type: 'GuestCheckedOut', data: { guestId } },
+          ]);
+        } finally {
+          await consumer.close();
+        }
+      },
+    );
+
+    void it(
+      'concurrent consumers with different processorIds do not block each other',
+      withDeadline,
+      async () => {
+        const guestId = uuid();
+        const { lastEventGlobalPosition } = await eventStore.appendToStream(
+          `guestStay-${guestId}`,
+          [{ type: 'GuestCheckedIn', data: { guestId } }],
+        );
+
+        const result1: GuestStayEvent[] = [];
+        const consumer1 = postgreSQLEventStoreConsumer({ connectionString });
+        consumer1.reactor<GuestStayEvent>({
+          processorId: uuid(),
+          stopAfter: (event) =>
+            event.metadata.globalPosition === lastEventGlobalPosition,
+          eachMessage: (event) => {
+            result1.push(event);
+          },
+        });
+
+        const result2: GuestStayEvent[] = [];
+        const consumer2 = postgreSQLEventStoreConsumer({ connectionString });
+        consumer2.reactor<GuestStayEvent>({
+          processorId: uuid(),
+          stopAfter: (event) =>
+            event.metadata.globalPosition === lastEventGlobalPosition,
+          eachMessage: (event) => {
+            result2.push(event);
+          },
+        });
+
+        try {
+          await Promise.all([consumer1.start(), consumer2.start()]);
+
+          assertThatArray(result1).isNotEmpty();
+          assertThatArray(result2).isNotEmpty();
+        } finally {
+          await Promise.all([consumer1.close(), consumer2.close()]);
         }
       },
     );

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.handling.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.handling.int.spec.ts
@@ -2,6 +2,7 @@ import { dumbo, type Dumbo } from '@event-driven-io/dumbo';
 import {
   assertThatArray,
   assertThrowsAsync,
+  defaultTag,
   EmmettError,
   type Event,
 } from '@event-driven-io/emmett';
@@ -13,8 +14,8 @@ import {
   getPostgreSQLEventStore,
   type PostgresEventStore,
 } from '../postgreSQLEventStore';
-import { postgreSQLProcessorLock } from '../projections/locks';
-import { defaultTag, storeProcessorCheckpoint } from '../schema';
+import { postgreSQLProcessorLock } from '../projections';
+import { storeProcessorCheckpoint } from '../schema';
 import { postgreSQLEventStoreConsumer } from './postgreSQLEventStoreConsumer';
 import type { PostgreSQLReactorOptions } from './postgreSQLProcessor';
 
@@ -472,12 +473,14 @@ void describe('PostgreSQL event store started consumer', () => {
           eachMessage: () => {},
         });
 
-        await assertThrowsAsync<EmmettError>(
-          () => consumer.start(),
-          (error) => error.message.includes(processorId),
-        );
-
-        await consumer.close().catch(() => {});
+        try {
+          await assertThrowsAsync<EmmettError>(
+            () => consumer.start(),
+            (error) => error.message.includes(processorId),
+          );
+        } finally {
+          await consumer.close();
+        }
       },
     );
 
@@ -567,7 +570,7 @@ void describe('PostgreSQL event store started consumer', () => {
           },
         });
 
-        const consumer1Promise = consumer1.start();
+        consumer1.start().catch(console.error);
         await consumer1HasLock;
 
         const consumer2 = postgreSQLEventStoreConsumer({ connectionString });
@@ -583,9 +586,7 @@ void describe('PostgreSQL event store started consumer', () => {
             (error) => error.message.includes(processorId),
           );
         } finally {
-          await consumer1.stop();
-          await consumer1Promise.catch(() => {});
-          await consumer2.close().catch(() => {});
+          await Promise.allSettled([consumer1.close(), consumer2.close()]);
         }
       },
     );
@@ -606,6 +607,7 @@ void describe('PostgreSQL event store started consumer', () => {
         const consumer1 = postgreSQLEventStoreConsumer({ connectionString });
         consumer1.reactor<GuestStayEvent>({
           processorId,
+          startFrom: 'BEGINNING',
           stopAfter: (event) =>
             event.metadata.globalPosition === lastEventGlobalPosition,
           eachMessage: () => {},
@@ -613,12 +615,13 @@ void describe('PostgreSQL event store started consumer', () => {
         try {
           await consumer1.start();
         } finally {
-          await consumer1.stop();
+          await consumer1.close();
         }
 
         const consumer2 = postgreSQLEventStoreConsumer({ connectionString });
         consumer2.reactor<GuestStayEvent>({
           processorId,
+          startFrom: 'BEGINNING',
           stopAfter: (event) =>
             event.metadata.globalPosition === lastEventGlobalPosition,
           eachMessage: () => {},
@@ -654,7 +657,7 @@ void describe('PostgreSQL event store started consumer', () => {
         try {
           await consumer1.start();
         } finally {
-          await consumer1.stop();
+          await consumer1.close();
         }
 
         const { lastEventGlobalPosition: secondPosition } =
@@ -757,7 +760,7 @@ void describe('PostgreSQL event store started consumer', () => {
           partition: defaultTag,
           processorInstanceId: 'crashed-instance',
         });
-        await pool.withConnection((connection) =>
+        await pool.withTransaction((connection) =>
           crashedInstanceLock.tryAcquire({ execute: connection.execute }),
         );
         await storeProcessorCheckpoint(pool.execute, {

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
@@ -165,9 +165,13 @@ export const postgreSQLEventStoreConsumer = <
       messagePuller = undefined;
       abortController = null;
     }
-    await start;
+    try {
+      await start;
+    } catch (error) {
+      console.log('Error during consumer stop:', error);
 
-    await stopProcessors();
+      await stopProcessors();
+    }
   };
 
   const init = async (): Promise<void> => {

--- a/src/packages/emmett-postgresql/src/eventStore/projections/locks/postgreSQLProcessorLock.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/locks/postgreSQLProcessorLock.int.spec.ts
@@ -675,6 +675,50 @@ void describe('tryAcquireProcessorLock', () => {
         'Expected processor_instance_id to remain set',
       );
     });
+
+    void it('same instance re-acquires after crash without explicit release', async () => {
+      const lockKey = 'test_crash_same_instance_reacquire';
+      const processorId = 'processor_crash_same_instance';
+      const instanceId = 'instance_crash_1';
+
+      const lock1 = postgreSQLProcessorLock({
+        ...defaultPartitionAndVersion1,
+        lockKey,
+        processorId,
+        processorInstanceId: instanceId,
+      });
+
+      await pool.withConnection(async (connection) => {
+        const result = await lock1.tryAcquire({ execute: connection.execute });
+        assertTrue(result, 'Expected first acquire to succeed');
+      });
+
+      const statusAfterCrash = await getProcessorStatus(pool.execute, {
+        processorId,
+        ...defaultPartitionAndVersion1,
+      });
+      assertDeepEqual(
+        statusAfterCrash?.status,
+        'running',
+        'Expected status to remain running after crash',
+      );
+
+      const lock2 = postgreSQLProcessorLock({
+        ...defaultPartitionAndVersion1,
+        lockKey,
+        processorId,
+        processorInstanceId: instanceId,
+      });
+
+      const reacquired = await pool.withConnection((connection) =>
+        lock2.tryAcquire({ execute: connection.execute }),
+      );
+
+      assertTrue(
+        reacquired,
+        'Expected same instance to re-acquire after crash without explicit release',
+      );
+    });
   });
 
   void describe('checkpoint handling', () => {
@@ -991,6 +1035,140 @@ void describe('tryAcquireProcessorLock', () => {
       assertTrue(
         allowedResult,
         'Expected takeover to succeed after custom timeout expires',
+      );
+    });
+
+    void it('different instance with default timeout cannot restart after crash within timeout window', async () => {
+      const lockKey = 'test_default_timeout_restart_blocked';
+      const processorId = 'processor_default_timeout_restart';
+      const instanceId1 = 'instance_1';
+      const instanceId2 = 'instance_2'; // simulates v4() generating a new UUID on restart
+
+      const lock1 = postgreSQLProcessorLock({
+        lockKey,
+        processorId,
+        ...defaultPartitionAndVersion1,
+        processorInstanceId: instanceId1,
+      });
+
+      await pool.withConnection(async (connection) => {
+        const result = await lock1.tryAcquire({ execute: connection.execute });
+        assertTrue(result, 'Expected first instance to acquire');
+        // connection closes without explicit release - simulates process crash
+      });
+
+      // status is now 'running' with instanceId1, last_updated is very recent
+      // restart with a new UUID (v4() pattern) and no lockTimeoutSeconds (default 300s)
+      const lock2 = postgreSQLProcessorLock({
+        lockKey,
+        processorId,
+        ...defaultPartitionAndVersion1,
+        processorInstanceId: instanceId2,
+        lockAcquisitionPolicy: { type: 'skip' },
+      });
+
+      const result = await pool.withConnection((connection) =>
+        lock2.tryAcquire({ execute: connection.execute }),
+      );
+
+      assertFalse(
+        result,
+        'Expected restart with new instance ID to fail within default timeout window',
+      );
+    });
+
+    void it('timeoutSeconds 0 allows immediate takeover after crash', async () => {
+      const lockKey = 'test_zero_timeout_crash_takeover';
+      const processorId = 'processor_zero_timeout_crash';
+      const instanceId1 = 'instance_1';
+      const instanceId2 = 'instance_2';
+
+      const lock1 = postgreSQLProcessorLock({
+        lockKey,
+        processorId,
+        ...defaultPartitionAndVersion1,
+        processorInstanceId: instanceId1,
+      });
+
+      await pool.withConnection(async (connection) => {
+        const result = await lock1.tryAcquire({ execute: connection.execute });
+        assertTrue(result, 'Expected first instance to acquire');
+      });
+
+      const statusAfterCrash = await getProcessorStatus(pool.execute, {
+        processorId,
+        ...defaultPartitionAndVersion1,
+      });
+      assertDeepEqual(
+        statusAfterCrash?.status,
+        'running',
+        'Expected status to remain running after crash',
+      );
+
+      const lock2 = postgreSQLProcessorLock({
+        lockKey,
+        processorId,
+        ...defaultPartitionAndVersion1,
+        processorInstanceId: instanceId2,
+        lockTimeoutSeconds: 0,
+      });
+
+      const result = await pool.withConnection((connection) =>
+        lock2.tryAcquire({ execute: connection.execute }),
+      );
+
+      assertTrue(
+        result,
+        'Expected timeoutSeconds=0 to allow immediate takeover after crash',
+      );
+    });
+
+    void it('timeoutSeconds 0 cannot steal advisory lock held in active transaction', async () => {
+      const lockKey = 'test_zero_timeout_active_lock';
+      const processorId = 'processor_zero_timeout_active';
+      const instanceId1 = 'instance_1';
+      const instanceId2 = 'instance_2';
+
+      const firstLockHeld = asyncAwaiter();
+      const secondLockAttempted = asyncAwaiter();
+
+      const lock1 = postgreSQLProcessorLock({
+        lockKey,
+        processorId,
+        ...defaultPartitionAndVersion1,
+        processorInstanceId: instanceId1,
+      });
+
+      const lock2 = postgreSQLProcessorLock({
+        lockKey,
+        processorId,
+        ...defaultPartitionAndVersion1,
+        processorInstanceId: instanceId2,
+        lockTimeoutSeconds: 0,
+        lockAcquisitionPolicy: { type: 'skip' },
+      });
+
+      const [firstResult, secondResult] = await Promise.all([
+        pool.withTransaction(async (tx) => {
+          const result = await lock1.tryAcquire({ execute: tx.execute });
+          firstLockHeld.resolve();
+          await secondLockAttempted.wait;
+          return result;
+        }),
+        (async () => {
+          await firstLockHeld.wait;
+          const result = await pool.withTransaction(async (tx) =>
+            lock2.tryAcquire({ execute: tx.execute }),
+          );
+          secondLockAttempted.resolve();
+          return result;
+        })(),
+      ]);
+
+      assertTrue(firstResult, 'Expected first instance to acquire lock');
+      assertFalse(
+        secondResult,
+        'Expected timeoutSeconds=0 to be blocked by actively held advisory lock',
       );
     });
   });

--- a/src/packages/emmett-postgresql/src/eventStore/schema/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/index.ts
@@ -14,6 +14,7 @@ import { appendToStreamSQL } from './appendToStream';
 import { migration_0_38_7_and_older } from './migrations/0_38_7';
 import {
   migration_0_42_0_2_AddProcessorProjectionFunctions,
+  migration_0_42_0_3_FixProcessorLockTimeout,
   migration_0_42_0_FromSubscriptionsToProcessors,
 } from './migrations/0_42_0';
 import {
@@ -77,6 +78,7 @@ export const eventStoreSchemaMigrations: SQLMigration[] = [
   migration_0_38_7_and_older,
   migration_0_42_0_FromSubscriptionsToProcessors,
   migration_0_42_0_2_AddProcessorProjectionFunctions,
+  migration_0_42_0_3_FixProcessorLockTimeout,
   schemaMigration,
 ];
 

--- a/src/packages/emmett-postgresql/src/eventStore/schema/migrations/0_42_0/0_42_0.migration.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/migrations/0_42_0/0_42_0.migration.ts
@@ -547,3 +547,80 @@ export const migration_0_42_0_2_AddProcessorProjectionFunctions: SQLMigration =
     'emt:postgresql:eventstore:0.42.0-2:add-processor-projection-functions',
     [migration_0_42_0_2_AddProcessorProjectionFunctionsSQL],
   );
+
+export const migration_0_42_0_3_FixProcessorLockTimeoutSQL = rawSql(`
+CREATE OR REPLACE FUNCTION emt_try_acquire_processor_lock(
+    p_lock_key               BIGINT,
+    p_processor_id           TEXT,
+    p_version                INT,
+    p_partition              TEXT       DEFAULT '${defaultTag}',
+    p_processor_instance_id  TEXT       DEFAULT 'emt:unknown',
+    p_projection_name        TEXT       DEFAULT NULL,
+    p_projection_type        VARCHAR(1) DEFAULT NULL,
+    p_projection_kind        TEXT       DEFAULT NULL,
+    p_lock_timeout_seconds   INT        DEFAULT 300
+)
+RETURNS TABLE (acquired BOOLEAN, checkpoint TEXT)
+LANGUAGE plpgsql
+AS $emt_try_acquire_processor_lock$
+DECLARE
+  current_position TEXT;
+  v_current_time TIMESTAMPTZ := clock_timestamp();
+BEGIN
+    RETURN QUERY
+    WITH lock_check AS (
+        SELECT pg_try_advisory_xact_lock(p_lock_key) AS lock_acquired
+    ),
+    ownership_check AS (
+        INSERT INTO emt_processors (
+            processor_id,
+            partition,
+            version,
+            processor_instance_id,
+            status,
+            last_processed_checkpoint,
+            last_processed_transaction_id,
+            created_at,
+            last_updated
+        )
+        SELECT p_processor_id, p_partition, p_version, p_processor_instance_id, 'running', '0000000000000000000', '0'::xid8, v_current_time, v_current_time
+        WHERE (SELECT lock_acquired FROM lock_check) = true
+        ON CONFLICT (processor_id, partition, version) DO UPDATE
+        SET processor_instance_id = p_processor_instance_id,
+            status = 'running',
+            last_updated = v_current_time
+        WHERE emt_processors.processor_instance_id = p_processor_instance_id
+           OR emt_processors.processor_instance_id = 'emt:unknown'
+           OR emt_processors.status = 'stopped'
+           OR emt_processors.last_updated < v_current_time - (p_lock_timeout_seconds || ' seconds')::interval
+        RETURNING last_processed_checkpoint
+    ),
+    projection_status AS (
+        INSERT INTO emt_projections (
+            name,
+            partition,
+            version,
+            type,
+            kind,
+            status,
+            definition
+        )
+        SELECT p_projection_name, p_partition, p_version, p_projection_type, p_projection_kind, 'async_processing', '{}'::jsonb
+        WHERE p_projection_name IS NOT NULL
+          AND (SELECT last_processed_checkpoint FROM ownership_check) IS NOT NULL
+        ON CONFLICT (name, partition, version) DO UPDATE
+        SET status = 'async_processing'
+        RETURNING name
+    )
+    SELECT
+        (SELECT COUNT(*) > 0 FROM ownership_check),
+        (SELECT oc.last_processed_checkpoint FROM ownership_check oc);
+END;
+$emt_try_acquire_processor_lock$;
+`);
+
+export const migration_0_42_0_3_FixProcessorLockTimeout: SQLMigration =
+  sqlMigration(
+    'emt:postgresql:eventstore:0.42.0-3:fix-processor-lock-timeout',
+    [migration_0_42_0_3_FixProcessorLockTimeoutSQL],
+  );

--- a/src/packages/emmett-postgresql/src/eventStore/schema/migrations/0_42_0/0_42_0.snapshot.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/migrations/0_42_0/0_42_0.snapshot.ts
@@ -320,6 +320,9 @@ CREATE OR REPLACE FUNCTION emt_try_acquire_processor_lock(
 RETURNS TABLE (acquired BOOLEAN, checkpoint TEXT)
 LANGUAGE plpgsql
 AS $emt_try_acquire_processor_lock$
+DECLARE
+  current_position TEXT;
+  v_current_time TIMESTAMPTZ := clock_timestamp();
 BEGIN
     RETURN QUERY
     WITH lock_check AS (
@@ -337,16 +340,16 @@ BEGIN
             created_at,
             last_updated
         )
-        SELECT p_processor_id, p_partition, p_version, p_processor_instance_id, 'running', '0000000000000000000', '0'::xid8, now(), now()
+        SELECT p_processor_id, p_partition, p_version, p_processor_instance_id, 'running', '0000000000000000000', '0'::xid8, v_current_time, v_current_time
         WHERE (SELECT lock_acquired FROM lock_check) = true
         ON CONFLICT (processor_id, partition, version) DO UPDATE
         SET processor_instance_id = p_processor_instance_id,
             status = 'running',
-            last_updated = now()
+            last_updated = v_current_time
         WHERE emt_processors.processor_instance_id = p_processor_instance_id
            OR emt_processors.processor_instance_id = 'emt:unknown'
            OR emt_processors.status = 'stopped'
-           OR emt_processors.last_updated < now() - (p_lock_timeout_seconds || ' seconds')::interval
+           OR emt_processors.last_updated < v_current_time - (p_lock_timeout_seconds || ' seconds')::interval
         RETURNING last_processed_checkpoint
     ),
     projection_status AS (

--- a/src/packages/emmett-postgresql/src/eventStore/schema/processors/processorsLocks.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/processors/processorsLocks.ts
@@ -25,6 +25,9 @@ CREATE OR REPLACE FUNCTION emt_try_acquire_processor_lock(
 RETURNS TABLE (acquired BOOLEAN, checkpoint TEXT)
 LANGUAGE plpgsql
 AS $emt_try_acquire_processor_lock$
+DECLARE
+  current_position TEXT;
+  v_current_time TIMESTAMPTZ := clock_timestamp();
 BEGIN
     RETURN QUERY
     WITH lock_check AS (
@@ -42,16 +45,16 @@ BEGIN
             created_at,
             last_updated
         )
-        SELECT p_processor_id, p_partition, p_version, p_processor_instance_id, 'running', '${bigInt.toNormalizedString(0n)}', '0'::xid8, now(), now()
+        SELECT p_processor_id, p_partition, p_version, p_processor_instance_id, 'running', '${bigInt.toNormalizedString(0n)}', '0'::xid8, v_current_time, v_current_time
         WHERE (SELECT lock_acquired FROM lock_check) = true
         ON CONFLICT (processor_id, partition, version) DO UPDATE
         SET processor_instance_id = p_processor_instance_id,
             status = 'running',
-            last_updated = now()
+            last_updated = v_current_time
         WHERE ${processorsTable.name}.processor_instance_id = p_processor_instance_id
            OR ${processorsTable.name}.processor_instance_id = '${unknownTag}'
            OR ${processorsTable.name}.status = 'stopped'
-           OR ${processorsTable.name}.last_updated < now() - (p_lock_timeout_seconds || ' seconds')::interval
+           OR ${processorsTable.name}.last_updated < v_current_time - (p_lock_timeout_seconds || ' seconds')::interval
         RETURNING last_processed_checkpoint
     ),
     projection_status AS (


### PR DESCRIPTION
Updated condition in PostgreSQL lock acquisition to use real current time, not `now()`, which is not the real now, but locked for a transaction. Using `now()` is fine to assign the same date, but not for the time-based condition like acquiring a lock lease.

Using `now()` made the retry pointless, as it always evaluated against the same time, so even if time elapsed, it wouldn't change the timeout condition.

Probably in a future version, it'll be safer to retry higher up in the code or pass the time, but for now (wink wink), that'll do.

Read more in: https://www.cybertec-postgresql.com/en/postgresql-now-vs-nowtimestamp-vs-clock_timestamp/

That was nasty to find!

![](https://media.tenor.com/KNDUHRbyCXoAAAAM/ew-nope.gif)

@dilgerma @visoth FYI