### PR TITLE
Fixed PostgreSQL and SQLite consumers not to close pool if it's externally provided

### DIFF
--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
@@ -115,6 +115,7 @@ export const postgreSQLEventStoreConsumer = <
 
   const startedAwaiter: AsyncAwaiter<void> = asyncAwaiter<void>();
 
+  const isOwnPool = !options.pool;
   const pool = options.pool
     ? options.pool
     : dumbo({
@@ -396,7 +397,7 @@ export const postgreSQLEventStoreConsumer = <
     stop,
     close: async () => {
       await stop();
-      await pool.close();
+      if (isOwnPool) await pool.close();
     },
   };
 };

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.ts
@@ -126,6 +126,7 @@ export const sqliteEventStoreConsumer = <
 
   const startedAwaiter: AsyncAwaiter<void> = asyncAwaiter<void>();
 
+  const isOwnPool = !options.pool;
   const pool =
     options.pool ??
     dumbo({
@@ -365,7 +366,7 @@ export const sqliteEventStoreConsumer = <
     stop,
     close: async () => {
       await stop();
-      await pool.close();
+      if (isOwnPool) await pool.close();
     },
   };
 };


### PR DESCRIPTION
If it's an external pool, we should not close it; let the external code own it and handle it.