### PR TITLE
Fixed regression in stopping PostgreSQL processors

### DIFF
--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
@@ -168,8 +168,8 @@ export const postgreSQLEventStoreConsumer = <
     try {
       await start;
     } catch (error) {
-      console.log('Error during consumer stop:', error);
-
+      console.log('Error during completing consumer:', error);
+    } finally {
       await stopProcessors();
     }
   };


### PR DESCRIPTION
Accidentally, it was moved to catch instead of always stopping, even when the start failed.

@dilgerma fyi