### PR TITLE
Improved reactors error handling docs to be clearer about the details

### DIFF
--- a/src/docs/api-reference/commandhandler.md
+++ b/src/docs/api-reference/commandhandler.md
@@ -114,7 +114,7 @@ With no `expectedStreamVersion` passed, the handler expects the version it read 
 - `{ onVersionConflict: number }` applies the default policy with a different retry count.
 - `AsyncRetryOptions` is a full custom policy, including its own `shouldRetryError`.
 
-Left `undefined`, retries are disabled. A per-call `retry` in the handle options overrides the handler-level policy.
+Left `undefined`, retries are disabled. A per-call `retry` in the handle options overrides the handler-level policy. For deciding which errors are transient enough to retry, see [Retry a Transient Failure](/guides/error-handling#retry) in the Error Handling guide.
 
 The default policy retries only on `ExpectedVersionConflictError`:
 

--- a/src/docs/api-reference/projections.md
+++ b/src/docs/api-reference/projections.md
@@ -452,4 +452,5 @@ const handle = async (events, context) => {
 - [Read Models Guide](/guides/projections) - Detailed patterns and strategies
 - [PostgreSQL Event Store](/event-stores/postgresql) - Pongo projections
 - [Testing Patterns](/guides/testing) - Testing projections
+- [Error Handling](/guides/error-handling#projection-errors) - Why a projection copes with an event instead of throwing
 - [Writing and testing event-driven projections](https://event-driven.io/en/emmett_projections_testing/)

--- a/src/docs/guides/error-handling.md
+++ b/src/docs/guides/error-handling.md
@@ -50,7 +50,23 @@ Reach for your own type when none of these fits, and [Map Your Own Errors](#cust
 
 A decision hands its events, or its error, to the command handler. The handler loads the stream, runs the decision, and appends the result under an optimistic-concurrency check, and that check is the one error the handler raises on its own. When the stream has moved on since you read it, the append throws `ExpectedVersionConflictError`, a `ConcurrencyError` with status 412. It exposes the `current` and `expected` versions so you can see how far apart they drifted.
 
-Over HTTP this surfaces as `412 Precondition Failed` through an ETag round-trip: the client sends the version it last saw in an `If-Match` header, and the append succeeds only if the stream still matches. For wiring the version through ETags and retrying on conflict, see [Control Concurrency](/guides/command-handling#concurrency) in the Command Handling guide.
+Over HTTP this surfaces as `412 Precondition Failed` through an ETag round-trip: the client sends the version it last saw in an `If-Match` header, and the append succeeds only if the stream still matches. For wiring the version through ETags, see [Control Concurrency](/guides/command-handling#concurrency) in the Command Handling guide.
+
+## Retry a Transient Failure {#retry}
+
+Not every error the handler raises has to reach the caller. Some are transient: run the same command again and it goes through. The version conflict from the last section is the clearest case. The append lost an optimistic-concurrency race, so the events it collided with are already in the stream, and re-running the handler rebuilds the state from them before appending on top. Set `retry` and Emmett does that for you, re-running the whole handler when the append throws `ExpectedVersionConflictError`:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#retry-on-conflict{5}
+
+`retry` sits on the handler config, or on a single call as here, so recovery covers every command or just the one in hand. `{ onVersionConflict: true }` is the shorthand for the built-in policy: a bounded run of attempts, each after a longer pause, retrying only the version conflict and giving up once the attempts run out, so a write that stays stuck still surfaces rather than looping. Pass a count in place of `true`, as in `{ onVersionConflict: 5 }`, to keep that policy but change how many attempts it makes.
+
+Each attempt re-runs the decision from the top, so the same command reaches your logic again. That is safe when the decision only reads state and returns events, and unsafe when it performs I/O, which then fires on every attempt. Keep the decision pure, as [Keep the Decision Pure](/guides/command-handling#keep-pure) shows, and the [idempotence](/guides/command-handling#idempotence) that makes a resent command safe covers a retried one too.
+
+A version conflict is not the only transient failure. A read model briefly unreachable, a session dropped mid-append: these clear on a retry too, while a broken invariant or invalid input would fail the same way every time and should surface at once. Pass a full policy with a `shouldRetryError` predicate to decide which errors earn another attempt:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#custom-retry{8}
+
+The predicate runs on each thrown error: return `true` and the attempt repeats under the given `retries` and backoff, return `false` and the error unwinds straight away. Match the types you know are transient, here a `DatabaseConnectionError` from your own infrastructure, and let a `ValidationError` or `IllegalStateError` fall through. The wider it reaches, the more paths re-run the decision, so the same purity caution holds.
 
 ## Never Throw in Asynchronous Event Handlers {#no-throw-async}
 

--- a/src/docs/guides/error-handling.md
+++ b/src/docs/guides/error-handling.md
@@ -58,7 +58,7 @@ Not every error the handler raises has to reach the caller. Some are transient: 
 
 <<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#retry-on-conflict{5}
 
-`retry` sits on the handler config, or on a single call as here, so recovery covers every command or just the one in hand. `{ onVersionConflict: true }` is the shorthand for the built-in policy: a bounded run of attempts, each after a longer pause, retrying only the version conflict and giving up once the attempts run out, so a write that stays stuck still surfaces rather than looping. Pass a count in place of `true`, as in `{ onVersionConflict: 5 }`, to keep that policy but change how many attempts it makes.
+`retry` sits on the handler config, or on a single call as here, so recovery covers every command or just the one in hand. `{ onVersionConflict: true }` is the shorthand for the built-in policy: a bounded run of attempts, each after a longer pause, retrying only the version conflict and giving up once the attempts run out, so a write that stays stuck still surfaces rather than looping. Pass a count in place of `true`, as in `{ onVersionConflict: 5 }`, to keep that policy but change how many attempts it makes. For the exact backoff figures and every form `retry` accepts, see [Retry](/api-reference/commandhandler#retry) in the reference.
 
 Each attempt re-runs the decision from the top, so the same command reaches your logic again. That is safe when the decision only reads state and returns events, and unsafe when it performs I/O, which then fires on every attempt. Keep the decision pure, as [Keep the Decision Pure](/guides/command-handling#keep-pure) shows, and the [idempotence](/guides/command-handling#idempotence) that makes a resent command safe covers a retried one too.
 
@@ -84,7 +84,7 @@ Returning nothing accepts the message and moves on. See [Workflows & Sagas](/gui
 
 ### Never Reject an Event in a Projection {#projection-errors}
 
-A projection is a special case. It builds a read model from events that are already recorded, and a recorded event is a fact: the projection only interprets it, so it has nothing to reject. If an event carries a value the read model did not expect, throwing does not undo it. The check that should have stopped it belongs in the [business logic](#throw-invariants), before the event was ever recorded; by the time the projection runs, it is too late.
+A projection is a special case. It builds a [read model](/guides/projections) from events that are already recorded, and a recorded event is a fact: the projection only interprets it, so it has nothing to reject. If an event carries a value the read model did not expect, throwing does not undo it. The check that should have stopped it belongs in the [business logic](#throw-invariants), before the event was ever recorded; by the time the projection runs, it is too late.
 
 So accept the event and build the best read model you can from it. Skip a duplicate, fall back to a default, clamp a value back into range, whatever keeps the read model sensible and moving. Here a discount is already a fact, so rather than throw when the running total would go negative, the projection clamps it to zero and carries on:
 

--- a/src/docs/guides/error-handling.md
+++ b/src/docs/guides/error-handling.md
@@ -11,23 +11,23 @@ When something goes wrong, your business logic makes one choice: record the outc
 
 Start in the business logic, where a decision faces a negative outcome. A checkout that could not complete, a payment the bank declined, a booking that clashed with another: each is a fact about what happened, and the recommended default is to record it as its own event type, next to the success one. The decision then returns whichever event fits:
 
-<<< @./../packages/emmett/src/workflows/workflow.testHelpers.ts#return-failure-event
+<<< @./../packages/emmett-tests/src/errorHandling/failureEvents.unit.spec.ts#return-failure-event{9-11}
 
 Returning different event types keeps the failure inside the normal flow of events. A projection can count failed checkouts, a workflow can compensate, and nothing downstream has to catch an exception to notice that something went wrong.
 
 ### Give Each Failure Its Own Event {#distinct-failures}
 
-When a decision can fail in more than one way, give each mode its own event rather than folding them into a single generic error. A group checkout does not only fail when a guest's checkout is rejected; it can also run past its deadline with guests still pending. That timeout is a different fact, so a separate decision records it as `GroupCheckoutTimedOut`:
+When a decision can fail in more than one way, give each mode its own event rather than folding them into a single generic rejection with a reason field. A coupon does not only fail because it lapsed; it can also have been used already, or the cart can sit below the coupon's minimum. Each is a different fact, so each gets its own event:
 
-<<< @./../packages/emmett/src/workflows/workflow.testHelpers.ts#timeout-failure-event
+<<< @./../packages/emmett-tests/src/errorHandling/failureEvents.unit.spec.ts#distinct-failure-events{5-8}
 
-The workflow now has two failure events, `GroupCheckoutFailed` and `GroupCheckoutTimedOut`, each carrying the data its handler needs: the timeout lists which checkouts were still pending, the rejection lists which ones failed. A consumer can tell them apart and react to each on its own terms, retrying after a timeout and refunding after a rejection.
+Every _failure_ event carries the data its own handler needs, which a shared `CouponRejected` could not: `CouponAlreadyUsed` carries when the coupon was first applied, `CartBelowCouponMinimum` carries both the cart total and the minimum it missed. A consumer can tell them apart and react to each on its own terms, emailing a fresh coupon after an expiry and suggesting more items after a near miss.
 
 ## Throw for Broken Invariants {#throw-invariants}
 
 Returning an event fits an outcome the business expects. A broken rule is different: a command that should never have been issued, such as an illegal state transition or invalid input. Throw before building any event, so a bad command never records one.
 
-Emmett ships error types for the common cases, each carrying an HTTP status code used later when the error reaches the web layer:
+Throw whatever error type you like: your own class, a plain `Error`, one from a library. Emmett does not require its own. Yet, it ships is a set of error types for the common cases, each carrying a HTTP-based error code, so that an error thrown deep in a decision maps to the right response by convention rather than by wiring:
 
 | Error type          | Status | Raise it when                                              |
 | ------------------- | ------ | ---------------------------------------------------------- |
@@ -38,13 +38,13 @@ Emmett ships error types for the common cases, each carrying an HTTP status code
 
 Guard an invalid transition by throwing before the event is built:
 
-<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#confirm-decision
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#confirm-decision{8-9}
 
 Reject bad input the same way:
 
-<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#validation-error-decision
+<<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#validation-error-decision{6-7}
 
-`ValidationError` and `IllegalStateError` take a message string. `NotFoundError` takes `{ id, type, message? }`. See [Command Handling](/guides/command-handling#decision) for writing decisions in full.
+Reach for your own type when none of these fits, and [Map Your Own Errors](#custom-mapping) shows how to give it a status. See [Command Handling](/guides/command-handling#decision) for writing decisions in full.
 
 ## Guard Concurrency in the Command Handler {#concurrency}
 
@@ -56,13 +56,13 @@ Over HTTP this surfaces as `412 Precondition Failed` through an ETag round-trip:
 
 Whether throwing is safe depends on what sits above the code to catch it. A command handler behind an HTTP endpoint, its usual home, has the request: a thrown error unwinds into a response. Asynchronous handlers, the projections, reactors, and workflows that react to events, have nothing above them. A throw propagates up, stops the processor, and leaves later events unhandled. The endpoint is only the usual home, not a rule: a command handler run from a reactor loses the same safety net. Instead of throwing, turn the problem into data. You have two ways to do that.
 
-Return a failure event, as [Return a Failure Event](#failures-as-events) showed. This reactor releases a room through an external property-management system; when the call fails it returns `GuestCheckoutFailed` instead of throwing, so the workflow keeps running and can compensate:
+Return a failure event, as [Return a Failure Event](#failures-as-events) showed. This reactor charges an order through an external payment gateway; when the gateway declines, it appends `PaymentFailed` instead of throwing, so the reactor keeps running and a workflow can compensate:
 
-<<< @./../packages/emmett/src/workflows/workflow.testHelpers.ts#failure-as-event
+<<< @./../packages/emmett-tests/src/errorHandling/reactorErrors.features.ts#failure-as-event{15,27}
 
-Or catch the error and return a handler result. `MessageProcessor.result`, from `@event-driven-io/emmett`, gives you `skip` and `stop`. `skip` passes over a single message and lets the reactor carry on; `stop` halts the whole reactor, so a later run resumes from the same point. Reach for `skip` in the ordinary case, and reserve `stop` for a critical path where continuing past the failure would do more harm than halting. Here a free order has nothing to charge, so the reactor skips it, while a failed charge sits on the revenue path, so it stops rather than let the pipeline drop a charge:
+Or catch the error and return a handler result. `MessageProcessor.result` gives you `skip` and `stop`. `skip` passes over a single message and lets the reactor carry on; `stop` halts the whole reactor, so a later run resumes from the same point. Reach for `skip` in the ordinary case, and reserve `stop` for a critical path where continuing past the failure would do more harm than halting. Here a free order has nothing to charge, so the reactor skips it, while a failed charge sits on the revenue path, so it stops rather than let the pipeline drop a charge:
 
-<<< @./../packages/emmett/src/processors/processors.unit.spec.ts#reactor-skip-stop
+<<< @./../packages/emmett-tests/src/errorHandling/reactorErrors.features.ts#reactor-skip-stop{3,12,19}
 
 Returning nothing accepts the message and moves on. See [Workflows & Sagas](/guides/workflows) for the wider pattern.
 
@@ -72,7 +72,7 @@ A projection is a special case. It builds a read model from events that are alre
 
 So accept the event and build the best read model you can from it. Skip a duplicate, fall back to a default, clamp a value back into range, whatever keeps the read model sensible and moving. Here a discount is already a fact, so rather than throw when the running total would go negative, the projection clamps it to zero and carries on:
 
-<<< @./../packages/emmett/src/eventStore/projections/inMemory/inMemoryProjection.unit.spec.ts#coping-projection
+<<< @./../packages/emmett/src/eventStore/projections/inMemory/inMemoryProjection.unit.spec.ts#coping-projection{29-32}
 
 The read model stays consistent and the processor keeps running. A total that drifts below zero is a sign that a rule is missing upstream, so fix it in the decision that records the event, not in the projection that reads it.
 
@@ -95,15 +95,15 @@ The status comes from the error's code, the title from that HTTP status, and the
 
 The default mapping reads a numeric `errorCode` off the error it caught, so the shortest route to your own status is to carry one. Derive from `EmmettError` and hand the code to its constructor:
 
-<<< @./../packages/emmett-expressjs/src/mapError.int.spec.ts#derive-emmett-error
+<<< @./../packages/emmett-expressjs/src/mapError.int.spec.ts#derive-emmett-error{5}
 
 The base class is a convenience rather than a requirement. Any error with a numeric `errorCode` maps the same way, which keeps your own hierarchy free of Emmett:
 
-<<< @./../packages/emmett-expressjs/src/mapError.int.spec.ts#error-with-code
+<<< @./../packages/emmett-expressjs/src/mapError.int.spec.ts#error-with-code{3}
 
 For an error you cannot change, one thrown by a library you do not own, pass `mapError` to `getApplication`. Return a `ProblemDocument` to shape the response, or `undefined` to fall back to the default mapping:
 
-<<< @./../packages/emmett-expressjs/src/mapError.int.spec.ts#custom-error-mapping
+<<< @./../packages/emmett-expressjs/src/mapError.int.spec.ts#custom-error-mapping{20,22}
 
 Give the document an explicit `type` URI whenever you set your own `title`. Under the default `about:blank` type, Problem Details replaces the title with the standard reason phrase for the status, and your wording is lost.
 
@@ -119,7 +119,7 @@ Emmett does not force either style, and returning a failure event already gives 
 
 Assert a thrown rule with `thenThrows`, checking the error type, the message, or both:
 
-<<< @/snippets/gettingStarted/businessLogic.unit.spec.ts#unit-error
+<<< @/snippets/gettingStarted/businessLogic.unit.spec.ts#unit-error{24-26}
 
 At the HTTP layer, assert the Problem Details response with `expectError`. See [Testing](/guides/testing#assert-error) for both levels in full.
 

--- a/src/docs/guides/testing.md
+++ b/src/docs/guides/testing.md
@@ -43,7 +43,7 @@ Some checks don't fit a fixed list: a computed total, a value in a range, a rule
 
 ### Assert the rule it enforces {#assert-error}
 
-A rule isn't proven until you show it saying no. Set up a state that should reject the command, then assert the exact error, not merely that something threw. That same error becomes the caller's `403` later, so it's worth pinning down. `thenThrows` takes the error type, a check on the message, or both:
+A rule isn't proven until you show it saying no. Set up a state that should reject the command, then assert the exact error, not merely that something threw. That same error becomes the caller's [`403`](/guides/error-handling#problem-details) later, so it's worth pinning down. `thenThrows` takes the error type, a check on the message, or both:
 
 <<< @/snippets/gettingStarted/businessLogic.unit.spec.ts#unit-error
 

--- a/src/packages/emmett-tests/src/errorHandling/failureEvents.unit.spec.ts
+++ b/src/packages/emmett-tests/src/errorHandling/failureEvents.unit.spec.ts
@@ -1,0 +1,399 @@
+import { describe, it } from 'vitest';
+
+// #region imports
+import {
+  DeciderSpecification,
+  type Command,
+  type Event,
+} from '@event-driven-io/emmett';
+// #endregion imports
+
+type PricedProductItem = { productId: string; quantity: number; price: number };
+
+type ProductItemAdded = Event<
+  'ProductItemAdded',
+  { shoppingCartId: string; productItem: PricedProductItem }
+>;
+type ProductItemOutOfStock = Event<
+  'ProductItemOutOfStock',
+  {
+    shoppingCartId: string;
+    productId: string;
+    requestedQuantity: number;
+    availableQuantity: number;
+    attemptedAt: Date;
+  }
+>;
+type CouponApplied = Event<
+  'CouponApplied',
+  {
+    shoppingCartId: string;
+    couponCode: string;
+    discountAmount: number;
+    appliedAt: Date;
+  }
+>;
+type CouponExpired = Event<
+  'CouponExpired',
+  {
+    shoppingCartId: string;
+    couponCode: string;
+    expiredAt: Date;
+    attemptedAt: Date;
+  }
+>;
+type CouponAlreadyUsed = Event<
+  'CouponAlreadyUsed',
+  {
+    shoppingCartId: string;
+    couponCode: string;
+    appliedAt: Date;
+    attemptedAt: Date;
+  }
+>;
+type CartBelowCouponMinimum = Event<
+  'CartBelowCouponMinimum',
+  {
+    shoppingCartId: string;
+    couponCode: string;
+    cartAmount: number;
+    minimumAmount: number;
+    attemptedAt: Date;
+  }
+>;
+
+type ShoppingCartEvent =
+  | ProductItemAdded
+  | ProductItemOutOfStock
+  | CouponApplied
+  | CouponExpired
+  | CouponAlreadyUsed
+  | CartBelowCouponMinimum;
+
+type ShoppingCart = {
+  totalAmount: number;
+  appliedCoupons: { code: string; appliedAt: Date }[];
+};
+
+const evolve = (
+  state: ShoppingCart,
+  { type, data }: ShoppingCartEvent,
+): ShoppingCart => {
+  switch (type) {
+    case 'ProductItemAdded':
+      return {
+        ...state,
+        totalAmount:
+          state.totalAmount +
+          data.productItem.price * data.productItem.quantity,
+      };
+    case 'CouponApplied':
+      return {
+        ...state,
+        totalAmount: state.totalAmount - data.discountAmount,
+        appliedCoupons: [
+          ...state.appliedCoupons,
+          { code: data.couponCode, appliedAt: data.appliedAt },
+        ],
+      };
+    // the failure events record what was attempted without changing the cart
+    case 'ProductItemOutOfStock':
+    case 'CouponExpired':
+    case 'CouponAlreadyUsed':
+    case 'CartBelowCouponMinimum':
+      return state;
+  }
+};
+
+const initialState = (): ShoppingCart => ({
+  totalAmount: 0,
+  appliedCoupons: [],
+});
+
+type AddProductItem = Command<
+  'AddProductItem',
+  {
+    shoppingCartId: string;
+    productItem: PricedProductItem;
+    availableQuantity: number;
+    now: Date;
+  }
+>;
+
+// #region return-failure-event
+const addProductItem = (
+  command: AddProductItem,
+  _state: ShoppingCart,
+): ProductItemAdded | ProductItemOutOfStock => {
+  const { shoppingCartId, productItem, availableQuantity, now } = command.data;
+
+  // running out of stock is an outcome the business expects, not a broken rule,
+  // so record it as its own event type instead of throwing
+  if (productItem.quantity > availableQuantity)
+    return {
+      type: 'ProductItemOutOfStock',
+      data: {
+        shoppingCartId,
+        productId: productItem.productId,
+        requestedQuantity: productItem.quantity,
+        availableQuantity,
+        attemptedAt: now,
+      },
+    };
+
+  return {
+    type: 'ProductItemAdded',
+    data: { shoppingCartId, productItem },
+  };
+};
+// #endregion return-failure-event
+
+type ApplyCoupon = Command<
+  'ApplyCoupon',
+  {
+    shoppingCartId: string;
+    couponCode: string;
+    discountAmount: number;
+    expiresAt: Date;
+    minimumCartAmount: number;
+    now: Date;
+  }
+>;
+
+// #region distinct-failure-events
+const applyCoupon = (
+  command: ApplyCoupon,
+  state: ShoppingCart,
+):
+  | CouponApplied
+  | CouponExpired
+  | CouponAlreadyUsed
+  | CartBelowCouponMinimum => {
+  const {
+    shoppingCartId,
+    couponCode,
+    discountAmount,
+    expiresAt,
+    minimumCartAmount,
+    now,
+  } = command.data;
+
+  // a coupon can fail in three ways, so each mode gets its own event type,
+  // carrying the data that mode's handler needs
+  if (now > expiresAt)
+    return {
+      type: 'CouponExpired',
+      data: {
+        shoppingCartId,
+        couponCode,
+        expiredAt: expiresAt,
+        attemptedAt: now,
+      },
+    };
+
+  const alreadyUsed = state.appliedCoupons.find(
+    ({ code }) => code === couponCode,
+  );
+
+  if (alreadyUsed)
+    return {
+      type: 'CouponAlreadyUsed',
+      data: {
+        shoppingCartId,
+        couponCode,
+        appliedAt: alreadyUsed.appliedAt,
+        attemptedAt: now,
+      },
+    };
+
+  if (state.totalAmount < minimumCartAmount)
+    return {
+      type: 'CartBelowCouponMinimum',
+      data: {
+        shoppingCartId,
+        couponCode,
+        cartAmount: state.totalAmount,
+        minimumAmount: minimumCartAmount,
+        attemptedAt: now,
+      },
+    };
+
+  return {
+    type: 'CouponApplied',
+    data: { shoppingCartId, couponCode, discountAmount, appliedAt: now },
+  };
+};
+// #endregion distinct-failure-events
+
+const shoppingCartId = 'shoppingCart-123';
+const now = new Date('2024-06-01T10:00:00Z');
+const shoes: PricedProductItem = {
+  productId: 'shoes-123',
+  quantity: 2,
+  price: 100,
+};
+
+void describe('Decision returning a success or a failure event', () => {
+  const given = DeciderSpecification.for<
+    AddProductItem,
+    ShoppingCartEvent,
+    ShoppingCart
+  >({
+    decide: addProductItem,
+    evolve,
+    initialState,
+  });
+
+  void it('adds the product item when there is enough stock', () =>
+    given([])
+      .when({
+        type: 'AddProductItem',
+        data: { shoppingCartId, productItem: shoes, availableQuantity: 5, now },
+      })
+      .then([
+        {
+          type: 'ProductItemAdded',
+          data: { shoppingCartId, productItem: shoes },
+        },
+      ]));
+
+  void it('records the shortfall as an event when stock runs out', () =>
+    given([])
+      .when({
+        type: 'AddProductItem',
+        data: { shoppingCartId, productItem: shoes, availableQuantity: 1, now },
+      })
+      .then([
+        {
+          type: 'ProductItemOutOfStock',
+          data: {
+            shoppingCartId,
+            productId: 'shoes-123',
+            requestedQuantity: 2,
+            availableQuantity: 1,
+            attemptedAt: now,
+          },
+        },
+      ]));
+});
+
+void describe('Decision giving each failure mode its own event', () => {
+  const given = DeciderSpecification.for<
+    ApplyCoupon,
+    ShoppingCartEvent,
+    ShoppingCart
+  >({
+    decide: applyCoupon,
+    evolve,
+    initialState,
+  });
+
+  const couponCode = 'SUMMER10';
+  const expiresAt = new Date('2024-07-01T00:00:00Z');
+
+  const applySummerCoupon: ApplyCoupon = {
+    type: 'ApplyCoupon',
+    data: {
+      shoppingCartId,
+      couponCode,
+      discountAmount: 20,
+      expiresAt,
+      minimumCartAmount: 100,
+      now,
+    },
+  };
+
+  void it('applies the coupon when the cart qualifies', () =>
+    given([
+      {
+        type: 'ProductItemAdded',
+        data: { shoppingCartId, productItem: shoes },
+      },
+    ])
+      .when(applySummerCoupon)
+      .then([
+        {
+          type: 'CouponApplied',
+          data: {
+            shoppingCartId,
+            couponCode,
+            discountAmount: 20,
+            appliedAt: now,
+          },
+        },
+      ]));
+
+  void it('records an expired coupon as its own event', () => {
+    const afterExpiry = new Date('2024-08-01T10:00:00Z');
+
+    return given([
+      {
+        type: 'ProductItemAdded',
+        data: { shoppingCartId, productItem: shoes },
+      },
+    ])
+      .when({
+        ...applySummerCoupon,
+        data: { ...applySummerCoupon.data, now: afterExpiry },
+      })
+      .then([
+        {
+          type: 'CouponExpired',
+          data: {
+            shoppingCartId,
+            couponCode,
+            expiredAt: expiresAt,
+            attemptedAt: afterExpiry,
+          },
+        },
+      ]);
+  });
+
+  void it('records a reused coupon as its own event, with the first use', () => {
+    const firstAppliedAt = new Date('2024-05-01T10:00:00Z');
+
+    return given([
+      {
+        type: 'ProductItemAdded',
+        data: { shoppingCartId, productItem: shoes },
+      },
+      {
+        type: 'CouponApplied',
+        data: {
+          shoppingCartId,
+          couponCode,
+          discountAmount: 20,
+          appliedAt: firstAppliedAt,
+        },
+      },
+    ])
+      .when(applySummerCoupon)
+      .then([
+        {
+          type: 'CouponAlreadyUsed',
+          data: {
+            shoppingCartId,
+            couponCode,
+            appliedAt: firstAppliedAt,
+            attemptedAt: now,
+          },
+        },
+      ]);
+  });
+
+  void it('records a cart below the minimum as its own event', () =>
+    given([])
+      .when(applySummerCoupon)
+      .then([
+        {
+          type: 'CartBelowCouponMinimum',
+          data: {
+            shoppingCartId,
+            couponCode,
+            cartAmount: 0,
+            minimumAmount: 100,
+            attemptedAt: now,
+          },
+        },
+      ]));
+});

--- a/src/packages/emmett-tests/src/errorHandling/postgreSQLReactorErrors.int.spec.ts
+++ b/src/packages/emmett-tests/src/errorHandling/postgreSQLReactorErrors.int.spec.ts
@@ -1,0 +1,44 @@
+import {
+  getPostgreSQLEventStore,
+  postgreSQLEventStoreConsumer,
+} from '@event-driven-io/emmett-postgresql';
+import { getPostgreSQLStartedContainer } from '@event-driven-io/emmett-testcontainers';
+import type { StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { afterAll, beforeAll, describe } from 'vitest';
+import {
+  testReactorRecordsFailureAsEvent,
+  testReactorSkipsAndStops,
+  type ConsumerFactory,
+  type ReactorConsumer,
+} from './reactorErrors.features';
+
+let postgres: StartedPostgreSqlContainer;
+let connectionString: string;
+
+beforeAll(async () => {
+  postgres = await getPostgreSQLStartedContainer();
+  connectionString = postgres.getConnectionUri();
+}, 120000);
+
+afterAll(async () => {
+  await postgres?.stop();
+});
+
+const postgreSQLConsumerFactory: ConsumerFactory = () => {
+  const eventStore = getPostgreSQLEventStore(connectionString);
+
+  const consumer = postgreSQLEventStoreConsumer({
+    connectionString,
+  }) as unknown as ReactorConsumer;
+
+  return Promise.resolve({
+    eventStore,
+    consumer,
+    teardown: () => eventStore.close(),
+  });
+};
+
+void describe('PostgreSQL consumer', () => {
+  testReactorRecordsFailureAsEvent(postgreSQLConsumerFactory);
+  testReactorSkipsAndStops(postgreSQLConsumerFactory);
+});

--- a/src/packages/emmett-tests/src/errorHandling/reactorErrors.features.ts
+++ b/src/packages/emmett-tests/src/errorHandling/reactorErrors.features.ts
@@ -1,0 +1,260 @@
+import {
+  assertDeepEqual,
+  assertEqual,
+  assertMatches,
+  type AnyMessage,
+  type Event,
+  type EventStore,
+  type MessageConsumer,
+  type ReactorOptions,
+  type RecordedMessage,
+} from '@event-driven-io/emmett';
+import { v4 as uuid } from 'uuid';
+import { afterEach, beforeEach, describe, it } from 'vitest';
+
+export type OrderPlaced = Event<
+  'OrderPlaced',
+  { orderId: string; amount: number }
+>;
+export type PaymentCharged = Event<
+  'PaymentCharged',
+  { orderId: string; amount: number }
+>;
+export type PaymentFailed = Event<
+  'PaymentFailed',
+  { orderId: string; amount: number; reason: string }
+>;
+
+export type PaymentEvent = OrderPlaced | PaymentCharged | PaymentFailed;
+
+export type ReactorConsumer = MessageConsumer & {
+  reactor: <MessageType extends AnyMessage>(
+    options: ReactorOptions<MessageType>,
+  ) => unknown;
+};
+
+export type ConsumerTestContext = {
+  eventStore: EventStore;
+  consumer: ReactorConsumer;
+  teardown?: () => Promise<void>;
+};
+
+export type ConsumerFactory = () => Promise<ConsumerTestContext>;
+
+let eventStore: EventStore;
+let consumer: ReactorConsumer;
+
+export class PaymentDeclinedError extends Error {
+  constructor(public readonly reason: string) {
+    super(`Payment declined: ${reason}`);
+  }
+}
+
+const declinedAmount = 999;
+
+const charged: string[] = [];
+
+const chargeGateway = (orderId: string, amount: number): Promise<void> => {
+  if (amount === declinedAmount)
+    return Promise.reject(new PaymentDeclinedError('InsufficientFunds'));
+
+  charged.push(orderId);
+  return Promise.resolve();
+};
+
+// #region failure-as-event
+const registerRecordingReactor = () =>
+  consumer.reactor<OrderPlaced>({
+    processorId: 'payments',
+    canHandle: ['OrderPlaced'],
+    eachMessage: async ({ data: { orderId, amount } }) => {
+      let payment: PaymentCharged | PaymentFailed;
+
+      try {
+        await chargeGateway(orderId, amount);
+        payment = { type: 'PaymentCharged', data: { orderId, amount } };
+      } catch (error) {
+        // the gateway declining is an outcome the business expects, so record
+        // it as an event; throwing here would stop the reactor instead
+        payment = {
+          type: 'PaymentFailed',
+          data: {
+            orderId,
+            amount,
+            reason:
+              error instanceof PaymentDeclinedError
+                ? error.reason
+                : 'GatewayUnavailable',
+          },
+        };
+      }
+
+      await eventStore.appendToStream(`payment-${orderId}`, [payment]);
+    },
+  });
+// #endregion failure-as-event
+
+// #region reactor-skip-stop
+import { EmmettError, MessageProcessor } from '@event-driven-io/emmett';
+
+const { skip, stop } = MessageProcessor.result;
+
+const registerChargingReactor = () =>
+  consumer.reactor<OrderPlaced>({
+    processorId: 'payments',
+    canHandle: ['OrderPlaced'],
+    eachMessage: async ({ data: { orderId, amount } }) => {
+      // a free order has nothing to charge: skipping moves the checkpoint past
+      // the message and lets the reactor carry on
+      if (amount === 0) return skip({ reason: 'free order' });
+
+      try {
+        await chargeGateway(orderId, amount);
+      } catch (error) {
+        // charging sits on the critical revenue path, so a lost charge must not
+        // be skipped: stop, and resume here once the cause is fixed
+        return stop({
+          reason:
+            error instanceof PaymentDeclinedError
+              ? error.reason
+              : 'GatewayUnavailable',
+          error: new EmmettError('payment charge failed'),
+        });
+      }
+    },
+  });
+// #endregion reactor-skip-stop
+
+const paymentStream = (orderId: string) => `payment-${orderId}`;
+
+const appendOrder = (orderId: string, amount: number) =>
+  eventStore.appendToStream<OrderPlaced>(`order-${orderId}`, [
+    { type: 'OrderPlaced', data: { orderId, amount } },
+  ]);
+
+const stoppingAfterOrder = (
+  source: ReactorConsumer,
+  lastOrderId: string,
+): ReactorConsumer => ({
+  ...source,
+  reactor: (options) =>
+    source.reactor({
+      ...options,
+      stopAfter: (message) => {
+        const order = message as RecordedMessage<OrderPlaced>;
+        return (
+          order.type === 'OrderPlaced' && order.data.orderId === lastOrderId
+        );
+      },
+    }),
+});
+
+const setupStore = (consumerFactory: ConsumerFactory) => {
+  let teardown: (() => Promise<void>) | undefined;
+
+  beforeEach(async () => {
+    const context = await consumerFactory();
+    eventStore = context.eventStore;
+    consumer = context.consumer;
+    teardown = context.teardown;
+    charged.length = 0;
+  });
+
+  afterEach(async () => {
+    if (teardown) await teardown();
+  });
+};
+
+export function testReactorRecordsFailureAsEvent(
+  consumerFactory: ConsumerFactory,
+) {
+  describe('reactor recording a failure as an event', () => {
+    setupStore(consumerFactory);
+
+    it('records the decline as an event and carries on to the next order', async () => {
+      const declinedOrderId = uuid();
+      const chargedOrderId = uuid();
+
+      await appendOrder(declinedOrderId, declinedAmount);
+      await appendOrder(chargedOrderId, 100);
+
+      consumer = stoppingAfterOrder(consumer, chargedOrderId);
+      registerRecordingReactor();
+
+      try {
+        await consumer.start();
+
+        const declined = await eventStore.readStream<PaymentEvent>(
+          paymentStream(declinedOrderId),
+        );
+        const succeeded = await eventStore.readStream<PaymentEvent>(
+          paymentStream(chargedOrderId),
+        );
+
+        assertEqual(declined.events?.length, 1);
+        assertMatches(declined.events[0], {
+          type: 'PaymentFailed',
+          data: {
+            orderId: declinedOrderId,
+            amount: declinedAmount,
+            reason: 'InsufficientFunds',
+          },
+        });
+
+        assertEqual(succeeded.events?.length, 1);
+        assertMatches(succeeded.events[0], {
+          type: 'PaymentCharged',
+          data: { orderId: chargedOrderId, amount: 100 },
+        });
+      } finally {
+        await consumer.close();
+      }
+    });
+  });
+}
+
+export function testReactorSkipsAndStops(consumerFactory: ConsumerFactory) {
+  describe('reactor skipping and stopping', () => {
+    setupStore(consumerFactory);
+
+    it('skips a message with nothing to do and keeps processing', async () => {
+      const freeOrderId = uuid();
+      const paidOrderId = uuid();
+
+      await appendOrder(freeOrderId, 0);
+      await appendOrder(paidOrderId, 100);
+
+      consumer = stoppingAfterOrder(consumer, paidOrderId);
+      registerChargingReactor();
+
+      try {
+        await consumer.start();
+
+        assertDeepEqual(charged, [paidOrderId]);
+      } finally {
+        await consumer.close();
+      }
+    });
+
+    it('stops the reactor when the critical path fails', async () => {
+      const firstOrderId = uuid();
+      const declinedOrderId = uuid();
+      const laterOrderId = uuid();
+
+      await appendOrder(firstOrderId, 50);
+      await appendOrder(declinedOrderId, declinedAmount);
+      await appendOrder(laterOrderId, 100);
+
+      consumer = stoppingAfterOrder(consumer, laterOrderId);
+      registerChargingReactor();
+
+      try {
+        await consumer.start();
+
+        assertDeepEqual(charged, [firstOrderId]);
+      } finally {
+        await consumer.close();
+      }
+    });
+  });
+}

--- a/src/packages/emmett-tests/src/errorHandling/sqliteReactorErrors.int.spec.ts
+++ b/src/packages/emmett-tests/src/errorHandling/sqliteReactorErrors.int.spec.ts
@@ -1,0 +1,60 @@
+import { sqlite3Pool } from '@event-driven-io/dumbo/sqlite3';
+import {
+  getSQLiteEventStore,
+  sqliteEventStoreConsumer,
+} from '@event-driven-io/emmett-sqlite';
+import { sqlite3EventStoreDriver } from '@event-driven-io/emmett-sqlite/sqlite3';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { v4 as uuid } from 'uuid';
+import { describe } from 'vitest';
+import {
+  testReactorRecordsFailureAsEvent,
+  testReactorSkipsAndStops,
+  type ConsumerFactory,
+  type ReactorConsumer,
+} from './reactorErrors.features';
+
+const testDatabasePath = path.dirname(fileURLToPath(import.meta.url));
+
+const sqliteConsumerFactory: ConsumerFactory = () => {
+  const fileName = path.resolve(testDatabasePath, `reactorErrors-${uuid()}.db`);
+
+  // the consumer and the event store share a pool, so a reactor appending to
+  // the store does not deadlock against the connection pulling its messages
+  const pool = sqlite3Pool({
+    fileName,
+    transactionOptions: { allowNestedTransactions: true },
+  });
+
+  const eventStore = getSQLiteEventStore({
+    driver: sqlite3EventStoreDriver,
+    fileName,
+    pool,
+  });
+
+  const consumer = sqliteEventStoreConsumer({
+    driver: sqlite3EventStoreDriver,
+    fileName,
+    pool,
+  }) as unknown as ReactorConsumer;
+
+  return Promise.resolve({
+    eventStore,
+    consumer,
+    teardown: async () => {
+      await eventStore.close();
+      await pool.close();
+      for (const suffix of ['', '-shm', '-wal']) {
+        const file = `${fileName}${suffix}`;
+        if (fs.existsSync(file)) fs.unlinkSync(file);
+      }
+    },
+  });
+};
+
+void describe('SQLite consumer', () => {
+  testReactorRecordsFailureAsEvent(sqliteConsumerFactory);
+  testReactorSkipsAndStops(sqliteConsumerFactory);
+});

--- a/src/packages/emmett/src/commandHandling/handleCommand.unit.spec.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.unit.spec.ts
@@ -175,6 +175,8 @@ const handleCommand = CommandHandler<ShoppingCart, ShoppingCartEvent>({
   initialState,
 });
 
+class TransientDatabaseConnectionError extends Error {}
+
 void describe('Command Handler', () => {
   const eventStore = getInMemoryEventStore();
 
@@ -517,7 +519,8 @@ void describe('Command Handler', () => {
         retries: 5,
         minTimeout: 50,
         factor: 2,
-        shouldRetryError: (error) => error instanceof ConcurrencyError,
+        shouldRetryError: (error) =>
+          error instanceof TransientDatabaseConnectionError,
       },
     });
     // #endregion custom-retry

--- a/src/packages/emmett/src/workflows/workflow.testHelpers.ts
+++ b/src/packages/emmett/src/workflows/workflow.testHelpers.ts
@@ -299,7 +299,6 @@ const pmsApi: PmsApi = {
   },
 };
 
-// #region failure-as-event
 const checkoutFromPms = async (
   checkOut: CheckOut,
 ): Promise<GuestCheckedOut | GuestCheckoutFailed> => {
@@ -308,13 +307,11 @@ const checkoutFromPms = async (
   try {
     await pmsApi.releaseRoom(parseGuestStayAccountId(guestStayAccountId));
 
-    // the room was released: record the success as an event
     return {
       type: 'GuestCheckedOut',
       data: { guestStayAccountId, groupCheckoutId, checkedOutAt: new Date() },
     };
   } catch (err) {
-    // the call failed: record the failure as an event instead of throwing
     const error = err instanceof Error ? err : new Error('Unknown error');
     return {
       type: 'GuestCheckoutFailed',
@@ -329,7 +326,6 @@ const checkoutFromPms = async (
     };
   }
 };
-// #endregion failure-as-event
 
 ////////////////////////////////////////////
 ////////// Workflow Processor
@@ -415,14 +411,12 @@ const completeGroupCheckout = (
     : finished(groupCheckoutId, state.guestStayAccountIds, now);
 };
 
-// #region timeout-failure-event
 const timedOut = (
   command: TimeoutGroupCheckout,
   state: GroupCheckout,
 ): GroupCheckoutTimedOut | [] => {
   if (state.status === 'NotExisting' || state.status === 'Finished') return [];
 
-  // running past the deadline is a different failure: give it its own event
   return {
     type: 'GroupCheckoutTimedOut',
     data: {
@@ -443,15 +437,12 @@ const timedOut = (
     },
   };
 };
-// #endregion timeout-failure-event
 
-// #region return-failure-event
 const finished = (
   groupCheckoutId: string,
   guestStayAccounts: Map<string, GuestStayStatus>,
   now: Date,
 ): GroupCheckoutCompleted | GroupCheckoutFailed => {
-  // every guest checked out: the group checkout completed
   return areAllCompleted(guestStayAccounts)
     ? {
         type: 'GroupCheckoutCompleted',
@@ -461,8 +452,7 @@ const finished = (
           completedAt: now,
         },
       }
-    : // some guest could not check out: record the failure as its own event
-      {
+    : {
         type: 'GroupCheckoutFailed',
         data: {
           groupCheckoutId,
@@ -478,7 +468,6 @@ const finished = (
         },
       };
 };
-// #endregion return-failure-event
 
 export const isAlreadyClosed = (status: GuestStayStatus | undefined) =>
   status === GuestStayStatus.Completed || status === GuestStayStatus.Failed;


### PR DESCRIPTION
Previously, they were showing detached code snippets that didn't capture the whole picture and were inaccessible to people who didn't know the underlying assumptions. And well, this is the group that reads docs.

A follow-up to:https://github.com/event-driven-io/emmett/pull/360