### PR TITLE
Fix command handling api reference docs

### DIFF
--- a/src/docs/api-reference/command.md
+++ b/src/docs/api-reference/command.md
@@ -215,9 +215,9 @@ function logCommand(command: AnyCommand): void {
 ### Direct Handler
 
 ```typescript
-import { CommandHandler } from '@event-driven-io/emmett';
+import { DeciderCommandHandler } from '@event-driven-io/emmett';
 
-const handle = CommandHandler(eventStore, {
+const handle = DeciderCommandHandler(eventStore, {
   decide,
   evolve,
   initialState,


### PR DESCRIPTION
Replace "CommandHandler" with "DeciderCommandHandler" in the docs example.