### PR TITLE
Split command handling reference into guide and reference

### DIFF
--- a/.claude/skills/diataxis/SKILL.md
+++ b/.claude/skills/diataxis/SKILL.md
@@ -1,0 +1,357 @@
+---
+name: diataxis
+description: Centralizes Diataxis documentation framework guidance so Claude can write, review, or improve documentation following the four distinct types (tutorials, how-to guides, reference, explanation).
+allowed-tools: Read, Grep, Glob, Bash, Edit, Write
+---
+
+# Diataxis Skill
+
+Unifies all Diataxis documentation guidance into one Skill. Claude activates this Skill whenever documentation should be written, reviewed, or improved, and then "lazy loads" the exact documentation type guidance by opening the reference docs linked below.
+
+## Critical Workflow
+
+**REQUIRED**: Before writing or reviewing ANY documentation, you MUST load the relevant documentation type reference file(s) using the Read tool.
+
+1. **Use the Compass** to identify the documentation type needed (see below)
+2. **Read the matching reference file(s)** BEFORE writing/reviewing:
+   - Learning experiences → Read `references/tutorials.md`
+   - Task-oriented guides → Read `references/how-to-guides.md`
+   - Information lookup → Read `references/reference.md`
+   - Understanding & context → Read `references/explanation.md`
+3. **Apply the documentation type's principles** from the loaded reference
+4. Write or review documentation according to that type's standards
+
+**DO NOT attempt to write or review documentation without first loading the appropriate reference file(s).**
+
+## The Diataxis Compass
+
+The compass is your primary decision-making tool. Ask two questions:
+
+### Question 1: Action or Cognition?
+
+- **Action** = Practical steps, doing things, hands-on work
+- **Cognition** = Theoretical knowledge, thinking, understanding
+
+### Question 2: Acquisition or Application?
+
+- **Acquisition** = Study, learning something new
+- **Application** = Work, using skills to accomplish tasks
+
+### The Four Quadrants
+
+```
+                    ACQUISITION              APPLICATION
+                    (Study)                  (Work)
+              ┌─────────────────────┬─────────────────────┐
+              │                     │                     │
+   ACTION     │     TUTORIALS       │    HOW-TO GUIDES    │
+   (Doing)    │   Learning-oriented │    Task-oriented    │
+              │   "Teach me"        │    "Help me do X"   │
+              │                     │                     │
+              ├─────────────────────┼─────────────────────┤
+              │                     │                     │
+   COGNITION  │    EXPLANATION      │     REFERENCE       │
+   (Knowing)  │ Understanding-      │  Information-       │
+              │    oriented         │     oriented        │
+              │   "Help me          │    "What is the     │
+              │    understand"      │     spec for X?"    │
+              └─────────────────────┴─────────────────────┘
+```
+
+### Quick Decision Guide
+
+| User Need                            | Action/Cognition | Acquisition/Application | → Type      |
+| ------------------------------------ | ---------------- | ----------------------- | ----------- |
+| "How do I get started?"              | Action           | Acquisition             | Tutorial    |
+| "How do I deploy to prod?"           | Action           | Application             | How-to      |
+| "What parameters does X accept?"     | Cognition        | Application             | Reference   |
+| "Why does the system work this way?" | Cognition        | Acquisition             | Explanation |
+
+## Key Distinctions (Critical!)
+
+### Tutorial vs How-to Guide
+
+Both contain steps, but serve fundamentally different purposes:
+
+| Aspect             | Tutorial                                      | How-to Guide                                |
+| ------------------ | --------------------------------------------- | ------------------------------------------- |
+| **User**           | Learner, may not know enough to ask questions | Competent practitioner who knows their goal |
+| **Responsibility** | Teacher bears responsibility for success      | User bears responsibility for outcomes      |
+| **Approach**       | Concrete, specific, controlled environment    | General, adaptable to real-world variation  |
+| **Path**           | Single path, no choices                       | Multiple routes, branching options          |
+| **Completeness**   | Must be complete end-to-end                   | Can start/end at reasonable points          |
+| **Safety**         | Must be safe, can always restart              | Cannot promise safety                       |
+| **Focus**          | Learning through doing                        | Getting work done                           |
+
+### Reference vs Explanation
+
+Both provide knowledge, but for different contexts:
+
+| Test Question                                      | If Yes →    | If No →     |
+| -------------------------------------------------- | ----------- | ----------- |
+| Would someone turn to this while actively working? | Reference   | Explanation |
+| Could you imagine reading this in the bath?        | Explanation | Reference   |
+| Is it lists, tables, or technical specs?           | Reference   | Explanation |
+| Does it answer "why?" questions?                   | Explanation | Reference   |
+
+## Applying Diataxis: Iterative Approach
+
+**Do NOT create empty structures.** Don't create `/tutorials`, `/how-to`, `/reference`, `/explanation` folders with nothing in them.
+
+**Start small:**
+
+1. Pick any existing documentation
+2. Apply compass to determine what type it should be
+3. Improve it according to that type's principles
+4. Repeat
+
+**Let structure emerge:** As you improve individual pieces, patterns will emerge that suggest organizational structure. The top-level structure forms from the inside out.
+
+## Documentation Type References (load on demand)
+
+- **[Tutorials](references/tutorials.md)** - Learning-oriented experiences enabling skill acquisition through guided practice
+- **[How-to Guides](references/how-to-guides.md)** - Task-oriented directions for accomplishing specific goals
+- **[Reference](references/reference.md)** - Information-oriented technical descriptions for authoritative lookup
+- **[Explanation](references/explanation.md)** - Understanding-oriented discussions providing context and answering "why?"
+
+## Key Principles
+
+1. **Different contexts need different documentation** - Users learning need tutorials; users working need how-to guides or reference; users seeking understanding need explanation
+2. **Separation of concerns** - Keep documentation types distinct to prevent confusion
+3. **User-centered approach** - Consider what the user is trying to accomplish and in what context
+4. **Iterative improvement** - Enhance documentation incrementally by applying Diataxis principles
+5. **Purpose-driven structure** - Each type has specific characteristics that make it effective for its intended purpose
+
+## Overview
+
+Diataxis is a systematic framework for organizing and writing technical documentation. It addresses three fundamental challenges in documentation:
+
+- **Content**: What to write
+- **Style**: How to write it
+- **Architecture**: How to organize it
+
+The framework is lightweight, practical, and user-centered, emerging from analysis of actual documentation user needs. It has been adopted by hundreds of projects including major organizations like Gatsby, Cloudflare, and Vonage.
+
+## The Four Documentation Types
+
+Diataxis organizes documentation into four distinct types, each serving specific user needs and contexts:
+
+### 1. Tutorials (Learning-Oriented)
+
+**Purpose**: Learning experiences that prioritize skill and knowledge acquisition through guided practice.
+
+**Key Characteristics**:
+
+- Provide experiences that enable learning rather than direct teaching
+- Function as lessons where the instructor bears primary responsibility
+- Must be meaningful, successful, logical, and usefully complete
+- Focus on study rather than task completion
+
+**Core Principles**:
+
+1. Don't teach directly—provide experiences enabling learning
+2. Show destination upfront to orient learners
+3. Deliver early, frequent results for rapid feedback
+4. Maintain narrative expectations to keep learners confident
+5. Guide observation to highlight what matters
+6. Enable the feeling of doing with rhythmic, pleasurable progression
+7. Permit repetition to reinforce successful actions
+8. Minimize explanation to avoid distraction
+9. Stay concrete with specific actions and results
+10. Ensure perfect reliability for learner confidence
+
+**Language Patterns**:
+
+- "We will..." (establishes collaboration)
+- Imperative directives: "First, do x. Now, do y"
+- "Notice that..." (provides orientation)
+- "You have built..." (acknowledges accomplishments)
+
+**Distinction**: Tutorials emphasize _acquisition and study_, while how-to guides facilitate _task completion_.
+
+### 2. How-to Guides (Task-Oriented)
+
+**Purpose**: Actionable directions for accomplishing specific tasks or solving real-world problems.
+
+**Key Characteristics**:
+
+- Goal-oriented for users who know what they want to achieve
+- Focus on "action and only action"—no digression, explanation, or teaching
+- Assume competent users who understand their objective
+- Practical usability takes precedence over comprehensiveness
+
+**Core Principles**:
+
+1. **User-centered, not tool-centered**: Address human needs and purposes, not just machinery operations
+2. **Logical sequencing**: Steps follow meaningful order reflecting both practical necessity and user thinking
+3. **Adaptability**: Flexible enough for real-world variations
+4. **Strategic naming**: Titles clearly state what will be accomplished ("How to integrate application performance monitoring")
+5. **Omit extras**: Avoid unnecessary reference material or explanations; link to them instead
+
+**Recipe Analogy**: Like cooking recipes, how-to guides address specific questions, assume basic competence, follow established formats, and exclude both teaching and historical context in favor of focused instructions.
+
+**Distinction**: How-to guides direct already-competent practitioners toward specific outcomes, unlike tutorials that teach foundational skills to novices.
+
+### 3. Reference (Information-Oriented)
+
+**Purpose**: Technical descriptions providing the authoritative foundation needed for confident task execution.
+
+**Key Characteristics**:
+
+- Austere and neutral with objective, factual language
+- Consulted for specific information rather than read narratively
+- Authoritative through accuracy, precision, and completeness
+- Structure mirrors the product's internal architecture
+
+**What Makes It Effective**:
+
+1. **Consistency**: Standard patterns allow effective use; information in familiar formats and predictable locations
+2. **Pure description**: Describe and only describe—no recipes, instructions, or marketing claims
+3. **Illustrative examples**: Succinct usage examples that clarify functionality
+4. **Appropriate warnings**: Necessary cautions about requirements, restrictions, and limitations
+
+**Structure**: Typically covers APIs, classes, functions, commands, options, features, flags, limitations, and error messages—organized according to the machinery's logical architecture.
+
+**Distinction**: Reference provides propositional or theoretical knowledge users consult during their work, unlike the experiential focus of tutorials or action focus of how-to guides.
+
+### 4. Explanation (Understanding-Oriented)
+
+**Purpose**: Deepen reader comprehension through discursive treatment of subjects, providing context and answering "why?" questions.
+
+**Key Characteristics**:
+
+- Understanding-oriented with priority on reflection and context
+- Suited for contemplative reading away from active work
+- Takes broader perspective examining entire topics as coherent areas of knowledge
+- Less urgent than other types but equally important for preventing fragmented knowledge
+
+**Core Principles**:
+
+1. **Make connections** across topics and domains
+2. **Provide background**: Design decisions, historical context, technical constraints
+3. **Discuss alternatives** and multiple perspectives
+4. **Admit opinion**: Acknowledge that understanding involves particular viewpoints
+5. **Stay bounded**: Resist absorbing instructional or reference content
+
+**Language Patterns**:
+
+- "The reason for x is because historically, y..."
+- "An x interacts with a y as follows..."
+- Patterns that reveal underlying mechanics and justify design choices
+
+**Distinction**: Explanation provides context and understanding for study, unlike the immediate work application of how-to guides and reference material.
+
+## The Organizational Framework
+
+Diataxis uses two intersecting axes to organize the four documentation types:
+
+- **Vertical Axis**: Action (what users do) versus Cognition (what users know)
+- **Horizontal Axis**: Study (skill acquisition) versus Work (skill application)
+
+This creates four quadrants:
+
+```
+              Study                    Work
+         _______________________________________________
+        |                    |                        |
+Action  |    Tutorials       |    How-to Guides      |
+        |   (learning)       |      (tasks)          |
+        |____________________|_______________________|
+        |                    |                        |
+Cogni-  |   Explanation      |      Reference        |
+tion    | (understanding)    |    (information)      |
+        |____________________|_______________________|
+```
+
+Understanding these boundaries helps prevent common documentation problems caused by blurring categories.
+
+## The Compass: A Practical Decision Tool
+
+The compass reduces the two-dimensional Diataxis problem to two simple questions:
+
+### Question 1: Action or Cognition?
+
+- **Action** = Practical steps, doing things, hands-on work
+- **Cognition** = Theoretical knowledge, thinking, understanding
+
+### Question 2: Acquisition or Application?
+
+- **Acquisition** = Study, learning something new
+- **Application** = Work, using skills to accomplish tasks
+
+### Quick Decision Table
+
+| Need                                 | Action/Cognition | Acquisition/Application | → Type          |
+| ------------------------------------ | ---------------- | ----------------------- | --------------- |
+| "How do I get started?"              | Action           | Acquisition             | **Tutorial**    |
+| "How do I deploy to prod?"           | Action           | Application             | **How-to**      |
+| "What parameters does X accept?"     | Cognition        | Application             | **Reference**   |
+| "Why does the system work this way?" | Cognition        | Acquisition             | **Explanation** |
+
+### Critical Distinctions
+
+**Tutorial vs How-to Guide** (most commonly confused):
+
+- Tutorials: Learner may not know enough to ask questions; single path; teacher responsible
+- How-to: User knows their goal; can branch/adapt; user responsible
+
+**Reference vs Explanation**:
+
+- Reference: Turn to it while working; lists, tables, specs
+- Explanation: Read away from work (could read in the bath); answers "why?"
+
+## Benefits of Diataxis
+
+**For Users**:
+
+- Clear navigation to the right information for their current need
+- Appropriate content style for their context (learning vs. working)
+- Reduced frustration from mixed-purpose documentation
+
+**For Documentation Teams**:
+
+- Clear decision framework for what to write and where
+- Structured approach to evaluating documentation quality
+- Actionable principles for maintainers
+- Better contributor satisfaction through clear guidelines
+
+**For Organizations**:
+
+- Improved user experience
+- More maintainable documentation
+- Scalable documentation architecture
+- Proven framework adopted by industry leaders
+
+## Implementation Approach
+
+Diataxis recommends **iterative improvement from the inside out**:
+
+### What NOT to Do
+
+**Don't create empty structures.** Never create `/tutorials`, `/how-to`, `/reference`, `/explanation` folders with nothing in them. This is counterproductive and creates false expectations.
+
+### The Iterative Workflow
+
+1. **Choose any piece** of existing documentation
+2. **Apply the compass** to determine what type it should be
+3. **Improve it** according to that type's principles
+4. **Repeat**
+
+### Let Structure Emerge
+
+As you improve individual pieces, patterns will emerge that suggest organizational structure. The top-level Diataxis structure should form organically from the inside out, not be imposed top-down.
+
+**Key insight**: Diataxis changes the structure of your documentation from the inside. The structure is a guide and compass, not a plan you must complete.
+
+## Key Takeaways
+
+1. **Different needs require different documentation**: Users studying to learn need different content than users working to accomplish tasks
+2. **Separation of concerns**: Keeping documentation types distinct prevents common problems like mixing teaching with task instructions
+3. **Structure follows purpose**: Each documentation type has specific characteristics that make it effective for its purpose
+4. **User-centered design**: The framework emerges from understanding actual user needs in different contexts
+5. **Pragmatic adoption**: Implement incrementally rather than requiring wholesale changes
+6. **Quality compass**: Provides clear criteria for evaluating whether documentation serves its intended purpose
+
+---
+
+_Source: [Diataxis Framework](https://diataxis.fr/)_

--- a/.claude/skills/diataxis/references/explanation.md
+++ b/.claude/skills/diataxis/references/explanation.md
@@ -1,0 +1,181 @@
+# Explanation Documentation Reference
+
+## Overview
+
+Explanation is **understanding-oriented** documentation that deepens reader comprehension through reflective, discursive treatment of topics. It answers: "Can you tell me about&?"
+
+## Core Purpose
+
+Explanation operates at a higher, broader perspective than tutorials, how-to guides, or reference material. It focuses on theoretical knowledge and context rather than immediate application, best consumed away from active work (not during task execution).
+
+## Distance from Practice
+
+Explanation is "characterised by its distance from the active concerns of the practitioner." While potentially less urgent than other documentation types, it remains equally important for building robust understanding.
+
+## Critical Distinction: Explanation vs Reference
+
+Both provide knowledge (cognition), but for fundamentally different contexts:
+
+| Test Question                                          | If Yes → Explanation | If No → Reference |
+| ------------------------------------------------------ | -------------------- | ----------------- |
+| Could you imagine **reading this in the bath**?        | ✓                    |                   |
+| Does it primarily answer **"why?" questions**?         | ✓                    |                   |
+| Would someone turn to this **while actively working**? |                      | ✓                 |
+| Is it **lists, tables, or technical specs**?           |                      | ✓                 |
+
+**Key insight**: A tidal chart with tables of figures is clearly reference. An article explaining why there are tides and how they behave is clearly explanation.
+
+**Explanation examples:**
+
+- "About user authentication" (why the system works this way)
+- "Database architecture" (how components relate)
+- "Design decisions in the permission system"
+- "The evolution of our API design"
+
+**Reference examples (NOT explanation):**
+
+- API endpoint documentation
+- Configuration option lists
+- Error code tables
+- Command syntax specifications
+
+## Essential Guidelines
+
+### Make Connections
+
+- Link topics to related concepts, even beyond immediate scope
+- Weave understanding across domains
+- Draw relationships between different parts of the system
+- Connect to broader technical or domain concepts
+
+### Provide Context
+
+Explanation should illuminate:
+
+- **Design decisions**: Why was this approach chosen?
+- **Historical reasons**: How did this evolve over time?
+- **Technical constraints**: What limitations influenced this design?
+- **Implications**: What does this mean for users/developers?
+- **Specific examples**: Concrete illustrations of abstract concepts
+
+### Address the Bigger Picture
+
+Discussion topics should include:
+
+- **History and evolution**: How did we get here?
+- **Choices and alternatives**: What other approaches exist?
+- **Reasons and justifications**: Why this way and not another?
+- **Multiple perspectives**: Different viewpoints on the same question
+- **Trade-offs**: What are the costs and benefits?
+
+## Structural Principles
+
+### Maintain Clear Boundaries
+
+- Prevent explanation from absorbing instructional or reference content
+- Keep material focused on the defined topic area
+- Use "why questions" as prompts to define scope
+- Don't let explanation become a tutorial or how-to guide
+- Don't include detailed technical specifications (that's reference material)
+
+### Naming Convention
+
+- Use titles that allow an implicit "About" prefix
+  - Good: "User authentication" (reads as "About user authentication")
+  - Good: "The request-response cycle"
+  - Good: "Database normalization"
+- Reflects the discursive nature of the material
+- Avoids action-oriented or task-oriented phrasing
+
+## Language Patterns
+
+Effective explanation employs constructions like:
+
+- **Justification**: "The reason for x is because historically, y&"
+- **Professional judgment**: "W is better than z, because&"
+- **Contextual comparison**: "An x is analogous to w. However&"
+- **Weighing alternatives**: "Some users prefer w. This can be good, but&"
+- **Unfolding mechanics**: "An x interacts with y as follows&"
+- **Historical context**: "Originally, the system used x, but this evolved to y when&"
+- **Design rationale**: "We chose this approach because&"
+
+## Critical Attitudes
+
+### Embrace Opinion and Perspective
+
+- Acknowledge that understanding emerges from particular viewpoints
+- Present alternative approaches and counter-examples
+- Offer professional judgment and reasoned opinions
+- Think of explanation as **discussion** rather than instruction
+- It's acceptable to express preference with justification
+
+### Voice and Tone
+
+- More discursive and reflective than other documentation types
+- Can be contemplative and exploratory
+- Allows for nuance and complexity
+- Can acknowledge uncertainty or multiple valid approaches
+
+## Common Mistakes to Avoid
+
+1. **Don't underestimate explanation's importance**
+   - While less immediately urgent, it's crucial for deep understanding
+   - Without explanation, users have fragmented, surface-level knowledge
+
+2. **Don't allow instructional content to infiltrate**
+   - Keep "how to do things" in how-to guides
+   - Don't provide step-by-step instructions
+   - Link to tutorials/guides rather than embedding them
+
+3. **Don't allow technical reference to infiltrate**
+   - Keep detailed API specs, parameters, and technical descriptions in reference
+   - Link to reference material rather than duplicating it
+
+4. **Don't leave scope undefined**
+   - Use guiding questions to bound the topic
+   - Define what is and isn't covered
+   - Stay focused on the defined subject area
+
+## Reference Model
+
+Harold McGee's _On Food and Cooking_ exemplifies explanation perfectly:
+
+- Explores cooking through history, society, and science
+- **Contains no recipes** (those would be how-to guides)
+- Changes how practitioners think about their craft
+- Provides understanding rather than directing immediate action
+- Readers consume it away from the kitchen for learning
+
+## When to Write Explanation
+
+Write explanation documentation when users need to:
+
+- Understand the "why" behind design decisions
+- Grasp the broader context of a system or feature
+- Learn about alternatives and trade-offs
+- Build mental models of how components relate
+- Understand historical evolution and rationale
+- Prepare for advanced work requiring deep understanding
+
+## When NOT to Write Explanation
+
+Don't write explanation when users need to:
+
+- Learn by doing (use tutorials)
+- Accomplish a specific task (use how-to guides)
+- Look up technical details (use reference)
+- Get started quickly (use tutorials or how-to guides)
+
+## Checklist for Writing Explanation
+
+- [ ] Focuses on understanding, not action
+- [ ] Provides context and connections
+- [ ] Explores alternatives and trade-offs
+- [ ] Explains the "why" behind decisions
+- [ ] Can be read away from active work
+- [ ] Contains no step-by-step instructions
+- [ ] Contains no detailed technical specifications
+- [ ] Discusses broader concepts and relationships
+- [ ] Title works with implicit "About" prefix
+- [ ] Acknowledges multiple perspectives where appropriate
+- [ ] Links to tutorials, how-to guides, and reference as needed

