### PR TITLE
Output messages from Workflow's output handler are used correctly as inputs

### DIFF
--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.workflow.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.workflow.int.spec.ts
@@ -2,6 +2,7 @@ import {
   assertEqual,
   assertThatArray,
   WorkflowHandler,
+  workflowOutputHandler,
   workflowStreamName,
   type WorkflowOptions,
 } from '@event-driven-io/emmett';
@@ -11,9 +12,11 @@ import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
 import { v4 as uuid } from 'uuid';
 import {
   GroupCheckoutWorkflow,
+  type CheckOut,
   type GroupCheckout,
   type GroupCheckoutInput,
   type GroupCheckoutOutput,
+  type GuestCheckedOut,
 } from '../../testing/groupCheckout.domain';
 import {
   getPostgreSQLEventStore,
@@ -382,6 +385,159 @@ void describe('PostgreSQL event store workflow processor', () => {
         assertEqual(events[1]!.type, 'GroupCheckoutInitiated');
         assertEqual(events[2]!.type, 'CheckOut');
         assertEqual(events[3]!.type, 'CheckOut');
+      } finally {
+        await consumer.close();
+      }
+    },
+  );
+
+  void it(
+    'completes group checkout when GuestCheckedOut arrives on external stream',
+    withDeadline,
+    async () => {
+      const groupCheckoutId = uuid();
+      const guestStayAccountId = uuid();
+      const now = new Date();
+
+      const consumer = postgreSQLEventStoreConsumer({
+        connectionString,
+      });
+
+      consumer.workflowProcessor<
+        GroupCheckoutInput,
+        GroupCheckout,
+        GroupCheckoutOutput
+      >({
+        ...workflowProcessorOptions,
+        separateInputInboxFromProcessing: true,
+        stopAfter: (message) =>
+          message.type === 'GroupCheckoutCompleted' &&
+          message.data.groupCheckoutId === groupCheckoutId,
+      });
+
+      try {
+        const consumerPromise = consumer.start();
+
+        await eventStore.appendToStream(`groupCheckout-${groupCheckoutId}`, [
+          {
+            type: 'InitiateGroupCheckout',
+            data: {
+              groupCheckoutId,
+              clerkId: 'clerk-1',
+              guestStayAccountIds: [guestStayAccountId],
+              now,
+            },
+          },
+        ]);
+
+        await eventStore.appendToStream(`guestStay-${guestStayAccountId}`, [
+          {
+            type: 'GuestCheckedOut',
+            data: {
+              guestStayAccountId,
+              checkedOutAt: now,
+              groupCheckoutId,
+            },
+          },
+        ]);
+
+        await consumerPromise;
+
+        const { events } = await eventStore.readStream(
+          workflowStreamName({
+            workflowName: 'GroupCheckoutWorkflow',
+            workflowId: groupCheckoutId,
+          }),
+        );
+
+        const eventTypes = events.map((e) => e.type);
+        assertThatArray(eventTypes).containsElements([
+          'GroupCheckoutWorkflow:InitiateGroupCheckout',
+          'GroupCheckoutInitiated',
+          'GroupCheckoutWorkflow:GuestCheckedOut',
+          'GroupCheckoutCompleted',
+        ]);
+      } finally {
+        await consumer.close();
+      }
+    },
+  );
+
+  void it(
+    'completes group checkout when output handler returns input message tagged for decide',
+    withDeadline,
+    async () => {
+      const groupCheckoutId = uuid();
+      const guestStayAccountId = uuid();
+      const now = new Date();
+
+      const consumer = postgreSQLEventStoreConsumer({
+        connectionString,
+      });
+
+      consumer.workflowProcessor<
+        GroupCheckoutInput,
+        GroupCheckout,
+        GroupCheckoutOutput
+      >({
+        ...workflowProcessorOptions,
+        separateInputInboxFromProcessing: true,
+        outputHandler: workflowOutputHandler<
+          GroupCheckoutInput,
+          GroupCheckoutOutput,
+          GroupCheckoutOutput
+        >({
+          canHandle: ['CheckOut'],
+          eachMessage: (msg): GuestCheckedOut => {
+            const checkOut = msg as unknown as CheckOut;
+            return {
+              type: 'GuestCheckedOut',
+              data: {
+                guestStayAccountId: checkOut.data.guestStayAccountId,
+                checkedOutAt: now,
+                groupCheckoutId: checkOut.data.groupCheckoutId,
+              },
+            };
+          },
+        }),
+        stopAfter: (message) =>
+          message.type === 'GroupCheckoutCompleted' &&
+          message.data.groupCheckoutId === groupCheckoutId,
+      });
+
+      try {
+        const consumerPromise = consumer.start();
+
+        await eventStore.appendToStream(`groupCheckout-${groupCheckoutId}`, [
+          {
+            type: 'InitiateGroupCheckout',
+            data: {
+              groupCheckoutId,
+              clerkId: 'clerk-1',
+              guestStayAccountIds: [guestStayAccountId],
+              now,
+            },
+          },
+        ]);
+
+        await consumerPromise;
+
+        const { events } = await eventStore.readStream(
+          workflowStreamName({
+            workflowName: 'GroupCheckoutWorkflow',
+            workflowId: groupCheckoutId,
+          }),
+        );
+
+        const eventTypes = events.map((e) => e.type);
+        assertThatArray(eventTypes).containsElements([
+          'GroupCheckoutWorkflow:InitiateGroupCheckout',
+          'GroupCheckoutInitiated',
+          'CheckOut',
+          'GuestCheckedOut',
+          'GroupCheckoutWorkflow:GuestCheckedOut',
+          'GroupCheckoutCompleted',
+        ]);
       } finally {
         await consumer.close();
       }

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.workflow.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.workflow.int.spec.ts
@@ -4,6 +4,7 @@ import {
   assertEqual,
   assertThatArray,
   WorkflowHandler,
+  workflowOutputHandler,
   workflowStreamName,
   type WorkflowOptions,
 } from '@event-driven-io/emmett';
@@ -18,9 +19,11 @@ import {
 } from '../../sqlite3';
 import {
   GroupCheckoutWorkflow,
+  type CheckOut,
   type GroupCheckout,
   type GroupCheckoutInput,
   type GroupCheckoutOutput,
+  type GuestCheckedOut,
 } from '../../testing/groupCheckout.domain';
 import { createEventStoreSchema } from '../schema';
 import {
@@ -400,6 +403,165 @@ void describe('SQLite event store workflow processor', () => {
         assertEqual(events[1]!.type, 'GroupCheckoutInitiated');
         assertEqual(events[2]!.type, 'CheckOut');
         assertEqual(events[3]!.type, 'CheckOut');
+      } finally {
+        await consumer.close();
+      }
+    },
+  );
+
+  void it(
+    'completes group checkout when GuestCheckedOut arrives on external stream',
+    withDeadline,
+    async () => {
+      const groupCheckoutId = uuid();
+      const guestStayAccountId = uuid();
+      const now = new Date();
+
+      const consumer = sqliteEventStoreConsumer({
+        driver: sqlite3EventStoreDriver,
+        fileName,
+      });
+
+      consumer.workflowProcessor<
+        GroupCheckoutInput,
+        GroupCheckout,
+        GroupCheckoutOutput
+      >({
+        ...workflowProcessorOptions,
+        separateInputInboxFromProcessing: true,
+        stopAfter: (message) =>
+          message.type === 'GroupCheckoutCompleted' &&
+          message.data.groupCheckoutId === groupCheckoutId,
+      });
+
+      try {
+        const consumerPromise = consumer.start();
+
+        await eventStore.appendToStream(`groupCheckout-${groupCheckoutId}`, [
+          {
+            type: 'InitiateGroupCheckout',
+            data: {
+              groupCheckoutId,
+              clerkId: 'clerk-1',
+              guestStayAccountIds: [guestStayAccountId],
+              now,
+            },
+          },
+        ]);
+
+        await eventStore.appendToStream(`guestStay-${guestStayAccountId}`, [
+          {
+            type: 'GuestCheckedOut',
+            data: {
+              guestStayAccountId,
+              checkedOutAt: now,
+              groupCheckoutId,
+            },
+          },
+        ]);
+
+        await consumerPromise;
+
+        const { events } = await eventStore.readStream(
+          workflowStreamName({
+            workflowName: 'GroupCheckoutWorkflow',
+            workflowId: groupCheckoutId,
+          }),
+        );
+
+        const eventTypes = events.map((e) => e.type);
+        assertThatArray(eventTypes).containsElements([
+          'GroupCheckoutWorkflow:InitiateGroupCheckout',
+          'GroupCheckoutInitiated',
+          'GroupCheckoutWorkflow:GuestCheckedOut',
+          'GroupCheckoutCompleted',
+        ]);
+      } finally {
+        await consumer.close();
+      }
+    },
+  );
+
+  void it(
+    'completes group checkout when output handler returns input message tagged for decide',
+    withDeadline,
+    async () => {
+      const groupCheckoutId = uuid();
+      const guestStayAccountId = uuid();
+      const now = new Date();
+
+      const consumer = sqliteEventStoreConsumer({
+        driver: sqlite3EventStoreDriver,
+        fileName,
+      });
+
+      consumer.workflowProcessor<
+        GroupCheckoutInput,
+        GroupCheckout,
+        GroupCheckoutOutput
+      >({
+        ...workflowProcessorOptions,
+        separateInputInboxFromProcessing: true,
+        outputHandler: workflowOutputHandler<
+          GroupCheckoutInput,
+          GroupCheckoutOutput,
+          GroupCheckoutOutput
+        >({
+          canHandle: ['CheckOut'],
+          eachMessage: (msg): GuestCheckedOut => {
+            const checkOut = msg as unknown as CheckOut;
+            return {
+              type: 'GuestCheckedOut',
+              data: {
+                guestStayAccountId: checkOut.data.guestStayAccountId,
+                checkedOutAt: now,
+                groupCheckoutId: checkOut.data.groupCheckoutId,
+              },
+            };
+          },
+        }),
+        stopAfter: (message) => {
+          return (
+            message.type === 'GroupCheckoutCompleted' &&
+            (message as unknown as { data: { groupCheckoutId: string } }).data
+              .groupCheckoutId === groupCheckoutId
+          );
+        },
+      });
+
+      try {
+        const consumerPromise = consumer.start();
+
+        await eventStore.appendToStream(`groupCheckout-${groupCheckoutId}`, [
+          {
+            type: 'InitiateGroupCheckout',
+            data: {
+              groupCheckoutId,
+              clerkId: 'clerk-1',
+              guestStayAccountIds: [guestStayAccountId],
+              now,
+            },
+          },
+        ]);
+
+        await consumerPromise;
+
+        const { events } = await eventStore.readStream(
+          workflowStreamName({
+            workflowName: 'GroupCheckoutWorkflow',
+            workflowId: groupCheckoutId,
+          }),
+        );
+
+        const eventTypes = events.map((e) => e.type);
+        assertThatArray(eventTypes).containsElements([
+          'GroupCheckoutWorkflow:InitiateGroupCheckout',
+          'GroupCheckoutInitiated',
+          'CheckOut',
+          'GuestCheckedOut',
+          'GroupCheckoutWorkflow:GuestCheckedOut',
+          'GroupCheckoutCompleted',
+        ]);
       } finally {
         await consumer.close();
       }

--- a/src/packages/emmett/src/workflows/workflowProcessor.ts
+++ b/src/packages/emmett/src/workflows/workflowProcessor.ts
@@ -296,9 +296,17 @@ export const workflowProcessor = <
               workflowId,
             });
 
+        const inputTaggedMessages = messagesToAppend.map((msg) => ({
+          ...(msg as Record<string, unknown>),
+          metadata: {
+            ...(msg as { metadata?: Record<string, unknown> }).metadata,
+            input: true,
+          },
+        }));
+
         await context.connection.messageStore.appendToStream(
           streamName,
-          messagesToAppend as unknown as Event[],
+          inputTaggedMessages as unknown as Event[],
         );
 
         return;

--- a/src/packages/emmett/src/workflows/workflowProcessor.unit.spec.ts
+++ b/src/packages/emmett/src/workflows/workflowProcessor.unit.spec.ts
@@ -745,6 +745,110 @@ void describe('Workflow Processor', () => {
       assertMatches(result, { type: 'STOP' });
     });
 
+    void it('output handler returned message feeds back to decide and completes the workflow', async () => {
+      // Given
+      const eventStore = getInMemoryEventStore();
+      const groupCheckoutId = randomUUID();
+      const guestStayAccountId = randomUUID();
+      const now = new Date();
+      const streamName = workflowStreamName({
+        workflowName: 'GroupCheckoutWorkflow',
+        workflowId: groupCheckoutId,
+      });
+
+      const processor = workflowProcessor({
+        ...workflowOptions,
+        separateInputInboxFromProcessing: true,
+        outputHandler: workflowOutputHandler<
+          GroupCheckoutInput,
+          GroupCheckoutOutput,
+          CheckOut
+        >({
+          canHandle: ['CheckOut'],
+          eachMessage: (msg): GuestCheckedOut => ({
+            type: 'GuestCheckedOut',
+            data: {
+              guestStayAccountId: msg.data.guestStayAccountId,
+              checkedOutAt: now,
+              groupCheckoutId,
+            },
+          }),
+        }),
+      });
+
+      // Seed the stream with a Pending state (one guest awaiting checkout)
+      await eventStore.appendToStream(streamName, [
+        {
+          type: 'GroupCheckoutWorkflow:InitiateGroupCheckout',
+          data: {
+            groupCheckoutId,
+            clerkId: 'clerk-1',
+            guestStayAccountIds: [guestStayAccountId],
+            now,
+          },
+          metadata: {
+            input: true,
+            originalMessageId: randomUUID(),
+            action: 'InitiatedBy',
+          },
+        },
+        {
+          type: 'GroupCheckoutInitiated',
+          data: {
+            groupCheckoutId,
+            clerkId: 'clerk-1',
+            guestStayAccountIds: [guestStayAccountId],
+            initiatedAt: now,
+          },
+          metadata: { action: 'Published' },
+        },
+      ] as unknown as Event[]);
+
+      await processor.start({ connection: { messageStore: eventStore } });
+
+      // Step 1: output handler intercepts CheckOut and appends GuestCheckedOut to the stream
+      const checkOutOutput = recordedOutput<CheckOut>(
+        { type: 'CheckOut', data: { guestStayAccountId, groupCheckoutId } },
+        streamName,
+      );
+      await processor.handle([checkOutOutput], {
+        connection: { messageStore: eventStore },
+      });
+
+      let { events } = await eventStore.readStream(streamName);
+      const appendedGuestCheckedOut = events[events.length - 1]!;
+      assertEqual(appendedGuestCheckedOut.type, 'GuestCheckedOut');
+
+      // Step 2: GuestCheckedOut arrives — first hop stores GroupCheckoutWorkflow:GuestCheckedOut
+      await processor.handle(
+        [
+          appendedGuestCheckedOut as unknown as RecordedMessage<GroupCheckoutInput>,
+        ],
+        { connection: { messageStore: eventStore } },
+      );
+
+      ({ events } = await eventStore.readStream(streamName));
+      const prefixedGuestCheckedOut = events[events.length - 1]!;
+      assertEqual(
+        prefixedGuestCheckedOut.type,
+        'GroupCheckoutWorkflow:GuestCheckedOut',
+      );
+
+      // Step 3: second hop — decide sees Pending state and produces GroupCheckoutCompleted
+      await processor.handle(
+        [
+          prefixedGuestCheckedOut as unknown as RecordedMessage<GroupCheckoutInput>,
+        ],
+        { connection: { messageStore: eventStore } },
+      );
+
+      // Then
+      ({ events } = await eventStore.readStream(streamName));
+      assertThatArray(events.map((e) => e.type)).containsElements([
+        'GroupCheckoutCompleted',
+      ]);
+    });
+
     void it('router response is appended to the workflow stream, derived from getWorkflowId', async () => {
       // Given: the output message's metadata.streamName is intentionally a
       // different value — the processor must derive the target stream from


### PR DESCRIPTION
Previously, they weren't tagged correctly as inputs, which caused them not to be used.