### PR TITLE
Ensured that projection will only handle events defined in canHandle

### DIFF
--- a/src/packages/emmett-postgresql/src/eventStore/projections/pongo/pongoProjections.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/pongo/pongoProjections.ts
@@ -161,24 +161,33 @@ export type PongoMultiStreamProjectionOptions<
   eventsOptions?: {
     schema?: EventStoreReadSchemaOptions<EventType, EventPayloadType>;
   };
-  getDocumentId: (event: ReadEvent<EventType>) => string;
 } & (
   | {
-      evolve: PongoWithNullableDocumentEvolve<
-        Document,
-        EventType,
-        EventMetaDataType
-      >;
+      getDocumentId: (event: ReadEvent<EventType>) => string | null;
+      getDocumentIds?: never;
     }
   | {
-      evolve: PongoWithNotNullDocumentEvolve<
-        Document,
-        EventType,
-        EventMetaDataType
-      >;
-      initialState: () => Document;
+      getDocumentId?: never;
+      getDocumentIds: (event: ReadEvent<EventType>) => string[];
     }
 ) &
+  (
+    | {
+        evolve: PongoWithNullableDocumentEvolve<
+          Document,
+          EventType,
+          EventMetaDataType
+        >;
+      }
+    | {
+        evolve: PongoWithNotNullDocumentEvolve<
+          Document,
+          EventType,
+          EventMetaDataType
+        >;
+        initialState: () => Document;
+      }
+  ) &
   JSONSerializationOptions;
 
 export const pongoMultiStreamProjection = <
@@ -195,7 +204,7 @@ export const pongoMultiStreamProjection = <
     EventPayloadType
   >,
 ): PostgreSQLProjectionDefinition<EventType, EventPayloadType> => {
-  const { collectionName, getDocumentId, canHandle } = options;
+  const { collectionName, getDocumentId, getDocumentIds, canHandle } = options;
   const collectionNameWithVersion =
     options.version && options.version > 0
       ? `${collectionName}_v${options.version}`
@@ -215,15 +224,19 @@ export const pongoMultiStreamProjection = <
         );
 
       const eventsByDocumentId = events