--- a/.claude/skills/diataxis/references/how-to-guides.md
+++ b/.claude/skills/diataxis/references/how-to-guides.md
@@ -1,0 +1,329 @@
+# How-to Guide Documentation Reference
+
+## Overview
+
+How-to guides are **goal-oriented directions** that help users accomplish specific tasks or solve real problems. They guide action through practical steps focused on what users want to achieve.
+
+## Core Definition
+
+How-to guides assume competence and focus exclusively on helping users accomplish a specific, known goal. They are about **action and only action** no teaching, no explanation, no reference material.
+
+## Critical Distinction: How-to Guide vs Tutorial
+
+This is the **most commonly confused distinction** in documentation. Both contain steps, but they serve fundamentally different purposes:
+
+| Aspect             | How-to Guide                                                        | Tutorial                                                                                 |
+| ------------------ | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| **User knowledge** | Already knows what they want to achieve                             | Learner may not know enough to even ask the right questions                              |
+| **Approach**       | General—many things unknowable in advance or different in each case | Concrete and particular—specific, known tools and materials we've set before the learner |
+| **Path structure** | Forks and branches, different routes to same destination            | Single line, no choices or alternatives                                                  |
+| **Completeness**   | Doesn't need to be complete—starts/ends at reasonable points        | Must be complete end-to-end guide                                                        |
+| **Safety**         | Cannot promise safety—often only one chance to get it right         | Must be safe—no harm can come, always possible to go back and start again                |
+| **Responsibility** | User has responsibility for getting in and out of trouble           | Teacher has responsibility—if learner gets in trouble, teacher must fix it               |
+| **Focus**          | Work—accomplishing tasks                                            | Study—learning skills                                                                    |
+
+**Good how-to guide examples:**
+
+- "How to configure SSL certificates"
+- "How to store cellulose nitrate film"
+- "How to configure frame profiling"
+- "Troubleshooting deployment problems"
+
+**NOT how-to guides** (too broad, really need tutorials):
+
+- "How to build a web application"
+- "How to use the API"
+
+## Key Principles
+
+### 1. Focus on User Goals, Not Tools
+
+**User-Centered Perspective:**
+
+- "How-to guides must be written from the perspective of the user, not of the machinery"
+- Address real-world human needs and purposes
+- Tools should be incidental to the larger human goal
+- Think about what users want to accomplish, not what the software can do
+
+**Omit the Obvious:**
+
+- Skip trivial technical steps users should already know
+- Don't include foundational concepts or basic operations
+- Assume baseline competence with the tools
+
+**Example Distinction:**
+
+- Poor: "How to use the API" (tool-centered)
+- Good: "How to integrate application performance monitoring" (user-centered goal)
+
+### 2. Assume Competence
+
+**Target Audience:**
+
+- Serve already-competent users who know what they want to achieve
+- Users understand their goal and have chosen to pursue it
+- Don't include teaching or foundational explanations
+- Expect readers can follow instructions correctly
+
+**Not for Beginners:**
+
+- How-to guides are not tutorials
+- They don't teach from scratch
+- They guide practitioners toward specific outcomes
+
+### 3. Maintain Laser Focus
+
+**Action Only:**
+
+- Stay centered on the specific task or problem
+- Avoid digression, explanation, or reference material
+- Every sentence should advance the user toward their goal
+- Remove anything that doesn't directly serve task completion
+
+**What to Exclude:**
+
+- Teaching moments or conceptual explanations
+- Complete reference material or option catalogs
+- Historical context or design rationale
+- Exploration of alternatives (unless directly relevant)
+
+**Linking Out:**
+
+- If additional context matters, link to it externally
+- Point to explanation documentation for "why"
+- Reference API docs for complete option lists
+- Link to tutorials for foundational learning
+
+### 4. Embrace Key Characteristics
+
+**Task/Problem Focus:**
+
+- Each guide addresses one specific goal or problem
+- Title clearly states what will be accomplished
+- Content delivers on that promise exclusively
+
+**Practical Usability Over Completeness:**
+
+- Better to be useful for real scenarios than theoretically complete
+- Address actual use cases, not every possible variation
+- Optimize for practitioners doing real work
+
+## Structural Guidelines
+
+### Sequence and Logic
+
+**Temporal Order:**
+
+- Organize steps in the order they must be performed
+- Each step builds meaningfully on previous ones
+- Follow natural workflow progression
+
+**Meaningful Progression:**
+
+- Consider how users think about the task
+- Structure reflects practical necessity
+- Anticipate mental model and workflow
+
+### Flow
+
+**Smooth Progress:**
+
+- Anticipate user needs like a helpful assistant
+- Minimize context-switching between tools
+- Structure thinking progression naturally
+- "Seek flow: smooth progress"
+
+**Rhythm:**
+
+- Maintain consistent pacing
+- Balance detail with forward momentum
+- Keep users moving toward completion
+
+### Adaptability
+
+**Real-World Flexibility:**
+
+- Address real-world complexity and variation
+- Allow users to adapt guidance to their situations
+- Don't over-specify narrow use cases
+- Acknowledge when choices depend on context
+
+**Conditional Guidance:**
+
+- "If you want x, do y"
+- "When z is true, use approach a"
+- Provide decision points where relevant
+
+## Naming and Language
+
+### Title Guidelines
+
+**Clear Statement of Outcome:**
+
+- State exactly what the guide accomplishes
+- Use "How to..." format
+- Avoid ambiguous titles that leave purpose unclear
+
+**Good Examples:**
+
+- "How to integrate application performance monitoring"
+- "How to deploy a Django application"
+- "How to configure SSL certificates"
+- "How to migrate data between databases"
+
+**Poor Examples:**
+
+- "Application performance monitoring" (unclear intenttutorial? reference?)
+- "Working with databases" (too vague)
+- "Deployment" (what about it?)
+
+### Voice and Phrasing
+
+**Conditional Imperatives:**
+
+- "If you want x, do y"
+- "To accomplish z, follow these steps"
+- "When a happens, perform b"
+
+**Opening Patterns:**
+
+- "This guide shows you how to..."
+- "Follow these steps to..."
+- "To [accomplish goal], you need to..."
+
+**Reference to Other Materials:**
+
+- "Refer to the x reference guide for full options"
+- "See the y tutorial for an introduction"
+- "For background on z, consult the explanation documentation"
+
+### Imperative Tone
+
+- Direct, action-oriented language
+- "Configure the settings..."
+- "Run the command..."
+- "Add the following code..."
+
+## What NOT to Include
+
+### Tutorials Are Different
+
+- How-to guides ` complete end-to-end teaching
+- Don't try to teach concepts while guiding tasks
+- Don't include learning exercises
+- Don't explain foundational principles
+
+### Avoid Procedural-Only Thinking
+
+- Problems need adaptability, not just procedures
+- Allow for variation in user context
+- Don't be so rigid that guides fail in real scenarios
+
+### No Teaching Moments
+
+- Resist the urge to explain while instructing
+- Keep foundational explanations out
+- Link to explanation docs instead
+
+### Not a Complete Reference
+
+- Don't document every option or parameter
+- Include only what's needed for the task
+- Link to reference docs for completeness
+
+### Minimize Digression
+
+- No historical context (that's explanation)
+- No exploration of alternatives (unless directly relevant)
+- No tangential information
+- Stay on the path to goal completion
+
+## The Recipe Model
+
+Cooking recipes exemplify strong how-to documentation:
+
+**Clear Problem Statement:**
+
+- Recipe title tells you what you'll make
+- Ingredients list shows what you need
+
+**Focused Instructions:**
+
+- Steps directed at the goal
+- No tangents about history of the dish
+- No explanation of why techniques work
+
+**Required Baseline Competence:**
+
+- Assumes you can chop, stir, measure
+- Doesn't teach basic kitchen skills
+- Focuses on this specific dish
+
+**Established Format:**
+
+- Consistent structure across recipes
+- Users know what to expect
+- Easy to scan and follow
+
+**Practical Orientation:**
+
+- Real-world cooking, not culinary theory
+- Adaptable to your kitchen and ingredients
+- Gets you to edible result
+
+## Common Pitfalls
+
+1. **Mixing Teaching with Tasks**
+   - Don't explain concepts while giving instructions
+   - Keep learning and doing separate
+
+2. **Tool-Centered Writing**
+   - Don't organize around software features
+   - Focus on what users want to accomplish
+
+3. **Over-Specification**
+   - Don't make guides so narrow they're not adaptable
+   - Allow for real-world variation
+
+4. **Scope Creep**
+   - Don't let guides expand into tutorials or reference
+   - Stay focused on the single task
+
+5. **Missing the Goal**
+   - Don't forget to state what will be accomplished
+   - Make the outcome crystal clear
+
+## When to Write How-to Guides
+
+Write how-to guides when users need to:
+
+- Accomplish a specific, defined task
+- Solve a particular problem
+- Integrate your product with another system
+- Configure something for a specific use case
+- Perform a known operation successfully
+
+## When NOT to Write How-to Guides
+
+Don't write how-to guides when users need to:
+
+- Learn concepts from scratch (use tutorials)
+- Look up technical details (use reference)
+- Understand why things work (use explanation)
+- Get their first experience with the product (use tutorial)
+
+## Checklist for Writing How-to Guides
+
+- [ ] Focuses on a specific, clearly-stated goal
+- [ ] Title uses "How to..." format and states outcome
+- [ ] Assumes user competence with basics
+- [ ] User-centered, not tool-centered
+- [ ] Steps in logical, temporal order
+- [ ] Action-oriented with minimal explanation
+- [ ] Adaptable to real-world variations
+- [ ] No teaching or foundational concepts
+- [ ] No complete reference material (links instead)
+- [ ] No historical context or design rationale
+- [ ] Maintains flow and forward momentum
+- [ ] Each step advances toward the goal
+- [ ] Links to tutorials, reference, and explanation as needed

--- a/.claude/skills/diataxis/references/reference.md
+++ b/.claude/skills/diataxis/references/reference.md
@@ -1,0 +1,284 @@
+# Reference Documentation Reference
+
+## Overview
+
+Reference guides provide **technical descriptions** that are **information-oriented**. They contain propositional/theoretical knowledge users consult during work, not learn from sequentially.
+
+## Core Purpose
+
+Reference documentation serves as the authoritative source of technical truth about the product. Users consult it to look up specific information they need while working, not to learn sequentially or complete tasks.
+
+## Critical Distinction: Reference vs Explanation
+
+Both provide knowledge (cognition), but for fundamentally different contexts:
+
+| Test Question                                          | If Yes → Reference | If No → Explanation |
+| ------------------------------------------------------ | ------------------ | ------------------- |
+| Would someone turn to this **while actively working**? | ✓                  |                     |
+| Is it **lists, tables, or technical specs**?           | ✓                  |                     |
+| Could you imagine **reading this in the bath**?        |                    | ✓                   |
+| Does it primarily answer **"why?" questions**?         |                    | ✓                   |
+
+**Key insight**: A tidal chart with tables of figures is clearly reference. An article explaining why there are tides and how they behave is clearly explanation.
+
+**Reference examples:**
+
+- API endpoint documentation
+- Configuration option lists
+- Error code tables
+- Command syntax specifications
+
+**Explanation examples:**
+
+- "About user authentication" (why the system works this way)
+- "Database architecture" (how components relate)
+- "Design decisions in the permission system"
+
+## Key Principles
+
+### 1. Describe and Only Describe
+
+**Austere, Uncompromising Style:**
+
+- Maintain **neutral, objective, factual** language
+- Use an **austere and uncompromising** style
+- Prioritize accuracy, precision, completeness, and clarity
+- No opinions, no marketing, no speculation
+
+**Pure Description:**
+
+- Avoid instruction, explanation, opinion, or discussion
+- Link to tutorials, how-to guides, or explanation rather than embedding them
+- State what something **is** and what it **does**, not how to use it or why
+
+**Mirror the Machinery:**
+
+- Structure content to mirror the product's structure itself, not user tasks
+- Document the architecture as it exists
+- Help users navigate code and documentation in parallel
+
+### 2. Adopt Standard Patterns
+
+"Reference material is useful when it is consistent."
+
+**Consistency Requirements:**
+
+- Use standardized formatting throughout
+- Place information where users expect it
+- Maintain familiar formats across all reference pages
+- Create predictable patterns users can rely on
+
+**Standard Elements:**
+
+- Function/method signatures
+- Parameter descriptions
+- Return values
+- Error conditions
+- Examples of usage
+
+### 3. Respect the Structure of the Machinery
+
+**Structural Alignment:**
+
+- Documentation structure should mirror the product's structure
+- Users navigate them in parallel
+- Helps readers understand relationships between components logically
+- Reflects the internal architecture and organization
+
+**Common Reference Structures:**
+
+- APIs and endpoints
+- Classes and methods
+- Commands and subcommands
+- Configuration options
+- Data structures
+- Error codes and messages
+
+### 4. Provide Examples
+
+**Illustrative, Not Pedagogical:**
+
+- Use examples to illustrate usage succinctly
+- Show context without explaining or teaching
+- Demonstrate syntax and format
+- Keep examples minimal and focused
+
+**Example Characteristics:**
+
+- Brief and to the point
+- Show actual usage in context
+- Include input and output where relevant
+- No explanatory narrative
+
+## Language Patterns
+
+### Do Use:
+
+- **Factual statements**: "Django's default logging configuration inherits Python's defaults"
+- **Declarative descriptions**: "The `authenticate()` method returns a User object or None"
+- **Lists of capabilities**: "This command accepts the following options..."
+- **Directive warnings**: "You must use a. You must not apply b unless c."
+- **Technical specifications**: "Accepts integers between 0 and 255"
+- **Behavioral descriptions**: "When x occurs, the system responds with y"
+
+### Avoid:
+
+- Marketing claims ("best", "powerful", "easy")
+- Instructions ("First, do this, then do that")
+- Recipes or step-by-step procedures
+- Opinions or recommendations ("you should", "it's better to")
+- Explanations of why things work this way
+- Speculation about future changes
+
+## Content to Include
+
+### Essential Elements
+
+**For Functions/Methods:**
+
+- Name and signature
+- Purpose (what it does, not how to use it)
+- Parameters with types and descriptions
+- Return values and types
+- Exceptions/errors that may be raised
+- Brief usage example
+
+**For Commands:**
+
+- Command syntax
+- Available options and flags
+- Arguments and their formats
+- Output format
+- Exit codes
+- Error conditions
+
+**For APIs:**
+
+- Endpoints and methods
+- Request format and parameters
+- Response format and codes
+- Authentication requirements
+- Rate limits
+- Error responses
+
+**For Configuration:**
+
+- Setting names
+- Valid values and types
+- Default values
+- Scope and applicability
+- Dependencies and interactions
+
+### Warnings and Constraints
+
+Include appropriate warnings about:
+
+- **Requirements**: Prerequisites, dependencies
+- **Restrictions**: What cannot be done
+- **Limitations**: Boundaries and constraints
+- **Deprecated features**: Status and migration paths
+- **Breaking changes**: Version-specific behavior
+
+## Structure and Organization
+
+### Logical Hierarchy
+
+- Organize by component, not by use case
+- Follow the product's internal organization
+- Group related items together
+- Use consistent navigation patterns
+
+### Findability
+
+- Make information easy to locate
+- Use clear, predictable headings
+- Provide navigation aids (TOC, search, cross-references)
+- Link related items
+
+### Completeness
+
+- Document **everything** in the public API
+- Include all parameters, options, and configurations
+- Don't omit things because they "should be obvious"
+- Cover edge cases and special behaviors
+
+## Metaphors and Models
+
+### Map Analogy
+
+Reference functions like a **map**:
+
+- Conveys necessary information about territory
+- Users don't need to verify it firsthand
+- Provides authoritative information
+- Users consult it during their journey
+
+### Food Packaging Label
+
+Like nutrition labels:
+
+- Presents information in standardized, lawful format
+- Never mixes marketing with factual content
+- Users know exactly where to find specific information
+- Consistency enables quick scanning
+
+## Common Mistakes to Avoid
+
+1. **Mixing in Instructions**
+   - Don't include "how to" steps
+   - Link to how-to guides instead
+
+2. **Including Explanations**
+   - Don't explain why things work this way
+   - Link to explanation documentation instead
+
+3. **Marketing Language**
+   - Avoid subjective claims
+   - Stick to objective facts
+
+4. **Inconsistent Structure**
+   - Maintain the same format throughout
+   - Don't reorganize by user needs
+
+5. **Incomplete Coverage**
+   - Document everything, not just common cases
+   - Include all parameters and options
+
+6. **Opinion and Recommendation**
+   - Don't tell users what they should do
+   - Present facts, not guidance
+
+## When to Write Reference
+
+Write reference documentation for:
+
+- APIs, functions, methods, and classes
+- Commands and their options
+- Configuration settings
+- Data structures and formats
+- Error codes and messages
+- Technical specifications
+
+## When NOT to Write Reference
+
+Don't use reference format for:
+
+- Teaching concepts (use tutorials)
+- Guiding through tasks (use how-to guides)
+- Explaining design decisions (use explanation)
+- Getting started experiences (use tutorials)
+
+## Checklist for Writing Reference
+
+- [ ] Uses neutral, objective language
+- [ ] Describes what things are and do, not how to use them
+- [ ] Structure mirrors the product's internal organization
+- [ ] Follows consistent patterns throughout
+- [ ] Includes all parameters, options, and configurations
+- [ ] Provides brief usage examples
+- [ ] Contains appropriate warnings and constraints
+- [ ] No instructions, explanations, or opinions
+- [ ] Easy to scan and find specific information
+- [ ] Complete coverage of public API/interface
+- [ ] Cross-references to related items
+- [ ] Links to tutorials, how-to guides, and explanation as needed

--- a/.claude/skills/diataxis/references/tutorials.md
+++ b/.claude/skills/diataxis/references/tutorials.md
@@ -1,0 +1,353 @@
+# Tutorial Documentation Reference
+
+## Overview
+
+A tutorial is a **learning-oriented, practical activity** where students learn by doing meaningful tasks toward achievable goals. It's a lesson, not a task completion guide.
+
+## Core Definition
+
+Tutorials are experiences that enable learning through doing. The tutorial author bears primary responsibility for the learner's success. Tutorials prioritize skill and knowledge acquisition, not task completion.
+
+## The Teacher's Contract
+
+Nearly all responsibility falls on the teacher. The student's only obligation is attentiveness and following directions.
+
+**The Exercise Must Be:**
+
+- **Meaningful**: Provides sense of achievement
+- **Successful**: Completable by the learner
+- **Logical**: Coherent progression that makes sense
+- **Usefully complete**: Exposes all necessary actions, concepts, and tools
+
+## Critical Distinction: Tutorial vs How-to Guide
+
+This is the **most commonly confused distinction** in documentation. Both contain steps, but they serve fundamentally different purposes:
+
+| Aspect             | Tutorial                                                                                 | How-to Guide                                                        |
+| ------------------ | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| **User knowledge** | Learner may not know enough to even ask the right questions                              | Already knows what they want to achieve                             |
+| **Approach**       | Concrete and particular—specific, known tools and materials we've set before the learner | General—many things unknowable in advance or different in each case |
+| **Path structure** | Single line, no choices or alternatives                                                  | Forks and branches, different routes to same destination            |
+| **Completeness**   | Must be complete end-to-end guide                                                        | Doesn't need to be complete—starts/ends at reasonable points        |
+| **Safety**         | Must be safe—no harm can come, always possible to go back and start again                | Cannot promise safety—often only one chance to get it right         |
+| **Responsibility** | Teacher has responsibility—if learner gets in trouble, teacher must fix it               | User has responsibility for getting in and out of trouble           |
+| **Focus**          | Study—learning skills                                                                    | Work—accomplishing tasks                                            |
+
+**Key insight**: You will revise tutorials far more than other docs. Unlike how-to guides (which only change when the product changes), you may completely rewrite a tutorial because you found a better learning experience.
+
+## The 11 Core Principles
+
+### 1. Don't Try to Teach
+
+"Your job, as a teacher, is to provide the learner with an experience that will allow them to learn."
+
+- Focus on enabling learning through doing, not explanation
+- Provide experiences, not lectures
+- Let understanding emerge from practice
+- The learner learns by doing, not by being told
+
+### 2. Show the Destination Upfront
+
+**Orient the Learner:**
+
+- Inform learners what they'll accomplish at the start
+- Example: "In this tutorial we will create and deploy a scalable web application"
+- Avoid presumptuous "you will learn" phrasing
+- Give learners confidence in where they're heading
+
+**Why This Matters:**
+
+- Reduces anxiety and uncertainty
+- Provides context for upcoming steps
+- Helps learners see the value of the journey
+
+### 3. Deliver Visible Results Early and Often
+
+**Rapid Feedback Loops:**
+
+- Every step must produce comprehensible results
+- Learners should see changes after each action
+- Enable cause-and-effect connections repeatedly
+- Build confidence through immediate success
+
+**The Power of Results:**
+
+- Validates that learners are on track
+- Reinforces correct actions
+- Maintains engagement and motivation
+- Allows learners to verify their progress
+
+### 4. Maintain Narrative Expectations
+
+**Guide What to Expect:**
+
+- Use phrases like "You will notice that&"
+- Show actual expected output
+- Warn about likely confusion points
+- Provide reassurance throughout
+
+**Example Patterns:**
+
+- "The output should look like&"
+- "Notice that the prompt has changed to&"
+- "You should now see&"
+- "This may take a few moments&"
+
+### 5. Point Out What Learners Should Notice
+
+"Learning requires reflection."
+
+**Active Observation Guidance:**
+
+- Explicitly highlight environmental changes
+- Point out important details
+- Draw attention to significant results
+- Don't assume learners notice things independently
+
+**Examples:**
+
+- "Notice that the prompt now shows (venv)"
+- "The terminal output indicates success with&"
+- "Observe how the interface has changed&"
+
+### 6. Target the Feeling of Doing
+
+**Flow State Creation:**
+
+- Build tasks that connect: purpose � action � thinking � result
+- Create rhythmic, pleasurable progression
+- Enable the satisfaction of skilled practice
+- Let competence feel rewarding
+
+**The Doing Experience:**
+
+- Learners should feel actively engaged
+- Each step should feel purposeful
+- Progress should feel natural and inevitable
+- Success should feel earned but achievable
+
+### 7. Encourage Repetition
+
+**Repetition Reinforces:**
+
+- Allow steps to be repeated where possible
+- Users naturally repeat successful steps
+- Repetition confirms reliability
+- Reinforcement builds confidence
+
+**Why Repetition Works:**
+
+- Solidifies new skills through practice
+- Allows learners to internalize patterns
+- Builds muscle memory for workflows
+- Increases retention
+
+### 8. Ruthlessly Minimize Explanation
+
+"A tutorial is not the place for explanation."
+
+**Keep Explanations Brief:**
+
+- Learners are focused on correct execution
+- Explanation distracts from doing
+- Provide links to deeper explanation rather than embedding it
+- Brief justifications only when absolutely necessary
+
+**The Distraction Problem:**
+
+- Explanation breaks the flow
+- Diverts attention from the task
+- Cognitive load increases
+- Learners lose the thread
+
+### 9. Focus on the Concrete
+
+**Concrete Before Abstract:**
+
+- Lead "from step to concrete step"
+- Use specific examples, not generalizations
+- The mind learns concrete-to-abstract, never the reverse
+- General patterns emerge naturally from concrete practice
+
+**Concrete Examples:**
+
+- Use actual file names, not placeholders
+- Show real commands, not templates
+- Demonstrate with specific values
+- Let abstraction emerge through experience
+
+### 10. Ignore Options and Alternatives
+
+**Single Path Only:**
+
+- Exclude alternative commands or approaches
+- No optional steps or variations
+- Don't discuss different API methods
+- Keep guidance focused on one successful path
+
+**Why Single Path:**
+
+- Prevents decision paralysis
+- Reduces cognitive load
+- Ensures tutorial reliability
+- Allows focus on learning, not choosing
+
+### 11. Aspire to Perfect Reliability
+
+"Confidence builds incrementally and shatters quickly."
+
+**Zero Tolerance for Failure:**
+
+- Every promised result must materialize
+- Tutorial must work every single time
+- Test extensively with actual users
+- Discover and eliminate hidden gaps
+
+**The Confidence Factor:**
+
+- One failure destroys trust
+- Learners blame themselves for tutorial problems
+- Unreliable tutorials create lasting negative impressions
+- Perfect reliability is non-negotiable
+
+## Anti-Pedagogical Temptations to Avoid
+
+These common patterns sabotage learning:
+
+1. **Abstraction and generalization**: Stay concrete
+2. **Explanation and exposition**: Link to it, don't embed it
+3. **Presenting choices**: Provide one clear path
+4. **Information overload**: Ruthlessly minimize content
+
+## Language Patterns
+
+| Pattern                    | Purpose                            | Example                                            |
+| -------------------------- | ---------------------------------- | -------------------------------------------------- |
+| "We..."                    | Affirm tutor-learner collaboration | "In this tutorial, we will build&"                 |
+| Imperative sequence        | Remove ambiguity                   | "First, do x. Now, do y. Next, do z."              |
+| Minimal justification      | Provide just enough rationale      | "We must do x before y because& (see Explanation)" |
+| Expected output            | Set clear expectations             | "The output should look like: [example]"           |
+| Observation cues           | Guide attention                    | "Notice that& Remember that& Let's check&"         |
+| Achievement acknowledgment | Affirm accomplishment              | "You have built a secure, three-layer application" |
+
+## Voice and Tone
+
+### Collaborative "We"
+
+- "We will create a new file"
+- "Now we'll add the configuration"
+- "Let's run the command together"
+- Emphasizes partnership in learning
+
+### Confident, Reassuring
+
+- Maintain certainty throughout
+- Assure learners they're on the right track
+- Acknowledge achievements
+- Build confidence incrementally
+
+### Active and Present
+
+- Use present tense for actions
+- Keep learners engaged in the moment
+- Focus on immediate next step
+- Maintain forward momentum
+
+## Tutorial vs. How-to Guide Distinction
+
+**Tutorials:**
+
+- Emphasis on **acquisition and study**
+- For learning new skills
+- Teacher bears responsibility
+- Complete learning journey
+- Appropriate for novices
+- Focus on education
+
+**How-to Guides:**
+
+- Facilitate **task completion**
+- For applying known skills
+- User bears responsibility
+- Focused problem-solving
+- Assume competence
+- Focus on productivity
+
+## The Cooking Analogy
+
+Teaching a child to cook illustrates tutorial principles perfectly:
+
+**Success Criteria:**
+
+- Child learns skills and gains pleasure
+- Not about perfect culinary output
+- Learning happens "through the activities" together
+- Not from instruction alone
+
+**Incomplete Is Acceptable:**
+
+- If the child achieved something
+- If the child enjoyed it
+- Skills will develop over time
+- Foundation matters most
+
+## Special Challenges of Tutorials
+
+### Maintenance Burden
+
+- Tutorials cascade through documentation
+- Changes ripple across entire narrative
+- Product evolution requires ongoing updates
+- Breaking changes are especially problematic
+
+### No Instructor Present
+
+- Can't correct mistakes in real-time
+- Can't check understanding
+- Can't adapt to learner needs
+- Must anticipate all problems
+
+### Design Complexity
+
+- Balancing "what to learn" and "what to do"
+- Requires careful sequencing
+- Must maintain perfect reliability
+- Needs extensive testing with real users
+
+## When to Write Tutorials
+
+Write tutorials when users need to:
+
+- Get their first hands-on experience
+- Learn fundamental concepts through practice
+- Build confidence with a new tool or system
+- Understand basic workflows
+- Achieve an early success that motivates further learning
+
+## When NOT to Write Tutorials
+
+Don't write tutorials when users need to:
+
+- Complete a specific task (use how-to guides)
+- Look up technical information (use reference)
+- Understand why things work (use explanation)
+- Apply skills they already have (use how-to guides)
+
+## Checklist for Writing Tutorials
+
+- [ ] Learning-oriented, not task-oriented
+- [ ] Shows destination at the beginning
+- [ ] Every step produces visible results
+- [ ] Maintains narrative expectations throughout
+- [ ] Points out what learners should notice
+- [ ] Creates the feeling of doing
+- [ ] Allows repetition where possible
+- [ ] Minimizes explanation (links to it instead)
+- [ ] Focuses on concrete steps, not abstractions
+- [ ] Ignores options and alternatives
+- [ ] Tested for perfect reliability
+- [ ] Uses "we" language to build partnership
+- [ ] Acknowledges learner achievements
+- [ ] No choices or decision points
+- [ ] Complete learning experience from start to finish
+- [ ] Links to how-to guides, reference, and explanation as needed

--- a/src/docs/.vitepress/config.mts
+++ b/src/docs/.vitepress/config.mts
@@ -27,11 +27,15 @@ export default defineConfig({
       {
         text: 'Guides',
         items: [
+          { text: 'Command Handling', link: '/guides/command-handling' },
           { text: 'Read Models', link: '/guides/projections' },
           { text: 'Testing', link: '/guides/testing' },
           { text: 'Error Handling', link: '/guides/error-handling' },
           { text: 'Workflows', link: '/guides/workflows' },
-          { text: 'Choosing an Event Store', link: '/guides/choosing-event-store' },
+          {
+            text: 'Choosing an Event Store',
+            link: '/guides/choosing-event-store',
+          },
         ],
       },
       {
@@ -69,11 +73,15 @@ export default defineConfig({
       {
         text: 'Guides',
         items: [
+          { text: 'Command Handling', link: '/guides/command-handling' },
           { text: 'Read Models', link: '/guides/projections' },
           { text: 'Testing', link: '/guides/testing' },
           { text: 'Error Handling', link: '/guides/error-handling' },
           { text: 'Workflows', link: '/guides/workflows' },
-          { text: 'Choosing an Event Store', link: '/guides/choosing-event-store' },
+          {
+            text: 'Choosing an Event Store',
+            link: '/guides/choosing-event-store',
+          },
         ],
       },
       {

--- a/src/docs/api-reference/commandhandler.md
+++ b/src/docs/api-reference/commandhandler.md
@@ -7,189 +7,154 @@ outline: deep
 
 ## Overview
 
-A command handler processes a command against a single event stream. The command is an intention, such as adding an item to a cart; your business logic decides what should happen; the events it returns are the outcome that gets stored.
+`CommandHandler` processes a command against a single event stream. Each call builds the current state from the stream's events with `evolve` and `initialState`, runs the decision, and appends the events it returns under an optimistic concurrency check.
 
-Use it whenever a command writes to a single stream. It saves you from repeating this flow by hand, and it applies the optimistic concurrency check that stops two commands on the same stream from overwriting each other.
+It builds on the event store's [`aggregateStream`](/api-reference/eventstore#aggregatestream) and [`appendToStream`](/api-reference/eventstore#appendtostream). The [Decider](/api-reference/decider) keeps `decide`, `evolve`, and `initialState` together as a single object. For setup and usage, see the [Command Handling](/guides/command-handling) guide.
 
-On each call it loads the stream and folds its events into the current state with `evolve` and `initialState`, runs your decision function, and appends the returned events using the version it read as the expected version. It builds on the event store's [`aggregateStream`](/api-reference/eventstore#aggregatestream) and [`appendToStream`](/api-reference/eventstore#appendtostream); when you'd rather keep `decide`, `evolve`, and `initialState` together as one object, the [Decider](/api-reference/decider) is the more structured alternative.
+## Construction
 
-## Basic Usage
-
-Configure a handler once with `evolve` and `initialState`, then reuse it across the app, calling it for each command with a stream id and one or more decision functions.
-
-### Creating a handler {#create}
+`CommandHandler(options)` returns the handler function. It takes three type parameters: `State`, `StreamEvent` (the discriminated union written to the stream), and an optional `EventPayloadType` (the stored shape when it differs from `StreamEvent`, used with schema versioning).
 
 <<< @/snippets/gettingStarted/commandHandler.ts#command-handler
-
-### Handling a command {#handle}
-
-<<< @/snippets/gettingStarted/commandHandling.ts#command-handling
-
-## Type Definitions
-
-`CommandHandler` takes three type parameters: `State`, `StreamEvent` (the discriminated union written to the stream), and an optional `EventPayloadType` (the stored shape when it differs from `StreamEvent`, used with schema versioning). It returns an async function whose third argument is either a single handler or an **array** of handlers. The full signatures are shown under [Type Source](#type-source); the tables below summarise them.
 
 ### CommandHandlerOptions
 
 | Property               | Type                                          | Description                                                                        |
 | ---------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `evolve`               | `(state: State, event: StreamEvent) => State` | Folds an event into state. Required.                                               |
+| `evolve`               | `(state: State, event: StreamEvent) => State` | Applies an event to the state, returning the next state. Required.                 |
 | `initialState`         | `() => State`                                 | Starting state for a stream with no events. Required.                              |
 | `mapToStreamId`        | `(id: string) => string`                      | Maps the business id to the stream name. Defaults to the identity function.        |
-| `retry`                | `CommandHandlerRetryOptions`                  | Retry policy for version conflicts. See [Retry Configuration](#retries).           |
-| `schema.versioning`    | `{ upcast?; downcast? }`                      | Converts stored events to and from `StreamEvent` for schema evolution.             |
-| `serialization`        | `{ serializer?; ... }`                        | Custom serialiser for reading and writing events.                                  |
+| `retry`                | `CommandHandlerRetryOptions`                  | Retry policy for version conflicts. See [Retry](#retry).                           |
+| `schema.versioning`    | `{ upcast?; downcast? }`                      | Converts stored events to and from `StreamEvent`. See [Advanced](#advanced).       |
+| `serialization`        | `{ serializer?; serializerOptions? }`         | Custom serialiser for reading and writing events. See [Advanced](#advanced).       |
 | `name` / `commandType` | `string` / `string \| string[]`               | Labels used for observability and as the default command type when none is passed. |
-| `observability`        | `CommandObservabilityConfig`                  | Tracing and metrics configuration.                                                 |
+| `observability`        | `CommandObservabilityConfig`                  | Tracing and metrics configuration. See [Advanced](#advanced).                      |
 
-### CommandHandlerResult
+## Calling the Handler
 
-Each call returns the new state, the events it appended, and the version to pass on the next call. For the stores shipped with Emmett:
+The handler is called as `handle(eventStore, id, decision, options?)`, with the event store, the business id, the decision, and optional per-call options. The third argument is a single decision or an array of decisions run in order (see [Decisions](#decisions)).
 
-| Property                    | Type                                                | Description                                                      |
-| --------------------------- | --------------------------------------------------- | ---------------------------------------------------------------- |
-| `newState`                  | `State`                                             | State after applying the newly produced events.                  |
-| `newEvents`                 | `StreamEvent[]`                                     | Events that were appended, empty when the handler produced none. |
-| `nextExpectedStreamVersion` | `StreamPosition` (`bigint` for the built-in stores) | Pass this as `expectedStreamVersion` on the next call.           |
-| `createdNewStream`          | `boolean`                                           | Whether this call created the stream.                            |
+### HandleOptions
 
-`nextExpectedStreamVersion` and `createdNewStream` come from the store you're using, so their exact type depends on it.
+| Property                | Type                         | Description                                                                                                     |
+| ----------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `expectedStreamVersion` | `ExpectedStreamVersion`      | Version the stream must be at for the append to succeed. Defaults to the version read at the start of the call. |
+| `retry`                 | `CommandHandlerRetryOptions` | Retry policy for this call. Overrides the handler-level `retry`.                                                |
 
-## Stream ID Mapping
+## Decisions
 
-The id you pass to the handler is not always the stream's name. A cart id, for example, might map to a stream named `shopping_cart:{id}`. Set `mapToStreamId` to build the stream name from the id; you keep passing the business id, and the handler applies the mapping.
+A decision receives the current state and returns the events to append. It returns a single event, an array of events, or an empty array when there is nothing to append, and throws to reject the command. It may be synchronous or asynchronous, returning the events or a `Promise` of them.
 
-<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#stream-id-mapping
-
-## Handler Functions
-
-A handler receives the current state and returns one or more events to append.
-
-### Single event {#single-event}
-
-A decision that produces one outcome returns a single event:
+A single event:
 
 <<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#single-event-decision
 
-The handler appends it and reports the new state:
-
-<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#single-event
-
-### Multiple events {#multiple-events}
-
-Return an array when a decision produces several events:
+Several events, appended in one write so the stream is never left holding only some of them:
 
 <<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#multiple-events-decision
 
-The call is unchanged; the events are appended in a single operation, so the stream cannot be left holding only some of them:
-
-<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#multiple-events
-
-### Sequential handlers {#sequential-handlers}
-
-Pass an array of handlers to run several decisions in order. Each runs on the state produced by the handlers before it, and all their events are appended in a single write:
+An array of decisions runs in order. Each receives the state left by the previous one, and all their events are appended in a single write:
 
 <<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#sequential-handlers
 
-## Optimistic Concurrency
+An empty array is a no-op. The decision returns it when the current state leaves nothing to do:
 
-The handler keeps the version it read from the stream and requires the stream to still be at that version when it appends. If another writer has changed the stream in between, the append fails with `ExpectedVersionConflictError` (a `ConcurrencyError`) instead of overwriting their events.
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#empty-array-no-op
 
-### Automatic version tracking {#automatic-version}
+## Result
 
-By default the handler reuses the version it read, so you don't need to pass one:
+Each call resolves to `CommandHandlerResult`:
 
-<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#automatic-version
+| Property                    | Type                                                | Description                                                  |
+| --------------------------- | --------------------------------------------------- | ------------------------------------------------------------ |
+| `newState`                  | `State`                                             | State after applying the produced events.                    |
+| `newEvents`                 | `StreamEvent[]`                                     | Events appended, empty when the decision produced none.      |
+| `nextExpectedStreamVersion` | `StreamPosition` (`bigint` for the built-in stores) | Version to pass as `expectedStreamVersion` on the next call. |
+| `createdNewStream`          | `boolean`                                           | Whether this call created the stream.                        |
 
-`nextExpectedStreamVersion` in the result is the stream's version after this append. The [ETag concurrency](#etag) example returns it to the client, which sends it back to guard its next write.
+`nextExpectedStreamVersion` and `createdNewStream` come from the store in use, so their exact type depends on it.
 
-### Explicit version {#explicit-version}
-
-Pass `expectedStreamVersion` when the version to check comes from outside the handler, such as a client's `If-Match` header. The append then succeeds only if the stream is still at that version:
-
-<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#explicit-version
-
-### New-stream requirement {#require-new-stream}
-
-Pass `STREAM_DOES_NOT_EXIST` as the expected version so the append succeeds only if the stream does not exist yet. This enforces that the stream is created exactly once:
-
-<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#require-new-stream
-
-## Retry Configuration {#retries}
-
-Set `retry` so Emmett re-runs the handler when a version conflict occurs.
-
-`{ onVersionConflict: true }` applies Emmett's default conflict policy (**3 retries, a 100&nbsp;ms minimum timeout, and a 1.5× backoff factor**), retrying only on `ExpectedVersionConflictError`:
-
-<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#retry-on-conflict
-
-Pass a number (`{ onVersionConflict: 5 }`) to keep that policy but change the retry count. For full control, such as a different backoff or retrying on errors other than version conflicts, pass `AsyncRetryOptions` with your own `shouldRetryError`:
-
-<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#custom-retry
-
-You can also set `retry` per call in the handle options, which overrides the handler-level policy for that call.
-
-## No-Op Handling
-
-A decision returns an empty array when the current state leaves it nothing to do. Confirming a cart that is already confirmed is the common case:
-
-<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#confirm-decision
-
-The handler then appends nothing and returns the current version with `newEvents: []` and `createdNewStream: false`, so re-sending the command is safe:
+When the decision returns an empty array, nothing is appended and the result carries `newEvents: []`, `createdNewStream: false`, and the current version:
 
 <<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#no-op
 
+## Stream ID Mapping
+
+`mapToStreamId` derives the stream name from the business id; the business id is still passed to the decision. It defaults to the identity function.
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#stream-id-mapping
+
+## Optimistic Concurrency
+
+The handler appends with an expected version and fails with `ExpectedVersionConflictError` (a `ConcurrencyError`) when the stream has moved on since it was read.
+
+### Version read from the stream {#read-version}
+
+With no `expectedStreamVersion` passed, the handler expects the version it read from the stream at the start of the call. `nextExpectedStreamVersion` in the result is the version after the append.
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#automatic-version
+
+### Explicit expected version {#explicit-expected-version}
+
+`expectedStreamVersion` sets the expected version explicitly, such as one carried in a client's `If-Match` header. The append succeeds only if the stream is still at that version.
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#explicit-version
+
+### Expecting a new stream {#new-stream}
+
+`STREAM_DOES_NOT_EXIST` as the expected version makes the append succeed only if the stream does not exist yet.
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#require-new-stream
+
+## Retry
+
+`retry` re-runs the decision and append when a version conflict is retryable. `CommandHandlerRetryOptions` takes three forms:
+
+- `{ onVersionConflict: true }` applies the default policy.
+- `{ onVersionConflict: number }` applies the default policy with a different retry count.
+- `AsyncRetryOptions` is a full custom policy, including its own `shouldRetryError`.
+
+Left `undefined`, retries are disabled. A per-call `retry` in the handle options overrides the handler-level policy.
+
+The default policy retries only on `ExpectedVersionConflictError`:
+
+| Field        | Value    |
+| ------------ | -------- |
+| `retries`    | `3`      |
+| `minTimeout` | `100` ms |
+| `factor`     | `1.5`    |
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#retry-on-conflict
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#custom-retry
+
 ## Error Handling
 
-### Business-rule errors {#business-errors}
+A decision throws to reject a command; the handler appends nothing and propagates the error unchanged. A version conflict is thrown by the append.
 
-If a command breaks a business rule, throw from the decision: `IllegalStateError` for an invalid state transition, `ValidationError` for bad input. Nothing gets appended, and the error reaches the caller unchanged:
+| Error                                               | Code  | Raised when                                                                |
+| --------------------------------------------------- | ----- | -------------------------------------------------------------------------- |
+| `ValidationError`                                   | `400` | The command carries invalid input.                                         |
+| `IllegalStateError`                                 | `403` | The command is not valid for the current state.                            |
+| `ExpectedVersionConflictError` (`ConcurrencyError`) | `412` | The stream moved on; carries `expected` and `current` versions as strings. |
 
 <<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#business-error
 
-### Concurrency errors {#concurrency-errors}
-
-A version conflict throws `ExpectedVersionConflictError`, which extends `ConcurrencyError`. Both carry the `expected` and `current` versions as strings, so you can report what happened to the caller:
-
 <<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#concurrency-error
 
-## Integration with Web Frameworks
+## Advanced
 
-### Express.js {#express}
+### Schema versioning
 
-`emmett-expressjs` wraps a handler with `on`: call the command handler, then return a response helper. Fetch any data the decision needs, such as the unit price, **before** calling the handler and pass it into the command; this keeps the decision pure. The first write creates the stream:
+`schema.versioning.upcast` maps a stored event to the current `StreamEvent` shape on read; `schema.versioning.downcast` maps a `StreamEvent` back to its stored shape on write. Together they carry a stream through event schema evolution.
 
-<<< @/snippets/gettingStarted/webApi/simpleApi.ts#add-product-item-endpoint{17,23-25}
+### Serialization
 
-### ETag concurrency {#etag}
+`serialization.serializer` replaces the default JSON serialiser used to read and write events; `serialization.serializerOptions` configures the default one.
 
-To expose optimistic concurrency over HTTP, carry the version in a weak ETag. Read the client's version from the `If-Match` header with `getETagValueFromIfMatch`, pass it as `expectedStreamVersion`, and return the new version via `toWeakETag(result.nextExpectedStreamVersion)`:
+### Observability
 
-<<< @./../packages/emmett-expressjs/src/e2e/commandHandler/api.ts#etag-command-handler
-
-A stale `If-Match` makes the handler throw `ExpectedVersionConflictError`, which `emmett-expressjs` maps to **HTTP 412 Precondition Failed**.
-
-## Best Practices {#best-practices}
-
-### Keep the Decision Pure {#best-practices-keep-pure}
-
-A handler that only reads state and returns events is easy to test and safe to retry. When a decision needs external data, such as a price or an exchange rate, fetch it **before** the handler and pass it in, as the [Express.js example](#express) does with the unit price.
-
-The handler can be `async`, and Emmett awaits it. Avoid I/O inside it, because on a version conflict the whole handler re-runs, so the call is made again on every retry:
-
-<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#async-handler
-
-### Guard Before Deciding {#best-practices-guard-first}
-
-Throw `IllegalStateError` or `ValidationError` before building any event, so an invalid command never produces one. The [`confirm` decision](#no-op-handling) does this: it refuses to confirm an empty cart. See [Error Handling](#error-handling) for how those errors reach the caller.
-
-### Type Events as a Discriminated Union {#best-practices-type-events}
-
-Declare your events as a discriminated union and pass it as `CommandHandler`'s `StreamEvent`:
-
-<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#event-union
-
-`evolve` and every handler's return value are then checked against that union, and unknown event types surface at compile time.
+`name` labels the handler in traces and metrics. `commandType` sets the default command type used when a call passes none. `observability` (`CommandObservabilityConfig`) configures tracing and metrics for the handler.
 
 ## Type Source
 
@@ -197,6 +162,7 @@ For the full signatures, see [`handleCommand.ts`](https://github.com/event-drive
 
 ## See also {#see-also}
 
+- [Command Handling](/guides/command-handling)
 - [Getting Started - Command Handling](/getting-started#command-handling)
 - [Command](/api-reference/command)
 - [Decider Pattern](/api-reference/decider)

--- a/src/docs/getting-started.md
+++ b/src/docs/getting-started.md
@@ -190,6 +190,8 @@ Such handlers should be defined per stream type (e.g., one for Shopping Cart, th
 
 You could put such code, e.g. in your WebApi endpoint. Let's go to the next step and use that in practice in the real web application.
 
+See the [Command Handling](/guides/command-handling) guide for writing decisions, controlling concurrency, retries, and wiring the handler to HTTP.
+
 ## Application Setup
 
 Seems like we have our business rules modelled, business logic reflected in code, and even tested. You also know how to write application code for handling commands. Isn't that cool? That's nice, but we need to build real applications, which nowadays typically mean a Web Application. Let's try to do it as well.

--- a/src/docs/guides/command-handling.md
+++ b/src/docs/guides/command-handling.md
@@ -1,0 +1,135 @@
+---
+documentationType: how-to-guide
+outline: deep
+---
+
+# Command Handling {#command-handling}
+
+A command is an intention to run business logic: add an item to a cart, confirm an order. Handling it means loading the stream, rebuilding the current state from its events, running your decision, and appending the events the decision returns under an optimistic concurrency check. This guide shows you how to set up a command handler, write the decision that holds your business logic, and control the concurrency, retries, and HTTP layer around it. For the full API surface, see the [Command Handler reference](/api-reference/commandhandler).
+
+## Create a Handler {#create-handler}
+
+Configure a handler once with `evolve` and `initialState`, then reuse it across the application:
+
+<<< @/snippets/gettingStarted/commandHandler.ts#command-handler
+
+## Write the Decision {#decision}
+
+A decision receives the current state and the command, and returns the events to append. It holds your business logic: it decides what happens, and it is the one place a business rule is enforced.
+
+### Return one event {#single-event}
+
+When a command produces a single outcome, return one event:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#single-event-decision
+
+### Return several events {#multiple-events}
+
+Return an array when one command produces several outcomes. The handler appends them together in a single write, so the stream cannot be left holding only some of them:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#multiple-events-decision
+
+### Guard against an invalid state {#guard-state}
+
+Throw `IllegalStateError` before building any event, so an invalid transition never produces one. The same decision returns an empty array when the state leaves nothing to do, which keeps re-sending the command safe:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#confirm-decision
+
+### Validate the input {#validate-input}
+
+Throw `ValidationError` when the command carries bad input, again before producing any event:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#validation-error-decision
+
+## Handle a Command {#handle}
+
+Call the handler with the event store, the stream id, and your decision. It loads the stream, runs the decision, and appends the result, returning `nextExpectedStreamVersion` to carry into the next call:
+
+<<< @/snippets/gettingStarted/commandHandling.ts#command-handling
+
+## Run Several Decisions in Order {#sequential}
+
+Pass an array of decisions to run them in sequence. Each runs on the state left by the ones before it, and all their events are appended in a single write:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#sequential-handlers
+
+## Control Concurrency {#concurrency}
+
+By default the handler reuses the version it read from the stream, so you do not pass one and concurrent writers cannot overwrite each other:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#automatic-version
+
+### Guard with a client's version {#explicit-version}
+
+When the version comes from outside, such as a client's `If-Match` header, pass it as `expectedStreamVersion`. The append then succeeds only if the stream is still at that version:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#explicit-version
+
+### Create a stream exactly once {#create-once}
+
+Pass `STREAM_DOES_NOT_EXIST` so the append succeeds only when the stream does not exist yet:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#require-new-stream
+
+A stale version throws `ExpectedVersionConflictError`. See [Optimistic Concurrency](/api-reference/commandhandler#optimistic-concurrency) in the reference for the full behaviour.
+
+## Retry on Conflict {#retry}
+
+Set `retry` so Emmett re-runs the handler when a version conflict occurs. `{ onVersionConflict: true }` applies the default policy:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#retry-on-conflict
+
+For a different backoff, or to retry on errors other than version conflicts, pass your own `shouldRetryError`:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#custom-retry
+
+## Integrate with Express {#express}
+
+`emmett-expressjs` wraps a handler with `on`. Fetch any data the decision needs, such as the unit price, before calling the handler and pass it into the command, which keeps the decision pure. The first write creates the stream:
+
+<<< @/snippets/gettingStarted/webApi/simpleApi.ts#add-product-item-endpoint{17,23-25}
+
+### Carry the version in an ETag {#etag}
+
+To expose optimistic concurrency over HTTP, read the client's version from the `If-Match` header with `getETagValueFromIfMatch`, pass it as `expectedStreamVersion`, and return the new version with `toWeakETag`. A stale `If-Match` maps to HTTP 412 Precondition Failed:
+
+<<< @./../packages/emmett-expressjs/src/e2e/commandHandler/api.ts#etag-command-handler
+
+## Best Practices {#best-practices}
+
+### Keep the Decision Pure {#keep-pure}
+
+A decision that only reads state and returns events is easy to test and safe to retry. When it needs external data, such as a price or an exchange rate, fetch it before the handler and pass it in. Avoid I/O inside the decision: on a version conflict the whole handler re-runs, so the call fires again on every retry:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#async-handler
+
+### Type Events as a Discriminated Union {#type-events}
+
+Declare your events as a discriminated union and pass it as the handler's `StreamEvent`. `evolve` and every decision are then checked against it, and unknown event types surface at compile time:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#event-union
+
+## Troubleshooting {#troubleshooting}
+
+### Version Conflict on Every Write {#always-conflicts}
+
+If every write throws `ExpectedVersionConflictError`, the expected version you pass is stale. When you track the version yourself, pass the `nextExpectedStreamVersion` from the previous result into the next call. When a client supplies it, return the new version as an ETag so the next request carries the current one. To let Emmett recover on its own, set [`retry`](#retry).
+
+### Nothing Is Appended {#nothing-appended}
+
+If a command runs without error yet no events land, the decision returned an empty array. That is the no-op path, taken when the state leaves nothing to do, such as confirming an already-confirmed cart. Check the guard that returns `[]`.
+
+### A Side Effect Fires Twice {#double-side-effect}
+
+If an external call inside a decision fires more than once, a version conflict retried the handler and re-ran the decision. Move the I/O out of the decision and pass its result in, as [Keep the Decision Pure](#keep-pure) shows.
+
+## Further Readings {#readings}
+
+- [Getting Started - Command Handling](/getting-started#command-handling)
+- [API Reference: Command Handler](/api-reference/commandhandler)
+- [API Reference: Command](/api-reference/command)
+- [Decider Pattern](/api-reference/decider)
+- [Event Store](/api-reference/eventstore)
+- [Error Handling](/guides/error-handling)
+- [Testing](/guides/testing)
+- [Optimistic Concurrency for Pessimistic Times](https://event-driven.io/en/optimistic_concurrency_for_pessimistic_times/)

--- a/src/packages/emmett/src/commandHandling/handleCommand.unit.spec.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.unit.spec.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from 'node:crypto';
 import { describe, it } from 'vitest';
-import { ConcurrencyError, IllegalStateError } from '../errors';
+import {
+  ConcurrencyError,
+  IllegalStateError,
+  ValidationError,
+} from '../errors';
 import {
   ExpectedVersionConflictError,
   getInMemoryEventStore,
@@ -25,7 +29,7 @@ type PricedProductItem = { productId: string; quantity: number; price: number };
 type ShoppingCart = {
   productItems: PricedProductItem[];
   totalAmount: number;
-  status: 'Opened' | 'Confirmed';
+  status: 'Opened' | 'Confirmed' | 'Cancelled';
 };
 
 type ProductItemAdded = Event<
@@ -37,10 +41,17 @@ type ShoppingCartConfirmed = Event<
   'ShoppingCartConfirmed',
   { confirmedAt: Date }
 >;
+type ShoppingCartCancelled = Event<
+  'ShoppingCartCancelled',
+  { canceledAt: Date }
+>;
 
 // #region event-union
 type ShoppingCartEvent =
-  ProductItemAdded | DiscountApplied | ShoppingCartConfirmed;
+  | ProductItemAdded
+  | DiscountApplied
+  | ShoppingCartConfirmed
+  | ShoppingCartCancelled;
 // #endregion event-union
 
 const evolve = (
@@ -64,6 +75,8 @@ const evolve = (
       };
     case 'ShoppingCartConfirmed':
       return { ...state, status: 'Confirmed' };
+    case 'ShoppingCartCancelled':
+      return { ...state, status: 'Cancelled' };
   }
 };
 
@@ -89,6 +102,21 @@ const addProductItem = (
   };
 };
 // #endregion single-event-decision
+
+type ApplyDiscount = Event<'ApplyDiscount', { percent: number }>;
+
+// #region validation-error-decision
+const applyDiscount = (
+  command: ApplyDiscount,
+  _state: ShoppingCart,
+): ShoppingCartEvent => {
+  // Reject invalid input before producing any event
+  if (command.data.percent <= 0 || command.data.percent > 1)
+    throw new ValidationError('Discount percent has to be between 0 and 1');
+
+  return { type: 'DiscountApplied', data: { percent: command.data.percent } };
+};
+// #endregion validation-error-decision
 
 const defaultDiscount = 0.1;
 
@@ -125,6 +153,22 @@ const confirm = (
   ];
 };
 // #endregion confirm-decision
+
+type CancelShoppingCart = Event<'CancelShoppingCart', { now: Date }>;
+
+// #region empty-array-no-op
+const cancel = (
+  command: CancelShoppingCart,
+  state: ShoppingCart,
+): ShoppingCartEvent[] => {
+  // Already cancelled: nothing left to do, so append nothing
+  if (state.status === 'Cancelled') return [];
+
+  return [
+    { type: 'ShoppingCartCancelled', data: { canceledAt: command.data.now } },
+  ];
+};
+// #endregion empty-array-no-op
 
 const handleCommand = CommandHandler<ShoppingCart, ShoppingCartEvent>({
   evolve,
@@ -249,6 +293,31 @@ void describe('Command Handler', () => {
     assertThatArray(newEvents).isEmpty();
     assertFalse(createdNewStream);
     assertEqual(nextExpectedStreamVersion, confirmedVersion);
+  });
+
+  void it('appends nothing when a decision returns an empty array', async () => {
+    const shoppingCartId = randomUUID();
+    const cancelCart: CancelShoppingCart = {
+      type: 'CancelShoppingCart',
+      data: { now: new Date() },
+    };
+
+    // cancel once
+    const { nextExpectedStreamVersion: cancelledVersion } = await handleCommand(
+      eventStore,
+      shoppingCartId,
+      (state) => cancel(cancelCart, state),
+    );
+
+    // cancelling an already-cancelled cart is a no-op, so nothing is appended
+    const { newEvents, nextExpectedStreamVersion, createdNewStream } =
+      await handleCommand(eventStore, shoppingCartId, (state) =>
+        cancel(cancelCart, state),
+      );
+
+    assertThatArray(newEvents).isEmpty();
+    assertFalse(createdNewStream);
+    assertEqual(nextExpectedStreamVersion, cancelledVersion);
   });
 
   void it('Creates new stream on first command and follows up with next expected version', async () => {
@@ -509,6 +578,21 @@ void describe('Command Handler', () => {
     // #endregion business-error
 
     await assertThrowsAsync(run, (error) => error instanceof IllegalStateError);
+  });
+
+  void it('propagates a validation error thrown by the handler', async () => {
+    const shoppingCartId = randomUUID();
+    const applyInvalidDiscount: ApplyDiscount = {
+      type: 'ApplyDiscount',
+      data: { percent: 1.5 },
+    };
+
+    const run = () =>
+      handleCommand(eventStore, shoppingCartId, (state) =>
+        applyDiscount(applyInvalidDiscount, state),
+      );
+
+    await assertThrowsAsync(run, (error) => error instanceof ValidationError);
   });
 
   void describe('retries', () => {


### PR DESCRIPTION
I realised that the command handling reference reads more like a "how-to guide" than a reference, and that we're also missing the command handling guide. That's why I broke it down into two docs, slimming down the reference to focus.

Added also diataxis skill for future use.

@thiagomini @SamHatoum @tburny  FYI.