-        .map((event) => {
-          const documentId = getDocumentId(event);
+        .flatMap((event) => {
+          const documentIds = getDocumentId
+            ? [getDocumentId(event)].filter((e) => e !== null)
+            : getDocumentIds(event);
 
-          return {
+          return documentIds.map((documentId) => ({
             documentId,
             event: event as ReadEvent<EventType, EventMetaDataType>,
-          };
+          }));
         })
         .reduce((acc, { documentId, event }) => {
+          if (documentId === null) return acc;
+
           if (!acc.has(documentId)) {
             acc.set(documentId, []);
           }
@@ -302,7 +315,6 @@ export type PongoSingleStreamProjectionOptions<
   DocumentPayload extends PongoDocument = Document,
 > = {
   canHandle: CanHandle<EventType>;
-  getDocumentId?: (event: ReadEvent<EventType>) => string;
   version?: number;
   collectionName: string;
   collectionOptions?: PongoDBCollectionOptions<Document, DocumentPayload>;
@@ -311,21 +323,35 @@ export type PongoSingleStreamProjectionOptions<
   };
 } & (
   | {
-      evolve: PongoWithNullableDocumentEvolve<
-        Document,
-        EventType,
-        EventMetaDataType
-      >;
+      getDocumentId: (event: ReadEvent<EventType>) => string | null;
+      getDocumentIds?: never;
     }
   | {
-      evolve: PongoWithNotNullDocumentEvolve<
-        Document,
-        EventType,
-        EventMetaDataType
-      >;
-      initialState: () => Document;
+      getDocumentId?: never;
+      getDocumentIds: (event: ReadEvent<EventType>) => string[];
+    }
+  | {
+      getDocumentId?: never;
+      getDocumentIds?: never;
     }
 ) &
+  (
+    | {
+        evolve: PongoWithNullableDocumentEvolve<
+          Document,
+          EventType,
+          EventMetaDataType
+        >;
+      }
+    | {
+        evolve: PongoWithNotNullDocumentEvolve<
+          Document,
+          EventType,
+          EventMetaDataType
+        >;
+        initialState: () => Document;
+      }
+  ) &
   JSONSerializationOptions;
 
 export const pongoSingleStreamProjection = <
@@ -334,23 +360,28 @@ export const pongoSingleStreamProjection = <
   EventMetaDataType extends PostgresReadEventMetadata =
     PostgresReadEventMetadata,
   EventPayloadType extends Event = EventType,
->(
-  options: PongoSingleStreamProjectionOptions<
-    Document,
-    EventType,
-    EventMetaDataType,
-    EventPayloadType
-  >,
-): PostgreSQLProjectionDefinition<EventType, EventPayloadType> => {
+>({
+  getDocumentId,
+  getDocumentIds,
+  ...options
+}: PongoSingleStreamProjectionOptions<
+  Document,
+  EventType,
+  EventMetaDataType,
+  EventPayloadType
+>): PostgreSQLProjectionDefinition<EventType, EventPayloadType> => {
   return pongoMultiStreamProjection<
     Document,
     EventType,
     EventMetaDataType,
     EventPayloadType
   >({
-    ...options,
     kind: 'emt:projections:postgresql:pongo:single_stream',
-    getDocumentId:
-      options.getDocumentId ?? ((event) => event.metadata.streamName),
+    ...options,
+    ...(getDocumentId
+      ? { getDocumentId: getDocumentId }
+      : getDocumentIds
+        ? { getDocumentIds: getDocumentIds }
+        : { getDocumentId: (event) => event.metadata.streamName }),
   });
 };

--- a/src/packages/emmett-postgresql/src/eventStore/projections/postgreSQLProjection.canHandle.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/postgreSQLProjection.canHandle.int.spec.ts
@@ -1,0 +1,133 @@
+import { getPostgreSQLStartedContainer } from '@event-driven-io/emmett-testcontainers';
+import type { StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import { v4 as uuid } from 'uuid';
+import {
+  eventInStream,
+  expectPongoDocuments,
+  pongoSingleStreamProjection,
+  PostgreSQLProjectionSpec,
+} from '.';
+import type {
+  DiscountApplied,
+  ProductItemAdded,
+  ShoppingCartConfirmed,
+} from '../../testing/shoppingCart.domain';
+
+type ShoppingCartShortInfo = {
+  productItemsCount: number;
+  totalAmount: number;
+  appliedDiscounts: string[];
+};
+
+const collectionName = 'shoppingCartShortInfo';
+
+// evolve deliberately knows how to apply DiscountApplied, even though the
+// projection only declares `ProductItemAdded` in canHandle. If
+// handleProjections did not filter, the discount would change totalAmount.
+const evolve = (
+  document: ShoppingCartShortInfo,
+  { type, data }: ProductItemAdded | DiscountApplied | ShoppingCartConfirmed,
+): ShoppingCartShortInfo => {
+  switch (type) {
+    case 'ProductItemAdded':
+      return {
+        ...document,
+        totalAmount:
+          document.totalAmount +
+          data.productItem.price * data.productItem.quantity,
+        productItemsCount:
+          document.productItemsCount + data.productItem.quantity,
+      };
+    case 'DiscountApplied':
+      if (document.appliedDiscounts.includes(data.couponId)) return document;
+
+      return {
+        ...document,
+        totalAmount: (document.totalAmount * (100 - data.percent)) / 100,
+        appliedDiscounts: [...document.appliedDiscounts, data.couponId],
+      };
+    default:
+      return document;
+  }
+};
+
+const shoppingCartShortInfoProjection = pongoSingleStreamProjection<
+  ShoppingCartShortInfo,
+  ProductItemAdded | DiscountApplied | ShoppingCartConfirmed
+>({
+  collectionName,
+  evolve,
+  // only ProductItemAdded is handled; the other event types must be filtered out
+  canHandle: ['ProductItemAdded'],
+  initialState: () => ({
+    productItemsCount: 0,
+    totalAmount: 0,
+    appliedDiscounts: [],
+  }),
+});
+
+void describe('PostgreSQL handleProjections canHandle filtering', () => {
+  let postgres: StartedPostgreSqlContainer;
+  let connectionString: string;
+  let given: PostgreSQLProjectionSpec<
+    ProductItemAdded | DiscountApplied | ShoppingCartConfirmed
+  >;
+  let shoppingCartId: string;
+
+  beforeAll(async () => {
+    postgres = await getPostgreSQLStartedContainer();
+    connectionString = postgres.getConnectionUri();
+
+    given = PostgreSQLProjectionSpec.for({
+      projection: shoppingCartShortInfoProjection,
+      connectionString,
+    });
+  });
+
+  beforeEach(() => {
+    shoppingCartId = `shoppingCart:${uuid()}`;
+  });
+
+  afterAll(async () => {
+    try {
+      await postgres.stop();
+    } catch (error) {
+      console.log(error);
+    }
+  });
+
+  void it('only applies events whose type is declared in canHandle', () => {
+    const couponId = uuid();
+
+    return given([])
+      .when([
+        eventInStream(shoppingCartId, {
+          type: 'ProductItemAdded',
+          data: {
+            productItem: { price: 100, productId: 'shoes', quantity: 100 },
+          },
+        }),
+        // not in canHandle: must be filtered out before reaching evolve
+        eventInStream(shoppingCartId, {
+          type: 'DiscountApplied',
+          data: { percent: 10, couponId },
+        }),
+        // not in canHandle: must be filtered out before reaching evolve
+        eventInStream(shoppingCartId, {
+          type: 'ShoppingCartConfirmed',
+          data: { confirmedAt: new Date() },
+        }),
+      ])
+      .then(
+        expectPongoDocuments
+          .fromCollection<ShoppingCartShortInfo>(collectionName)
+          .withId(shoppingCartId)
+          .toBeEqual({
+            productItemsCount: 100,
+            totalAmount: 10000,
+            appliedDiscounts: [],
+          }),
+      );
+  });
+});

--- a/src/packages/emmett-postgresql/src/eventStore/projections/postgreSQLProjection.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/postgreSQLProjection.ts
@@ -93,15 +93,15 @@ export const handleProjections = async <EventType extends Event = Event>(
     partition = defaultTag,
   } = options;
 
-  const eventTypes = events.map((e) => e.type);
-
-  const projections = allProjections.filter((p) =>
-    p.canHandle.some((type) => eventTypes.includes(type)),
-  );
-
   const client = (await transaction.connection.open()) as PgClient;
 
-  for (const projection of projections) {
+  for (const projection of allProjections) {
+    const filteredEvents = events.filter(({ type }) =>
+      projection.canHandle.includes(type),
+    );
+
+    if (filteredEvents.length === 0) continue;
+
     // TODO: Make projection name mandatory
     if (projection.name) {
       const lockAcquired = await postgreSQLProjectionLock({
@@ -115,7 +115,7 @@ export const handleProjections = async <EventType extends Event = Event>(
       }
     }
 
-    await projection.handle(events, {
+    await projection.handle(filteredEvents, {
       connection: {
         connectionString,
         pool,

--- a/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjection.documentId.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjection.documentId.int.spec.ts
@@ -1,0 +1,197 @@
+import { getPostgreSQLStartedContainer } from '@event-driven-io/emmett-testcontainers';
+import type { StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import { v4 as uuid } from 'uuid';
+import {
+  eventInStream,
+  expectPongoDocuments,
+  pongoMultiStreamProjection,
+  pongoSingleStreamProjection,
+  PostgreSQLProjectionSpec,
+} from '.';
+import type { ProductItemAdded } from '../../testing/shoppingCart.domain';
+
+type ProductTally = {
+  productItemsCount: number;
+  totalAmount: number;
+};
+
+const evolve = (
+  document: ProductTally,
+  { type, data }: ProductItemAdded,
+): ProductTally => {
+  switch (type) {
+    case 'ProductItemAdded':
+      return {
+        ...document,
+        totalAmount:
+          document.totalAmount +
+          data.productItem.price * data.productItem.quantity,
+        productItemsCount:
+          document.productItemsCount + data.productItem.quantity,
+      };
+    default:
+      return document;
+  }
+};
+
+const initialState = (): ProductTally => ({
+  productItemsCount: 0,
+  totalAmount: 0,
+});
+
+const nullableIdCollectionName = 'productTallyByNullableId';
+const fanOutCollectionName = 'productTallyByCategory';
+
+// returns null for products that should be ignored
+const nullableIdProjection = pongoSingleStreamProjection<
+  ProductTally,
+  ProductItemAdded
+>({
+  collectionName: nullableIdCollectionName,
+  evolve,
+  canHandle: ['ProductItemAdded'],
+  initialState,
+  getDocumentId: (event) =>
+    event.data.productItem.productId.startsWith('ignored')
+      ? null
+      : event.data.productItem.productId,
+});
+
+// fans a single event into a per-product and a per-stream "all" document,
+// and skips the event entirely when there are no ids to update
+const fanOutProjection = pongoMultiStreamProjection<
+  ProductTally,
+  ProductItemAdded
+>({
+  collectionName: fanOutCollectionName,
+  evolve,
+  canHandle: ['ProductItemAdded'],
+  initialState,
+  getDocumentIds: (event) =>
+    event.data.productItem.quantity === 0
+      ? []
+      : [event.data.productItem.productId, `${event.metadata.streamName}:all`],
+});
+
+void describe('Pongo projection document id behaviour', () => {
+  let postgres: StartedPostgreSqlContainer;
+  let connectionString: string;
+  let givenNullableId: PostgreSQLProjectionSpec<ProductItemAdded>;
+  let givenFanOut: PostgreSQLProjectionSpec<ProductItemAdded>;
+  let streamName: string;
+  let productId: string;
+  let allId: string;
+
+  beforeAll(async () => {
+    postgres = await getPostgreSQLStartedContainer();
+    connectionString = postgres.getConnectionUri();
+
+    givenNullableId = PostgreSQLProjectionSpec.for({
+      projection: nullableIdProjection,
+      connectionString,
+    });
+    givenFanOut = PostgreSQLProjectionSpec.for({
+      projection: fanOutProjection,
+      connectionString,
+    });
+  });
+
+  beforeEach(() => {
+    streamName = `shoppingCart:${uuid()}`;
+    // unique ids keep tests isolated within the shared database
+    productId = `shoes-${uuid()}`;
+    allId = `${streamName}:all`;
+  });
+
+  afterAll(async () => {
+    try {
+      await postgres.stop();
+    } catch (error) {
+      console.log(error);
+    }
+  });
+
+  void it('skips the event when getDocumentId returns null', () => {
+    const ignoredId = `ignored-${uuid()}`;
+
+    return givenNullableId([])
+      .when([
+        eventInStream(streamName, {
+          type: 'ProductItemAdded',
+          data: {
+            productItem: {
+              price: 100,
+              productId: ignoredId,
+              quantity: 100,
+            },
+          },
+        }),
+      ])
+      .then(
+        expectPongoDocuments
+          .fromCollection<ProductTally>(nullableIdCollectionName)
+          .withId(ignoredId)
+          .notToExist(),
+      );
+  });
+
+  void it('uses the returned id when getDocumentId returns a string', () =>
+    givenNullableId([])
+      .when([
+        eventInStream(streamName, {
+          type: 'ProductItemAdded',
+          data: {
+            productItem: { price: 100, productId, quantity: 100 },
+          },
+        }),
+      ])
+      .then(
+        expectPongoDocuments
+          .fromCollection<ProductTally>(nullableIdCollectionName)
+          .withId(productId)
+          .toBeEqual({ productItemsCount: 100, totalAmount: 10000 }),
+      ));
+
+  void it('skips the event when getDocumentIds returns an empty array', () =>
+    givenFanOut([])
+      .when([
+        eventInStream(streamName, {
+          type: 'ProductItemAdded',
+          data: {
+            productItem: { price: 100, productId, quantity: 0 },
+          },
+        }),
+      ])
+      .then(async (options) => {
+        await expectPongoDocuments
+          .fromCollection<ProductTally>(fanOutCollectionName)
+          .withId(productId)
+          .notToExist()(options);
+        await expectPongoDocuments
+          .fromCollection<ProductTally>(fanOutCollectionName)
+          .withId(allId)
+          .notToExist()(options);
+      }));
+
+  void it('updates every document when getDocumentIds returns multiple ids', () =>
+    givenFanOut([])
+      .when([
+        eventInStream(streamName, {
+          type: 'ProductItemAdded',
+          data: {
+            productItem: { price: 100, productId, quantity: 100 },
+          },
+        }),
+      ])
+      .then(
+        expectPongoDocuments
+          .fromCollection<ProductTally>(fanOutCollectionName)
+          .matching({
+            _id: { $in: [productId, allId] },
+            productItemsCount: 100,
+            totalAmount: 10000,
+          })
+          .toHaveCount(2),
+      ));
+});

--- a/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjection.documentId.unit.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjection.documentId.unit.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it } from 'vitest';
+import type {
+  DiscountApplied,
+  ProductItemAdded,
+} from '../../testing/shoppingCart.domain';
+import { pongoMultiStreamProjection, pongoSingleStreamProjection } from '.';
+
+type ShoppingCartShortInfo = {
+  productItemsCount: number;
+  totalAmount: number;
+};
+
+const collectionName = 'shoppingCartShortInfo';
+
+const evolve = (
+  document: ShoppingCartShortInfo,
+  { type, data: event }: ProductItemAdded | DiscountApplied,
+): ShoppingCartShortInfo => {
+  switch (type) {
+    case 'ProductItemAdded':
+      return {
+        ...document,
+        totalAmount:
+          document.totalAmount +
+          event.productItem.price * event.productItem.quantity,
+        productItemsCount:
+          document.productItemsCount + event.productItem.quantity,
+      };
+    default:
+      return document;
+  }
+};
+
+const initialState = (): ShoppingCartShortInfo => ({
+  productItemsCount: 0,
+  totalAmount: 0,
+});
+
+void describe('Pongo projection document id options', () => {
+  void it('accepts getDocumentId returning a string', () => {
+    pongoMultiStreamProjection<
+      ShoppingCartShortInfo,
+      ProductItemAdded | DiscountApplied
+    >({
+      collectionName,
+      evolve,
+      canHandle: ['ProductItemAdded', 'DiscountApplied'],
+      initialState,
+      getDocumentId: (event) => event.metadata.streamName,
+    });
+  });
+
+  void it('accepts getDocumentId returning null', () => {
+    pongoMultiStreamProjection<
+      ShoppingCartShortInfo,
+      ProductItemAdded | DiscountApplied
+    >({
+      collectionName,
+      evolve,
+      canHandle: ['ProductItemAdded', 'DiscountApplied'],
+      initialState,
+      getDocumentId: (event) =>
+        event.type === 'ProductItemAdded' ? event.metadata.streamName : null,
+    });
+  });
+
+  void it('accepts getDocumentIds returning an array', () => {
+    pongoMultiStreamProjection<
+      ShoppingCartShortInfo,
+      ProductItemAdded | DiscountApplied
+    >({
+      collectionName,
+      evolve,
+      canHandle: ['ProductItemAdded', 'DiscountApplied'],
+      initialState,
+      getDocumentIds: (event) => [event.metadata.streamName],
+    });
+  });
+
+  void it('rejects passing both getDocumentId and getDocumentIds', () => {
+    pongoMultiStreamProjection<
+      ShoppingCartShortInfo,
+      ProductItemAdded | DiscountApplied
+    >(
+      // @ts-expect-error getDocumentId and getDocumentIds are mutually exclusive
+      {
+        collectionName,
+        evolve,
+        canHandle: ['ProductItemAdded', 'DiscountApplied'],
+        initialState,
+        getDocumentId: (event) => event.metadata.streamName,
+        getDocumentIds: (event) => [event.metadata.streamName],
+      },
+    );
+  });
+
+  void it('rejects a multi stream projection without getDocumentId or getDocumentIds', () => {
+    pongoMultiStreamProjection<
+      ShoppingCartShortInfo,
+      ProductItemAdded | DiscountApplied
+    >(
+      // @ts-expect-error a multi stream projection requires getDocumentId or getDocumentIds
+      {
+        collectionName,
+        evolve,
+        canHandle: ['ProductItemAdded', 'DiscountApplied'],
+        initialState,
+      },
+    );
+  });
+
+  void it('accepts a single stream projection without getDocumentId (defaults to stream name)', () => {
+    pongoSingleStreamProjection<
+      ShoppingCartShortInfo,
+      ProductItemAdded | DiscountApplied
+    >({
+      collectionName,
+      evolve,
+      canHandle: ['ProductItemAdded', 'DiscountApplied'],
+      initialState,
+    });
+  });
+});

--- a/src/packages/emmett-sqlite/src/eventStore/projections/pongo/pongoProjection.documentId.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/projections/pongo/pongoProjection.documentId.int.spec.ts
@@ -1,0 +1,182 @@
+import { v4 as uuid } from 'uuid';
+import { beforeEach, describe, it } from 'vitest';
+import { sqlite3EventStoreDriver } from '../../../sqlite3';
+import type { ProductItemAdded } from '../../../testing/shoppingCart.domain';
+import { eventInStream, SQLiteProjectionSpec } from '../sqliteProjectionSpec';
+import {
+  pongoMultiStreamProjection,
+  pongoSingleStreamProjection,
+} from './pongoProjections';
+import { expectPongoDocuments } from './pongoProjectionSpec';
+
+type ProductTally = {
+  productItemsCount: number;
+  totalAmount: number;
+};
+
+const evolve = (
+  document: ProductTally,
+  { type, data }: ProductItemAdded,
+): ProductTally => {
+  switch (type) {
+    case 'ProductItemAdded':
+      return {
+        ...document,
+        totalAmount:
+          document.totalAmount +
+          data.productItem.price * data.productItem.quantity,
+        productItemsCount:
+          document.productItemsCount + data.productItem.quantity,
+      };
+    default:
+      return document;
+  }
+};
+
+const initialState = (): ProductTally => ({
+  productItemsCount: 0,
+  totalAmount: 0,
+});
+
+const nullableIdCollectionName = 'productTallyByNullableId';
+const fanOutCollectionName = 'productTallyByCategory';
+
+// returns null for products that should be ignored
+const nullableIdProjection = pongoSingleStreamProjection<
+  ProductTally,
+  ProductItemAdded
+>({
+  collectionName: nullableIdCollectionName,
+  evolve,
+  canHandle: ['ProductItemAdded'],
+  initialState,
+  getDocumentId: (event) =>
+    event.data.productItem.productId.startsWith('ignored')
+      ? null
+      : event.data.productItem.productId,
+});
+
+// fans a single event into a per-product and a per-stream "all" document,
+// and skips the event entirely when there are no ids to update
+const fanOutProjection = pongoMultiStreamProjection<
+  ProductTally,
+  ProductItemAdded
+>({
+  collectionName: fanOutCollectionName,
+  evolve,
+  canHandle: ['ProductItemAdded'],
+  initialState,
+  getDocumentIds: (event) =>
+    event.data.productItem.quantity === 0
+      ? []
+      : [event.data.productItem.productId, `${event.metadata.streamName}:all`],
+});
+
+void describe('Pongo projection document id behaviour', () => {
+  let givenNullableId: SQLiteProjectionSpec<ProductItemAdded>;
+  let givenFanOut: SQLiteProjectionSpec<ProductItemAdded>;
+  let streamName: string;
+  let productId: string;
+  let allId: string;
+
+  beforeEach(() => {
+    streamName = `shoppingCart:${uuid()}`;
+    productId = `shoes-${uuid()}`;
+    allId = `${streamName}:all`;
+
+    // a fresh in-memory database per test keeps the shared "all" document isolated
+    givenNullableId = SQLiteProjectionSpec.for({
+      projection: nullableIdProjection,
+      driver: sqlite3EventStoreDriver,
+      fileName: ':memory:',
+    });
+    givenFanOut = SQLiteProjectionSpec.for({
+      projection: fanOutProjection,
+      driver: sqlite3EventStoreDriver,
+      fileName: ':memory:',
+    });
+  });
+
+  void it('skips the event when getDocumentId returns null', () => {
+    const ignoredId = `ignored-${uuid()}`;
+
+    return givenNullableId([])
+      .when([
+        eventInStream(streamName, {
+          type: 'ProductItemAdded',
+          data: {
+            productItem: {
+              price: 100,
+              productId: ignoredId,
+              quantity: 100,
+            },
+          },
+        }),
+      ])
+      .then(
+        expectPongoDocuments
+          .fromCollection<ProductTally>(nullableIdCollectionName)
+          .withId(ignoredId)
+          .notToExist(),
+      );
+  });
+
+  void it('uses the returned id when getDocumentId returns a string', () =>
+    givenNullableId([])
+      .when([
+        eventInStream(streamName, {
+          type: 'ProductItemAdded',
+          data: {
+            productItem: { price: 100, productId, quantity: 100 },
+          },
+        }),
+      ])
+      .then(
+        expectPongoDocuments
+          .fromCollection<ProductTally>(nullableIdCollectionName)
+          .withId(productId)
+          .toBeEqual({ productItemsCount: 100, totalAmount: 10000 }),
+      ));
+
+  void it('skips the event when getDocumentIds returns an empty array', () =>
+    givenFanOut([])
+      .when([
+        eventInStream(streamName, {
+          type: 'ProductItemAdded',
+          data: {
+            productItem: { price: 100, productId, quantity: 0 },
+          },
+        }),
+      ])
+      .then(async (options) => {
+        await expectPongoDocuments
+          .fromCollection<ProductTally>(fanOutCollectionName)
+          .withId(productId)
+          .notToExist()(options);
+        await expectPongoDocuments
+          .fromCollection<ProductTally>(fanOutCollectionName)
+          .withId(allId)
+          .notToExist()(options);
+      }));
+
+  void it('updates every document when getDocumentIds returns multiple ids', () =>
+    givenFanOut([])
+      .when([
+        eventInStream(streamName, {
+          type: 'ProductItemAdded',
+          data: {
+            productItem: { price: 100, productId, quantity: 100 },
+          },
+        }),
+      ])
+      .then(
+        expectPongoDocuments
+          .fromCollection<ProductTally>(fanOutCollectionName)
+          .matching({
+            _id: { $in: [productId, allId] },
+            productItemsCount: 100,
+            totalAmount: 10000,
+          })
+          .toHaveCount(2),
+      ));
+});

--- a/src/packages/emmett-sqlite/src/eventStore/projections/pongo/pongoProjection.documentId.unit.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/projections/pongo/pongoProjection.documentId.unit.spec.ts
@@ -1,0 +1,126 @@
+import { describe, it } from 'vitest';
+import type {
+  DiscountApplied,
+  ProductItemAdded,
+} from '../../../testing/shoppingCart.domain';
+import {
+  pongoMultiStreamProjection,
+  pongoSingleStreamProjection,
+} from './pongoProjections';
+
+type ShoppingCartShortInfo = {
+  productItemsCount: number;
+  totalAmount: number;
+};
+
+const collectionName = 'shoppingCartShortInfo';
+
+const evolve = (
+  document: ShoppingCartShortInfo,
+  { type, data: event }: ProductItemAdded | DiscountApplied,
+): ShoppingCartShortInfo => {
+  switch (type) {
+    case 'ProductItemAdded':
+      return {
+        ...document,
+        totalAmount:
+          document.totalAmount +
+          event.productItem.price * event.productItem.quantity,
+        productItemsCount:
+          document.productItemsCount + event.productItem.quantity,
+      };
+    default:
+      return document;
+  }
+};
+
+const initialState = (): ShoppingCartShortInfo => ({
+  productItemsCount: 0,
+  totalAmount: 0,
+});
+
+void describe('Pongo projection document id options', () => {
+  void it('accepts getDocumentId returning a string', () => {
+    pongoMultiStreamProjection<
+      ShoppingCartShortInfo,
+      ProductItemAdded | DiscountApplied
+    >({
+      collectionName,
+      evolve,
+      canHandle: ['ProductItemAdded', 'DiscountApplied'],
+      initialState,
+      getDocumentId: (event) => event.metadata.streamName,
+    });
+  });
+
+  void it('accepts getDocumentId returning null', () => {
+    pongoMultiStreamProjection<
+      ShoppingCartShortInfo,
+      ProductItemAdded | DiscountApplied
+    >({
+      collectionName,
+      evolve,
+      canHandle: ['ProductItemAdded', 'DiscountApplied'],
+      initialState,
+      getDocumentId: (event) =>
+        event.type === 'ProductItemAdded' ? event.metadata.streamName : null,
+    });
+  });
+
+  void it('accepts getDocumentIds returning an array', () => {
+    pongoMultiStreamProjection<
+      ShoppingCartShortInfo,
+      ProductItemAdded | DiscountApplied
+    >({
+      collectionName,
+      evolve,
+      canHandle: ['ProductItemAdded', 'DiscountApplied'],
+      initialState,
+      getDocumentIds: (event) => [event.metadata.streamName],
+    });
+  });
+
+  void it('rejects passing both getDocumentId and getDocumentIds', () => {
+    pongoMultiStreamProjection<
+      ShoppingCartShortInfo,
+      ProductItemAdded | DiscountApplied
+    >(
+      // @ts-expect-error getDocumentId and getDocumentIds are mutually exclusive
+      {
+        collectionName,
+        evolve,
+        canHandle: ['ProductItemAdded', 'DiscountApplied'],
+        initialState,
+        getDocumentId: (event) => event.metadata.streamName,
+        getDocumentIds: (event) => [event.metadata.streamName],
+      },
+    );
+  });
+
+  void it('rejects a multi stream projection without getDocumentId or getDocumentIds', () => {
+    pongoMultiStreamProjection<
+      ShoppingCartShortInfo,
+      ProductItemAdded | DiscountApplied
+    >(
+      // @ts-expect-error a multi stream projection requires getDocumentId or getDocumentIds
+      {
+        collectionName,
+        evolve,
+        canHandle: ['ProductItemAdded', 'DiscountApplied'],
+        initialState,
+      },
+    );
+  });
+
+  void it('accepts a single stream projection without getDocumentId (defaults to stream name)', () => {
+    pongoSingleStreamProjection<
+      ShoppingCartShortInfo,
+      ProductItemAdded | DiscountApplied
+    >({
+      collectionName,
+      evolve,
+      canHandle: ['ProductItemAdded', 'DiscountApplied'],
+      initialState,
+    });
+  });
+});

--- a/src/packages/emmett-sqlite/src/eventStore/projections/pongo/pongoProjections.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/projections/pongo/pongoProjections.ts
@@ -155,24 +155,33 @@ export type PongoMultiStreamProjectionOptions<
   eventsOptions?: {
     schema?: EventStoreReadSchemaOptions<EventType, EventPayloadType>;
   };
-  getDocumentId: (event: ReadEvent<EventType>) => string;
 } & (
   | {
-      evolve: PongoWithNullableDocumentEvolve<
-        Document,
-        EventType,
-        EventMetaDataType
-      >;
+      getDocumentId: (event: ReadEvent<EventType>) => string | null;
+      getDocumentIds?: never;
     }
   | {
-      evolve: PongoWithNotNullDocumentEvolve<
-        Document,
-        EventType,
-        EventMetaDataType
-      >;
-      initialState: () => Document;
+      getDocumentId?: never;
+      getDocumentIds: (event: ReadEvent<EventType>) => string[];
     }
 ) &
+  (
+    | {
+        evolve: PongoWithNullableDocumentEvolve<
+          Document,
+          EventType,
+          EventMetaDataType
+        >;
+      }
+    | {
+        evolve: PongoWithNotNullDocumentEvolve<
+          Document,
+          EventType,
+          EventMetaDataType
+        >;
+        initialState: () => Document;
+      }
+  ) &
   JSONSerializationOptions;
 
 export const pongoMultiStreamProjection = <
@@ -188,7 +197,7 @@ export const pongoMultiStreamProjection = <
     EventPayloadType
   >,
 ): SQLiteProjectionDefinition<EventType, EventPayloadType> => {
-  const { collectionName, getDocumentId, canHandle } = options;
+  const { collectionName, getDocumentId, getDocumentIds, canHandle } = options;
   const collectionNameWithVersion =
     options.version && options.version > 0
       ? `${collectionName}_v${options.version}`
@@ -208,13 +217,15 @@ export const pongoMultiStreamProjection = <
         );
 
       const eventsByDocumentId = events
-        .map((event) => {
-          const documentId = getDocumentId(event);
+        .flatMap((event) => {
+          const documentIds = getDocumentId
+            ? [getDocumentId(event)].filter((e) => e !== null)
+            : getDocumentIds(event);
 
-          return {
+          return documentIds.map((documentId) => ({
             documentId,
             event: event as ReadEvent<EventType, EventMetaDataType>,
-          };
+          }));
         })
         .reduce((acc, { documentId, event }) => {
           if (!acc.has(documentId)) {
@@ -294,7 +305,6 @@ export type PongoSingleStreamProjectionOptions<
   DocumentPayload extends PongoDocument = Document,
 > = {
   canHandle: CanHandle<EventType>;
-  getDocumentId?: (event: ReadEvent<EventType>) => string;
   version?: number;
   collectionName: string;
   collectionOptions?: PongoDBCollectionOptions<Document, DocumentPayload>;
@@ -303,21 +313,35 @@ export type PongoSingleStreamProjectionOptions<
   };
 } & (
   | {
-      evolve: PongoWithNullableDocumentEvolve<
-        Document,
-        EventType,
-        EventMetaDataType
-      >;
+      getDocumentId: (event: ReadEvent<EventType>) => string | null;
+      getDocumentIds?: never;
     }
   | {
-      evolve: PongoWithNotNullDocumentEvolve<
-        Document,
-        EventType,
-        EventMetaDataType
-      >;
-      initialState: () => Document;
+      getDocumentId?: never;
+      getDocumentIds: (event: ReadEvent<EventType>) => string[];
+    }
+  | {
+      getDocumentId?: never;
+      getDocumentIds?: never;
     }
 ) &
+  (
+    | {
+        evolve: PongoWithNullableDocumentEvolve<
+          Document,
+          EventType,
+          EventMetaDataType
+        >;
+      }
+    | {
+        evolve: PongoWithNotNullDocumentEvolve<
+          Document,
+          EventType,
+          EventMetaDataType
+        >;
+        initialState: () => Document;
+      }
+  ) &
   JSONSerializationOptions;
 
 export const pongoSingleStreamProjection = <
@@ -325,23 +349,28 @@ export const pongoSingleStreamProjection = <
   EventType extends Event,
   EventMetaDataType extends SQLiteReadEventMetadata = SQLiteReadEventMetadata,
   EventPayloadType extends Event = EventType,
->(
-  options: PongoSingleStreamProjectionOptions<
-    Document,
-    EventType,
-    EventMetaDataType,
-    EventPayloadType
-  >,
-): SQLiteProjectionDefinition<EventType, EventPayloadType> => {
+>({
+  getDocumentId,
+  getDocumentIds,
+  ...options
+}: PongoSingleStreamProjectionOptions<
+  Document,
+  EventType,
+  EventMetaDataType,
+  EventPayloadType
+>): SQLiteProjectionDefinition<EventType, EventPayloadType> => {
   return pongoMultiStreamProjection<
     Document,
     EventType,
     EventMetaDataType,
     EventPayloadType
   >({
-    ...options,
     kind: 'emt:projections:postgresql:pongo:single_stream',
-    getDocumentId:
-      options.getDocumentId ?? ((event) => event.metadata.streamName),
+    ...options,
+    ...(getDocumentId
+      ? { getDocumentId: getDocumentId }
+      : getDocumentIds
+        ? { getDocumentIds: getDocumentIds }
+        : { getDocumentId: (event) => event.metadata.streamName }),
   });
 };

--- a/src/packages/emmett-sqlite/src/eventStore/projections/sqliteProjection.canHandle.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/projections/sqliteProjection.canHandle.int.spec.ts
@@ -1,0 +1,114 @@
+import { v4 as uuid } from 'uuid';
+import { beforeEach, describe, it } from 'vitest';
+import { sqlite3EventStoreDriver } from '../../sqlite3';
+import type {
+  DiscountApplied,
+  ProductItemAdded,
+  ShoppingCartConfirmed,
+} from '../../testing/shoppingCart.domain';
+import { expectPongoDocuments, pongoSingleStreamProjection } from './pongo';
+import { eventInStream, SQLiteProjectionSpec } from './sqliteProjectionSpec';
+
+type ShoppingCartShortInfo = {
+  productItemsCount: number;
+  totalAmount: number;
+  appliedDiscounts: string[];
+};
+
+const collectionName = 'shoppingCartShortInfo';
+
+// evolve deliberately knows how to apply DiscountApplied, even though the
+// projection only declares `ProductItemAdded` in canHandle. If
+// handleProjections did not filter, the discount would change totalAmount.
+const evolve = (
+  document: ShoppingCartShortInfo,
+  { type, data }: ProductItemAdded | DiscountApplied | ShoppingCartConfirmed,
+): ShoppingCartShortInfo => {
+  switch (type) {
+    case 'ProductItemAdded':
+      return {
+        ...document,
+        totalAmount:
+          document.totalAmount +
+          data.productItem.price * data.productItem.quantity,
+        productItemsCount:
+          document.productItemsCount + data.productItem.quantity,
+      };
+    case 'DiscountApplied':
+      if (document.appliedDiscounts.includes(data.couponId)) return document;
+
+      return {
+        ...document,
+        totalAmount: (document.totalAmount * (100 - data.percent)) / 100,
+        appliedDiscounts: [...document.appliedDiscounts, data.couponId],
+      };
+    default:
+      return document;
+  }
+};
+
+const shoppingCartShortInfoProjection = pongoSingleStreamProjection<
+  ShoppingCartShortInfo,
+  ProductItemAdded | DiscountApplied | ShoppingCartConfirmed
+>({
+  collectionName,
+  evolve,
+  // only ProductItemAdded is handled; the other event types must be filtered out
+  canHandle: ['ProductItemAdded'],
+  initialState: () => ({
+    productItemsCount: 0,
+    totalAmount: 0,
+    appliedDiscounts: [],
+  }),
+});
+
+void describe('SQLite handleProjections canHandle filtering', () => {
+  let given: SQLiteProjectionSpec<
+    ProductItemAdded | DiscountApplied | ShoppingCartConfirmed
+  >;
+  let shoppingCartId: string;
+
+  beforeEach(() => {
+    shoppingCartId = `shoppingCart:${uuid()}`;
+
+    given = SQLiteProjectionSpec.for({
+      projection: shoppingCartShortInfoProjection,
+      driver: sqlite3EventStoreDriver,
+      fileName: ':memory:',
+    });
+  });
+
+  void it('only applies events whose type is declared in canHandle', () => {
+    const couponId = uuid();
+
+    return given([])
+      .when([
+        eventInStream(shoppingCartId, {
+          type: 'ProductItemAdded',
+          data: {
+            productItem: { price: 100, productId: 'shoes', quantity: 100 },
+          },
+        }),
+        // not in canHandle: must be filtered out before reaching evolve
+        eventInStream(shoppingCartId, {
+          type: 'DiscountApplied',
+          data: { percent: 10, couponId },
+        }),
+        // not in canHandle: must be filtered out before reaching evolve
+        eventInStream(shoppingCartId, {
+          type: 'ShoppingCartConfirmed',
+          data: { confirmedAt: new Date() },
+        }),
+      ])
+      .then(
+        expectPongoDocuments
+          .fromCollection<ShoppingCartShortInfo>(collectionName)
+          .withId(shoppingCartId)
+          .toBeEqual({
+            productItemsCount: 100,
+            totalAmount: 10000,
+            appliedDiscounts: [],
+          }),
+      );
+  });
+});

--- a/src/packages/emmett-sqlite/src/eventStore/projections/sqliteProjection.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/projections/sqliteProjection.ts
@@ -60,13 +60,14 @@ export const handleProjections = async <EventType extends Event = Event>(
     driverType,
   } = options;
 
-  const eventTypes = events.map((e) => e.type);
-
   for (const projection of allProjections) {
-    if (!projection.canHandle.some((type) => eventTypes.includes(type))) {
-      continue;
-    }
-    await projection.handle(events, {
+    const filteredEvents = events.filter(({ type }) =>
+      projection.canHandle.includes(type),
+    );
+
+    if (filteredEvents.length === 0) continue;
+
+    await projection.handle(filteredEvents, {
       connection,
       execute,
       driverType,

--- a/src/packages/emmett/src/eventStore/projections/inMemory/inMemoryProjection.canHandle.unit.spec.ts
+++ b/src/packages/emmett/src/eventStore/projections/inMemory/inMemoryProjection.canHandle.unit.spec.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, it } from 'vitest';
+import { v4 as uuid } from 'uuid';
+import {
+  eventInStream,
+  expectInMemoryDocuments,
+  InMemoryProjectionSpec,
+  inMemorySingleStreamProjection,
+} from '.';
+import type {
+  DiscountApplied,
+  ProductItemAdded,
+  ShoppingCartConfirmed,
+} from '../../../testing/shoppingCart.domain';
+
+type ShoppingCartShortInfo = {
+  productItemsCount: number;
+  totalAmount: number;
+  appliedDiscounts: string[];
+};
+
+const collectionName = 'shoppingCartShortInfo';
+
+// evolve deliberately knows how to apply DiscountApplied, even though the
+// projection only declares `ProductItemAdded` in canHandle. If
+// handleInMemoryProjections did not filter, the discount would change
+// totalAmount.
+const evolve = (
+  document: ShoppingCartShortInfo,
+  { type, data }: ProductItemAdded | DiscountApplied | ShoppingCartConfirmed,
+): ShoppingCartShortInfo => {
+  switch (type) {
+    case 'ProductItemAdded':
+      return {
+        ...document,
+        totalAmount:
+          document.totalAmount +
+          data.productItem.price * data.productItem.quantity,
+        productItemsCount:
+          document.productItemsCount + data.productItem.quantity,
+      };
+    case 'DiscountApplied':
+      if (document.appliedDiscounts.includes(data.couponId)) return document;
+
+      return {
+        ...document,
+        totalAmount: (document.totalAmount * (100 - data.percent)) / 100,
+        appliedDiscounts: [...document.appliedDiscounts, data.couponId],
+      };
+    default:
+      return document;
+  }
+};
+
+const shoppingCartShortInfoProjection = inMemorySingleStreamProjection<
+  ShoppingCartShortInfo,
+  ProductItemAdded | DiscountApplied | ShoppingCartConfirmed
+>({
+  collectionName,
+  evolve,
+  // only ProductItemAdded is handled; the other event types must be filtered out
+  canHandle: ['ProductItemAdded'],
+  initialState: () => ({
+    productItemsCount: 0,
+    totalAmount: 0,
+    appliedDiscounts: [],
+  }),
+});
+
+void describe('InMemory handleProjections canHandle filtering', () => {
+  let given: InMemoryProjectionSpec<
+    ProductItemAdded | DiscountApplied | ShoppingCartConfirmed
+  >;
+  let shoppingCartId: string;
+
+  beforeEach(() => {
+    shoppingCartId = `shoppingCart:${uuid()}`;
+
+    given = InMemoryProjectionSpec.for({
+      projection: shoppingCartShortInfoProjection,
+    });
+  });
+
+  void it('only applies events whose type is declared in canHandle', () => {
+    const couponId = uuid();
+
+    return given([])
+      .when([
+        eventInStream(shoppingCartId, {
+          type: 'ProductItemAdded',
+          data: {
+            productItem: { price: 100, productId: 'shoes', quantity: 100 },
+          },
+        }),
+        // not in canHandle: must be filtered out before reaching evolve
+        eventInStream(shoppingCartId, {
+          type: 'DiscountApplied',
+          data: { percent: 10, couponId },
+        }),
+        // not in canHandle: must be filtered out before reaching evolve
+        eventInStream(shoppingCartId, {
+          type: 'ShoppingCartConfirmed',
+          data: { confirmedAt: new Date() },
+        }),
+      ])
+      .then(
+        expectInMemoryDocuments
+          .fromCollection<ShoppingCartShortInfo>(collectionName)
+          .withId(shoppingCartId)
+          .toBeEqual({
+            productItemsCount: 100,
+            totalAmount: 10000,
+            appliedDiscounts: [],
+          }),
+      );
+  });
+});

--- a/src/packages/emmett/src/eventStore/projections/inMemory/inMemoryProjection.ts
+++ b/src/packages/emmett/src/eventStore/projections/inMemory/inMemoryProjection.ts
@@ -41,22 +41,19 @@ export const handleInMemoryProjections = async <
 ): Promise<void> => {
   const { projections, events, database, eventStore, observability } = options;
 
-  // Get all event types from the events batch to filter projections
-  const eventTypes = events.map((e) => e.type);
-
-  // Filter projections that can handle these event types
-  const relevantProjections = projections.filter((p) =>
-    p.canHandle.some((type) => eventTypes.includes(type)),
-  );
-
   const { startScope } = ObservabilityScope(observability);
 
   // Process each projection
-  for (const projection of relevantProjections) {
+  for (const projection of projections) {
+    const filteredEvents = events.filter(({ type }) =>
+      projection.canHandle.includes(type),
+    );
+    if (filteredEvents.length === 0) continue;
+
     await startScope(
       'eventStore.inlineProjection',
       async (observabilityScope) =>
-        projection.handle(events, {
+        projection.handle(filteredEvents, {
           eventStore,
           database,
           observabilityScope,


### PR DESCRIPTION
Extended also `getDocumentId` to allow returning null, and added `getDocumentIds` as an array of events in PongoProjection