### PR TITLE
Added message handling middlewares to Command, Decider and Workflow handlers

### DIFF
--- a/src/docs/api-reference/commandhandler.md
+++ b/src/docs/api-reference/commandhandler.md
@@ -19,16 +19,17 @@ It builds on the event store's [`aggregateStream`](/api-reference/eventstore#agg
 
 ### CommandHandlerOptions
 
-| Property               | Type                                          | Description                                                                        |
-| ---------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `evolve`               | `(state: State, event: StreamEvent) => State` | Applies an event to the state, returning the next state. Required.                 |
-| `initialState`         | `() => State`                                 | Starting state for a stream with no events. Required.                              |
-| `mapToStreamId`        | `(id: string) => string`                      | Maps the business id to the stream name. Defaults to the identity function.        |
-| `retry`                | `CommandHandlerRetryOptions`                  | Retry policy for version conflicts. See [Retry](#retry).                           |
-| `schema.versioning`    | `{ upcast?; downcast? }`                      | Converts stored events to and from `StreamEvent`. See [Advanced](#advanced).       |
-| `serialization`        | `{ serializer?; serializerOptions? }`         | Custom serialiser for reading and writing events. See [Advanced](#advanced).       |
-| `name` / `commandType` | `string` / `string \| string[]`               | Labels used for observability and as the default command type when none is passed. |
-| `observability`        | `CommandObservabilityConfig`                  | Tracing and metrics configuration. See [Advanced](#advanced).                      |
+| Property               | Type                                                   | Description                                                                                   |
+| ---------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| `evolve`               | `(state: State, event: StreamEvent) => State`          | Applies an event to the state, returning the next state. Required.                            |
+| `initialState`         | `() => State`                                          | Starting state for a stream with no events. Required.                                         |
+| `mapToStreamId`        | `(id: string) => string`                               | Maps the business id to the stream name. Defaults to the identity function.                   |
+| `retry`                | `CommandHandlerRetryOptions`                           | Retry policy for version conflicts. See [Retry](#retry).                                      |
+| `schema.versioning`    | `{ upcast?; downcast? }`                               | Converts stored events to and from `StreamEvent`. See [Advanced](#advanced).                  |
+| `serialization`        | `{ serializer?; serializerOptions? }`                  | Custom serialiser for reading and writing events. See [Advanced](#advanced).                  |
+| `name` / `commandType` | `string` / `string \| string[]`                        | Labels used for observability and as the default command type when none is passed.            |
+| `observability`        | `CommandObservabilityConfig`                           | Tracing and metrics configuration. See [Advanced](#advanced).                                 |
+| `middleware`           | `Middleware[] \| { beforeAll?; afterAll?; decision? }` | Configures invocation-wide and per-decision middleware. An array is shorthand for `decision`. |
 
 ## Calling the Handler
 
@@ -67,12 +68,73 @@ Each call resolves to `CommandHandlerResult`:
 
 | Property                    | Type                                                | Description                                                  |
 | --------------------------- | --------------------------------------------------- | ------------------------------------------------------------ |
-| `newState`                  | `State`                                             | State after applying the produced events.                    |
-| `newEvents`                 | `StreamEvent[]`                                     | Events appended, empty when the decision produced none.      |
+| `newState`                  | `State`                                             | State after applying the appended events.                    |
+| `events`                    | `StreamEvent[]`                                     | Every event produced by decisions that ran.                  |
+| `appendedEvents`            | `StreamEvent[]`                                     | Events persisted by this call.                               |
+| `newEvents`                 | `StreamEvent[]`                                     | Deprecated alias of `appendedEvents`.                        |
 | `nextExpectedStreamVersion` | `StreamPosition` (`bigint` for the built-in stores) | Version to pass as `expectedStreamVersion` on the next call. |
 | `createdNewStream`          | `boolean`                                           | Whether this call created the stream.                        |
 
 `nextExpectedStreamVersion` and `createdNewStream` come from the store in use, so their exact type depends on it.
+
+## Decision Middleware
+
+Ordinary decision results are treated as `APPEND`. Middleware can change how a complete decision result is handled with `skipOn`, `stopOn`, `rejectOn`, `stopAfter`, or a custom middleware. A predicate may inspect individual events, but a match always applies to every event returned by that decision.
+
+- `APPEND` stages and evolves the events, then continues.
+- `SKIP` exposes the events in `events` without staging or evolving them, then continues.
+- `STOP` discards the current events, commits earlier staged events, and stops.
+- `REJECT` discards every staged event, restores the state from before the batch, and stops.
+- `APPEND_AND_STOP` stages and evolves the current events, then commits and stops.
+
+`SKIP`, `STOP`, `REJECT`, and `APPEND_AND_STOP` return normally; they do not throw. Produced events remain in `events` even when they are not present in `appendedEvents`. `throwOn` is the exception-producing helper.
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.middleware.unit.spec.ts#command-handler-before-all-throw-on
+
+### Configuration
+
+`middleware` accepts a decision middleware array or an object:
+
+| Form                                     | Behavior                                              |
+| ---------------------------------------- | ----------------------------------------------------- |
+| `middleware: Middleware[]`               | Applies the array to every decision.                  |
+| `middleware: { decision: Middleware[] }` | Equivalent to the array form.                         |
+| `middleware: { beforeAll, decision }`    | Runs `beforeAll` once before aggregation/retries.     |
+| `middleware: { afterAll, decision }`     | Runs `afterAll` once after the successful invocation. |
+
+`beforeAll` receives the complete handler input and an operation context containing `streamName` and `handleOptions`. Raw `CommandHandler` supplies the decision or decision array. `DeciderCommandHandler` supplies the command or command array. `WorkflowHandler` supplies the input message.
+
+`afterAll` receives the final handler result and the operation context. Both lifecycle callbacks run outside retry processing. `afterAll` runs only after a successful invocation; throwing from it does not roll back events or messages that were already appended.
+
+Decision middleware runs for every decision and every retry attempt. Its arguments depend on the handler:
+
+| Handler                 | First argument | Second argument |
+| ----------------------- | -------------- | --------------- |
+| `CommandHandler`        | Current state  | None            |
+| `DeciderCommandHandler` | Command        | Current state   |
+| `WorkflowHandler`       | Input message  | Current state   |
+
+### Helpers
+
+| Helper                    | Matching behavior                                               |
+| ------------------------- | --------------------------------------------------------------- |
+| `before(callback)`        | Runs `callback` before the decision.                            |
+| `after(callback)`         | Runs `callback` with the handling result after the decision.    |
+| `skipOn(predicate)`       | Returns `SKIP`.                                                 |
+| `stopOn(predicate)`       | Returns `STOP`.                                                 |
+| `rejectOn(predicate)`     | Returns `REJECT`.                                               |
+| `stopAfter(predicate)`    | Returns `APPEND_AND_STOP`.                                      |
+| `throwOn(predicate, map)` | Throws the error created by `map` before the batch is appended. |
+
+A helper predicate runs for each output. If one output matches, the helper applies its result to every output returned by that decision.
+
+### Custom middleware
+
+Custom middleware can inspect the input, state, and result before selecting how the decision is handled:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommandWithDecider.middleware.unit.spec.ts#custom-decision-middleware
+
+Use `afterAll` for logging, metrics or other measurements that need the returned result. Use event-store hooks for commit instrumentation that must reflect storage-level behavior.
 
 When the decision returns an empty array, nothing is appended and the result carries `newEvents: []`, `createdNewStream: false`, and the current version:
 

--- a/src/docs/api-reference/workflows.md
+++ b/src/docs/api-reference/workflows.md
@@ -45,6 +45,14 @@ type WorkflowOutput<Output> = Array<
 
 Workflows can emit both events (facts) and commands (requests to other aggregates).
 
+`WorkflowHandler` accepts `middleware` as a decision middleware array or as an
+object with `beforeAll` and `decision` members. The same
+`APPEND`, `SKIP`, `STOP`, `REJECT`, and `APPEND_AND_STOP` results used by command
+handlers apply to the workflow's complete output array. Suppressing or rejecting
+outputs does not suppress the durable inbox record for the input. Results expose
+all produced outputs as `messages`, persisted outputs as `appendedMessages`, and
+the deprecated `newMessages` alias retains its persisted-output meaning.
+
 ### WorkflowEvent
 
 Events in a workflow stream include both inputs and outputs:

--- a/src/docs/guides/command-handling.md
+++ b/src/docs/guides/command-handling.md
@@ -53,6 +53,120 @@ Pass an array of decisions to run them in sequence. Each runs on the state left 
 
 <<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#sequential-handlers
 
+## Control Which Decision Results Are Appended {#decision-middleware}
+
+Suppose a command reports that a product is out of stock. You may need to return that outcome to the caller without saving it, or stop the remaining commands after saving the changes made so far.
+
+You can configure a reusable rule on either `CommandHandler` or `DeciderCommandHandler`. The rule runs for each command outcome and chooses whether to save it, continue with the next command, or reject the whole batch. Outcomes that are not saved are still returned, so you can use them in the response.
+
+Emmett calls these rules _decision middleware_. Use the helpers below for the common cases, or write custom middleware when you need different behavior.
+
+The business logic remains responsible only for describing what happened. These decisions return ordinary cart events for unavailable stock, duplicate products, item limits, and failed payment authorization:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.middleware.unit.spec.ts#decision-handling-business-logic
+
+The handler configuration below decides which of those events belong in the shopping-cart stream and whether the rest of a command batch should run.
+
+<a id="reject-output"></a>
+
+**Reject the complete batch**
+
+Use `rejectOn` when none of the changes from the current call should be saved after a matching outcome. This configuration rejects the complete batch when a decision returns `ProductItemOutOfStock`:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.middleware.unit.spec.ts#command-handler-reject-on-setup
+
+`rejectOn` leaves the cart unchanged and does not run later decisions. It still returns `ProductItemOutOfStock`, so the endpoint can use the available quantity to return status 409. Use this when the commands belong to one operation and a failure in any of them should cancel the whole operation. [Map Returned Events to Error Responses](/guides/error-handling#map-returned-events) shows the complete Express route.
+
+If one command produces several events, they remain one unit. A match rejects all events produced by that command.
+
+<a id="stop-output"></a>
+
+**Commit earlier decisions and stop**
+
+Use `stopOn` when earlier changes should be saved, but the matching outcome and later commands should not be. This configuration stops when payment authorization returns `ShoppingCartConfirmationFailed`:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.middleware.unit.spec.ts#command-handler-stop-on-setup
+
+Use `stopOn` when earlier commands may stand on their own. The caller still receives `ShoppingCartConfirmationFailed`, so it can explain why processing stopped. Use `rejectOn` instead when those earlier changes must also be cancelled.
+
+<a id="skip-output"></a>
+
+**Skip one outcome and continue**
+
+Use `skipOn` when you want to ignore the matching outcome and continue. This configuration skips `ProductItemAlreadyInCart` and runs the next decision:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.middleware.unit.spec.ts#command-handler-skip-on-setup
+
+The caller receives `ProductItemAlreadyInCart`, but that event is not appended to the shopping-cart stream. Processing continues, and the confirmation sees a cart with one copy of the product.
+
+<a id="stop-after-output"></a>
+
+**Record a terminal failure and stop**
+
+Use `stopAfter` when the matching outcome should be saved and no later command should run. This configuration records `ShoppingCartItemLimitReached` before stopping:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.middleware.unit.spec.ts#command-handler-stop-after-setup
+
+`ProductItemAdded` and `ShoppingCartItemLimitReached` are appended together. The third product decision does not run. `stopOn` would omit `ShoppingCartItemLimitReached`; `stopAfter` includes it.
+
+<a id="throw-on-output"></a>
+
+**Turn a produced event into an exception**
+
+Use `throwOn` when the matching outcome should enter an existing exception-based error path, such as HTTP Problem Details mapping:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.middleware.unit.spec.ts#command-handler-before-all-throw-on
+
+Nothing from the call is stored. Unlike `rejectOn`, `throwOn` does not return the matching event to the caller; the created error follows the application's exception-handling path.
+
+<a id="before-all"></a>
+
+**Check the complete input before handling**
+
+Use `middleware.beforeAll` when a check should run once for the whole call instead of once per command. Request authorization is one example. It runs before the current state is read. If it throws, no commands run and nothing is saved.
+
+For `CommandHandler`, it receives the decision or decision array. For `DeciderCommandHandler`, it receives the command or command array. For `WorkflowHandler`, it receives the input message. The second argument contains the resolved stream name and handle options.
+
+Put checks that need a command or rebuilt state in `middleware.decision`. Pass the decision middleware array directly as `middleware` when `beforeAll` is not needed.
+
+<a id="after-all"></a>
+
+**Observe the completed result**
+
+Use `middleware.afterAll` when a measurement or notification should describe the completed operation rather than each command separately. It receives the final result, so it can record values such as the number of appended events or the resulting stream version. The decider example below records the appended-event count.
+
+Do not use `afterAll` for validation or for anything that must prevent the save. The operation has already completed, so an error from this callback cannot undo it. Use the event-store hooks when you need to observe each store commit rather than the completed handler result.
+
+<a id="decider-middleware"></a>
+
+**Use middleware with `DeciderCommandHandler`**
+
+The handling choices shown above work the same way with `CommandHandler` and `DeciderCommandHandler`. The difference is what each middleware receives. Raw command handling supplies the current state because the command is captured by the decision function. `DeciderCommandHandler` supplies the command and current state, so a shared handler can authorize or measure commands without wrapping every call.
+
+Use `before` for work before `decide`, and `after` for work based on its result:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommandWithDecider.middleware.unit.spec.ts#decider-command-middleware
+
+Callbacks may omit state, as `authorizeCommand` does here. Accept it as the second argument when needed: `before((command, state) => ...)`. Decision middleware runs again on concurrency retry.
+
+<a id="custom-decision-middleware"></a>
+
+**Write custom decision middleware**
+
+Use custom middleware when one handler needs several handling rules or when a helper predicate is not enough. The middleware receives `next`, calls it with the command and current state, then returns the handling selected for the produced outcome:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommandWithDecider.middleware.unit.spec.ts#custom-decision-middleware
+
+This middleware uses the same rules as the preceding examples:
+
+- `ProductItemAlreadyInCart` is returned but not saved, and the next command runs.
+- `ShoppingCartConfirmationFailed` is returned without being saved; earlier changes are saved and later commands do not run.
+- `ProductItemOutOfStock` rejects the complete command batch.
+- `ShoppingCartItemLimitReached` is saved before the remaining commands are stopped.
+- Other outcomes keep the default append-and-continue behavior returned by `next`.
+
+The first configured middleware is the outermost wrapper. Put authorization or timing middleware before outcome-selection middleware when it must observe the complete decision call.
+
 ## Control Concurrency {#concurrency}
 
 By default the handler reuses the version it read from the stream, so you do not pass one and concurrent writers cannot overwrite each other:
@@ -83,6 +197,14 @@ For a different backoff, or to retry on errors other than version conflicts, pas
 
 <<< @./../packages/emmett/src/commandHandling/handleCommand.unit.spec.ts#custom-retry
 
+### Make decision middleware retry-safe {#middleware-retry}
+
+`beforeAll` runs once before retry processing. Decision middleware and the decision run again for every attempt:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.middleware.unit.spec.ts#command-middleware-retry
+
+The caller receives only the outcome of the attempt that completes. Any external work performed by decision middleware may run more than once, so make it safe to repeat. Use `beforeAll` for a check that must run once and does not need the rebuilt state. `afterAll` runs once after an attempt completes and receives its final result.
+
 ## Make It Idempotent {#idempotence}
 
 **The same command can reach the handler twice.** A shopper double-clicks "Add to cart", a request times out and the browser sends it again, a [retry](#retry) re-runs it after a conflict. Handling it twice shouldn't add the product twice, and two things you already have keep it safe.
@@ -102,6 +224,10 @@ Second, [optimistic concurrency](#concurrency). When you carry the version, a du
 `emmett-expressjs` wraps a handler with `on`. Fetch any data the decision needs, such as the unit price, before calling the handler and pass it into the command, which keeps the decision pure. The first write creates the stream:
 
 <<< @/snippets/gettingStarted/webApi/simpleApi.ts#add-product-item-endpoint{17,23-25}
+
+When decision middleware returns a business failure, use `ResponseFromEvents` to return the response expected by Express `on` without assuming the failure is the final event. The `failure` callback returns an ordinary response helper such as `Conflict(...)`. If no event selects a failure response, `success` may be a status code or a callback returning `NoContent(...)`, `Created(...)`, or another response helper. The callback receives the complete handler result when headers such as an ETag depend on it:
+
+<<< @./../packages/emmett-expressjs/src/responses.int.spec.ts#express-response-from-events-route
 
 ### Carry the version in an ETag {#etag}
 

--- a/src/docs/guides/error-handling.md
+++ b/src/docs/guides/error-handling.md
@@ -23,6 +23,26 @@ When a decision can fail in more than one way, give each mode its own event rath
 
 Every _failure_ event carries the data its own handler needs, which a shared `CouponRejected` could not: `CouponAlreadyUsed` carries when the coupon was first applied, `CartBelowCouponMinimum` carries both the cart total and the minimum it missed. A consumer can tell them apart and react to each on its own terms, emailing a fresh coupon after an expiry and suggesting more items after a near miss.
 
+### Return a Failure Without Recording It {#selective-failure-events}
+
+Whether a failure event belongs in the stream depends on who needs it after the current request finishes. Record it when it changes how the aggregate is rebuilt, when another component must react to it, or when it forms part of the history you need to retain. The earlier checkout examples use that model: the failure remains available to projections and workflows long after the caller receives its response.
+
+Some failed attempts do not change the aggregate and do not need to trigger any later processing. The endpoint still needs enough information to tell the client why the command was not applied. When the requested product quantity is unavailable, the decision can return `ProductItemOutOfStock` with the requested and available quantities while leaving the cart unchanged. If no downstream consumer needs that attempt, the event does not need to be appended to the cart stream.
+
+Configure `rejectOn` when that outcome should leave the stream unchanged while remaining available to the caller:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommand.middleware.unit.spec.ts#command-handler-reject-on
+
+`rejectOn` does not turn the event into an exception. The decision returns `ProductItemOutOfStock`, and the handler returns that event to the caller without saving changes from the command batch. The cart remains as it was before the request, and later commands in the batch do not run. The endpoint can use the event's data to build a specific conflict response.
+
+You can instead configure `throwOn` to translate the produced event into an exception before anything is appended. The exception enters the application's centralized error mapping, and the handler does not return a normal result.
+
+`rejectOn` and `throwOn` can therefore produce the same HTTP error response through different control flow. `rejectOn` returns the failure event, and the endpoint maps that known outcome explicitly. This keeps expected failures in a deterministic result pipeline without using exceptions for control flow. Use `throwOn` when the endpoint already relies on centralized exception mapping or when returning the event would not be useful. See [Turn a Produced Event into an Exception](/guides/command-handling#throw-on-output) for the exception form and [Reject the Complete Batch](/guides/command-handling#reject-output) for the batch behavior.
+
+#### Keep Earlier Changes and Stop {#stop-on-failure}
+
+Use `stopOn` when commands earlier in the batch made independent changes that should remain saved. The matching failure is returned without being appended, and later commands do not run. Use `rejectOn` instead when the complete batch must be all-or-nothing. [Commit Earlier Decisions and Stop](/guides/command-handling#stop-output) shows the configuration alongside the other handling choices.
+
 ## Throw for Broken Invariants {#throw-invariants}
 
 Returning an event fits an outcome the business expects. A broken rule is different: a command that should never have been issued, such as an illegal state transition or invalid input. Throw before building any event, so a bad command never records one.
@@ -106,6 +126,16 @@ When the error unwinds to an HTTP endpoint, it still needs a shape the caller ca
 ```
 
 The status comes from the error's code, the title from that HTTP status, and the detail from the error message. Emmett's built-in errors carry their status code, so they map without any configuration: `ValidationError` to 400, `IllegalStateError` to 403, `NotFoundError` to 404, `ConcurrencyError` to 412. Anything else becomes a 500.
+
+### Map Returned Events to Error Responses {#map-returned-events}
+
+An event returned through `rejectOn` or `stopOn` does not enter exception middleware. At the web API boundary, the endpoint must map that business outcome to HTTP explicitly. It can use an ordinary switch, or use `ResponseFromEvents` from the Express and Hono integrations.
+
+This Express route calls the command handler, passes its result to `ResponseFromEvents`, and returns the same `Conflict(...)` or success response that an `on` route normally returns:
+
+<<< @./../packages/emmett-expressjs/src/responses.int.spec.ts#express-response-from-events-route
+
+The `failure` callback is checked for each produced event, from newest to oldest, until it returns a response. Returning `undefined` leaves that event unmapped. If no failure response is selected, `success` provides the normal status or response callback. The Hono helper uses the same mapping and additionally receives its `context`.
 
 ### Map Your Own Errors {#custom-mapping}
 

--- a/src/docs/guides/workflows.md
+++ b/src/docs/guides/workflows.md
@@ -148,6 +148,10 @@ type GroupCheckoutOutput =
         failedCheckouts: string[];
       }
     >
+  | Event<
+      'GroupCheckoutRejected',
+      { groupCheckoutId: string; reason: 'NoGuestStays' }
+    >
   | Event<'GroupCheckoutTimedOut', { groupCheckoutId: string }>;
 ```
 
@@ -184,6 +188,14 @@ const initiateGroupCheckout = (
   }
 
   const { groupCheckoutId, guestStayAccountIds } = command.data;
+
+  if (guestStayAccountIds.length === 0) {
+    return {
+      kind: 'Event',
+      type: 'GroupCheckoutRejected',
+      data: { groupCheckoutId, reason: 'NoGuestStays' },
+    };
+  }
 
   return [
     // Record that checkout was initiated
@@ -306,6 +318,8 @@ const evolve = (
       if (state.status !== 'Pending') return state;
       return { status: 'Finished' };
     }
+    case 'GroupCheckoutRejected':
+      return state;
     default:
       return state;
   }
@@ -341,11 +355,24 @@ const groupCheckoutProcessor = workflowProcessor({
       'GroupCheckoutInitiated',
       'GroupCheckoutCompleted',
       'GroupCheckoutFailed',
+      'GroupCheckoutRejected',
       'GroupCheckoutTimedOut',
     ],
   },
 });
 ```
+
+## Return an Output Without Storing It {#reject-workflow-output}
+
+`WorkflowHandler` records the input message before its outputs are dispatched. This prevents the same input from being handled twice. Normally, the commands and events produced by the workflow are stored in the workflow stream as its outbox.
+
+Sometimes the workflow produces a failure that the caller needs immediately, but that should not be dispatched to another handler. Here an `InitiateGroupCheckout` command with no guest stays produces `GroupCheckoutRejected`. `rejectOn` returns that event without adding it to the workflow outbox:
+
+<<< @./../packages/emmett/src/workflows/handleWorkflow.middleware.unit.spec.ts#workflow-output-rejection
+
+The input remains recorded, so delivering the same command again is still treated as a duplicate. `GroupCheckoutRejected` is available in `result.messages`, but it is not stored or dispatched. Use this only when no later processor needs the rejection; otherwise let the workflow append it normally.
+
+The other decision-middleware choices have the same output behavior as command handling: `skipOn` omits the matching output and continues, `stopOn` omits it and stops, and `stopAfter` stores it before stopping. See the [CommandHandler reference](/api-reference/commandhandler#decision-middleware) for their exact result contracts.
 
 ## Testing Workflows
 

--- a/src/packages/emmett-expressjs/src/responses.int.spec.ts
+++ b/src/packages/emmett-expressjs/src/responses.int.spec.ts
@@ -1,0 +1,198 @@
+import {
+  assertEqual,
+  assertMatches,
+  DeciderCommandHandler,
+  getInMemoryEventStore,
+  rejectOn,
+  type Event,
+} from '@event-driven-io/emmett';
+import type { Request, Router } from 'express';
+import request from 'supertest';
+import { describe, it } from 'vitest';
+import {
+  Conflict,
+  getApplication,
+  NoContent,
+  on,
+  ResponseFromEvents,
+  sendResponseFromEvents,
+  toWeakETag,
+} from '.';
+
+type ProductItemAdded = Event<'ProductItemAdded', { productId: string }>;
+type ProductItemOutOfStock = Event<
+  'ProductItemOutOfStock',
+  { availableQuantity: number }
+>;
+type ShoppingCartEvent = ProductItemAdded | ProductItemOutOfStock;
+
+const successfulResult = {
+  events: [
+    { type: 'ProductItemAdded', data: { productId: 'product-1' } },
+  ] as ShoppingCartEvent[],
+  nextExpectedStreamVersion: 4n,
+};
+const rejectedResult = {
+  events: [
+    { type: 'ProductItemOutOfStock', data: { availableQuantity: 2 } },
+    { type: 'ProductItemAdded', data: { productId: 'product-1' } },
+  ] as ShoppingCartEvent[],
+};
+
+const shoppingCartApi = (router: Router) => {
+  router.get(
+    '/success',
+    on(() =>
+      ResponseFromEvents({
+        events: successfulResult,
+        success: (result) =>
+          NoContent({
+            eTag: toWeakETag(result.nextExpectedStreamVersion),
+          }),
+      }),
+    ),
+  );
+  router.get(
+    '/numeric',
+    on(() =>
+      ResponseFromEvents({ events: successfulResult.events, success: 202 }),
+    ),
+  );
+  router.get(
+    '/default',
+    on(() => ResponseFromEvents({ events: successfulResult.events })),
+  );
+  router.get(
+    '/numeric-failure',
+    on(() =>
+      ResponseFromEvents({
+        events: rejectedResult,
+        failure: (event) =>
+          event.type === 'ProductItemOutOfStock' ? 409 : undefined,
+      }),
+    ),
+  );
+  router.get('/send', (_request, response) =>
+    sendResponseFromEvents(response, {
+      events: successfulResult.events,
+      success: 204,
+    }),
+  );
+};
+
+const application = getApplication({ apis: [shoppingCartApi] });
+
+type AddProductItem = {
+  type: 'AddProductItem';
+  data: { productId: string; quantity: number; availableQuantity: number };
+};
+type Cart = { productIds: string[] };
+type AddProductItemRequest = Request<
+  { shoppingCartId: string },
+  unknown,
+  { productId: string; quantity: number }
+>;
+
+const handleAddProductItem = DeciderCommandHandler<
+  Cart,
+  AddProductItem,
+  ShoppingCartEvent
+>({
+  initialState: () => ({ productIds: [] }),
+  evolve: (state, event) =>
+    event.type === 'ProductItemAdded'
+      ? { productIds: [...state.productIds, event.data.productId] }
+      : state,
+  decide: (command) =>
+    command.data.quantity > command.data.availableQuantity
+      ? {
+          type: 'ProductItemOutOfStock',
+          data: { availableQuantity: command.data.availableQuantity },
+        }
+      : {
+          type: 'ProductItemAdded',
+          data: { productId: command.data.productId },
+        },
+  middleware: [rejectOn((event) => event.type === 'ProductItemOutOfStock')],
+});
+const eventStore = getInMemoryEventStore();
+
+const addProductItemApi = (router: Router) => {
+  // #region express-response-from-events-route
+  router.post(
+    '/shopping-carts/:shoppingCartId/product-items',
+    on(async (request: AddProductItemRequest) => {
+      const result = await handleAddProductItem(
+        eventStore,
+        request.params.shoppingCartId,
+        {
+          type: 'AddProductItem',
+          data: {
+            productId: String(request.body.productId),
+            quantity: Number(request.body.quantity),
+            availableQuantity: 2,
+          },
+        },
+      );
+
+      return ResponseFromEvents({
+        events: result,
+        success: 204,
+        failure: (event) => {
+          switch (event.type) {
+            case 'ProductItemOutOfStock':
+              return Conflict({
+                problemDetails: `Only ${event.data.availableQuantity} items are available`,
+              });
+          }
+          return undefined;
+        },
+      });
+    }),
+  );
+  // #endregion express-response-from-events-route
+};
+
+const addProductItemApplication = getApplication({
+  apis: [addProductItemApi],
+});
+
+describe('ResponseFromEvents Express integration', () => {
+  it('returns a success response through on', async () => {
+    const response = await request(application).get('/success');
+
+    assertEqual(response.statusCode, 204);
+    assertEqual(response.headers.etag, 'W/"4"');
+  });
+
+  it('maps a failure that is not the last produced event', async () => {
+    const response = await request(addProductItemApplication)
+      .post('/shopping-carts/cart-1/product-items')
+      .send({ productId: 'product-1', quantity: 3 });
+
+    assertEqual(response.statusCode, 409);
+    assertMatches(response.body, {
+      status: 409,
+      detail: 'Only 2 items are available',
+    });
+  });
+
+  it('accepts a numeric success status', async () => {
+    assertEqual((await request(application).get('/numeric')).statusCode, 202);
+  });
+
+  it('defaults the success response to no content', async () => {
+    assertEqual((await request(application).get('/default')).statusCode, 204);
+  });
+
+  it('accepts a numeric failure status', async () => {
+    assertEqual(
+      (await request(application).get('/numeric-failure')).statusCode,
+      409,
+    );
+  });
+
+  it('supports the imperative send path', async () => {
+    assertEqual((await request(application).get('/send')).statusCode, 204);
+  });
+});

--- a/src/packages/emmett-expressjs/src/responses.ts
+++ b/src/packages/emmett-expressjs/src/responses.ts
@@ -115,3 +115,62 @@ export const sendProblem = (
   response.statusCode = statusCode;
   response.json(problemDetails);
 };
+
+export type EventResponseSource<Event> = Event[] | { events: Event[] };
+
+type EventOf<Source> = Source extends (infer Event)[]
+  ? Event
+  : Source extends { events: (infer Event)[] }
+    ? Event
+    : never;
+
+type MappedHttpResponse = (response: Response) => void;
+
+export type EventSuccessResponse = number | MappedHttpResponse;
+
+export type EventFailureResponse = number | MappedHttpResponse;
+
+export type ResponseFromEventsOptions<
+  Source extends EventResponseSource<unknown>,
+> = {
+  events: Source;
+  success?: number | ((source: Source) => EventSuccessResponse);
+  failure?: (
+    event: EventOf<Source>,
+    source: Source,
+  ) => EventFailureResponse | undefined;
+};
+
+export const ResponseFromEvents = <
+  Source extends EventResponseSource<unknown>,
+>({
+  events: source,
+  success = 204,
+  failure,
+}: ResponseFromEventsOptions<Source>): MappedHttpResponse => {
+  const events = (
+    Array.isArray(source) ? source : source.events
+  ) as EventOf<Source>[];
+
+  if (failure) {
+    for (let index = events.length - 1; index >= 0; index--) {
+      const selected = failure(events[index]!, source);
+      if (selected === undefined) continue;
+      return typeof selected === 'number'
+        ? (response) => sendProblem(response, selected)
+        : selected;
+    }
+  }
+
+  const selected = typeof success === 'number' ? success : success(source);
+  return typeof selected === 'number'
+    ? (response) => send(response, selected)
+    : selected;
+};
+
+export const sendResponseFromEvents = <
+  Source extends EventResponseSource<unknown>,
+>(
+  response: Response,
+  options: ResponseFromEventsOptions<Source>,
+): void => ResponseFromEvents(options)(response);

--- a/src/packages/emmett-expressjs/src/responses.unit.spec.ts
+++ b/src/packages/emmett-expressjs/src/responses.unit.spec.ts
@@ -8,13 +8,25 @@ import type { Response } from 'express';
 import { ProblemDocument } from 'http-problem-details';
 import { beforeEach, describe, it, vi } from 'vitest';
 import { toWeakETag } from './etag';
+import { Conflict, NoContent, on } from './handler';
 import {
+  ResponseFromEvents,
   send,
   sendAccepted,
   sendCreated,
   sendNoContent,
   sendProblem,
 } from './responses';
+
+type ProductItemAdded = {
+  type: 'ProductItemAdded';
+  data: { productId: string };
+};
+type ProductItemOutOfStock = {
+  type: 'ProductItemOutOfStock';
+  data: { availableQuantity: number };
+};
+type ShoppingCartEvent = ProductItemAdded | ProductItemOutOfStock;
 
 // Minimal mock of Express Response
 const mockResponse = () => {
@@ -66,6 +78,85 @@ void describe('send', () => {
     const res = mockResponse();
     send(res, 200, { eTag: toWeakETag(42), body: 'x' });
     assertEqual(res.headers['etag'], 'W/"42"');
+  });
+});
+
+void describe('ResponseFromEvents', () => {
+  void it('returns the HttpResponse expected by on', async () => {
+    const res = mockResponse();
+
+    const route = on(() =>
+      ResponseFromEvents({
+        events: [
+          { type: 'ProductItemAdded', data: { productId: 'product-1' } },
+        ],
+        success: 202,
+      }),
+    );
+    await route({} as never, res, vi.fn());
+
+    assertEqual(res.statusCode, 202);
+  });
+
+  void it('maps a matching event from a complete handler result', () => {
+    const res = mockResponse();
+    const result = {
+      events: [
+        {
+          type: 'ProductItemOutOfStock',
+          data: { availableQuantity: 2 },
+        },
+        { type: 'ProductItemAdded', data: { productId: 'product-1' } },
+      ] as ShoppingCartEvent[],
+      appendedEvents: [],
+      nextExpectedStreamVersion: 4n,
+    };
+
+    const selectResponse = () => {
+      // #region express-command-result-response
+      return ResponseFromEvents({
+        events: result,
+        success: 204,
+        failure: (event) => {
+          switch (event.type) {
+            case 'ProductItemOutOfStock':
+              return Conflict({
+                problemDetails: `Only ${event.data.availableQuantity} items are available`,
+              });
+          }
+          return undefined;
+        },
+      });
+      // #endregion express-command-result-response
+    };
+    const response = selectResponse();
+
+    response(res);
+
+    assertEqual(res.statusCode, 409);
+    assertMatches(res.body, {
+      status: 409,
+      detail: 'Only 2 items are available',
+    });
+  });
+
+  void it('uses the complete result in a success response callback', () => {
+    const res = mockResponse();
+    const result = {
+      events: [{ type: 'ProductItemAdded', data: { productId: 'product-1' } }],
+      nextExpectedStreamVersion: 4n,
+    };
+
+    ResponseFromEvents({
+      events: result,
+      success: (handled) =>
+        NoContent({
+          eTag: toWeakETag(handled.nextExpectedStreamVersion),
+        }),
+    })(res);
+
+    assertEqual(res.statusCode, 204);
+    assertEqual(res.headers['etag'], 'W/"4"');
   });
 });
 

--- a/src/packages/emmett-honojs/src/responses.int.spec.ts
+++ b/src/packages/emmett-honojs/src/responses.int.spec.ts
@@ -1,0 +1,119 @@
+import {
+  assertEqual,
+  assertMatches,
+  type Event,
+} from '@event-driven-io/emmett';
+import { Hono } from 'hono';
+import { describe, it } from 'vitest';
+import {
+  Conflict,
+  NoContent,
+  ResponseFromEvents,
+  sendResponseFromEvents,
+  toWeakETag,
+} from '.';
+
+type ProductItemAdded = Event<'ProductItemAdded', { productId: string }>;
+type ProductItemOutOfStock = Event<
+  'ProductItemOutOfStock',
+  { availableQuantity: number }
+>;
+type ShoppingCartEvent = ProductItemAdded | ProductItemOutOfStock;
+
+const successfulResult = {
+  events: [
+    { type: 'ProductItemAdded', data: { productId: 'product-1' } },
+  ] as ShoppingCartEvent[],
+  nextExpectedStreamVersion: 4n,
+};
+const rejectedResult = {
+  events: [
+    { type: 'ProductItemOutOfStock', data: { availableQuantity: 2 } },
+    { type: 'ProductItemAdded', data: { productId: 'product-1' } },
+  ] as ShoppingCartEvent[],
+};
+
+const application = new Hono();
+application.get('/success', (context) =>
+  ResponseFromEvents({
+    context,
+    events: successfulResult,
+    success: (result) =>
+      NoContent({
+        context,
+        eTag: toWeakETag(result.nextExpectedStreamVersion),
+      }),
+  }),
+);
+application.get('/failure', (context) =>
+  ResponseFromEvents({
+    context,
+    events: rejectedResult,
+    failure: (event) =>
+      event.type === 'ProductItemOutOfStock'
+        ? Conflict({
+            context,
+            problemDetails: `Only ${event.data.availableQuantity} items are available`,
+          })
+        : undefined,
+  }),
+);
+application.get('/numeric', (context) =>
+  ResponseFromEvents({
+    context,
+    events: successfulResult.events,
+    success: 202,
+  }),
+);
+application.get('/default', (context) =>
+  ResponseFromEvents({ context, events: successfulResult.events }),
+);
+application.get('/numeric-failure', (context) =>
+  ResponseFromEvents({
+    context,
+    events: rejectedResult,
+    failure: (event) =>
+      event.type === 'ProductItemOutOfStock' ? 409 : undefined,
+  }),
+);
+application.get('/send', (context) =>
+  sendResponseFromEvents(context, {
+    events: successfulResult.events,
+    success: 204,
+  }),
+);
+
+describe('ResponseFromEvents Hono integration', () => {
+  it('returns a success response', async () => {
+    const response = await application.request('/success');
+
+    assertEqual(response.status, 204);
+    assertEqual(response.headers.get('etag'), 'W/"4"');
+  });
+
+  it('maps a failure that is not the last produced event', async () => {
+    const response = await application.request('/failure');
+
+    assertEqual(response.status, 409);
+    assertMatches(await response.json(), {
+      status: 409,
+      detail: 'Only 2 items are available',
+    });
+  });
+
+  it('accepts a numeric success status', async () => {
+    assertEqual((await application.request('/numeric')).status, 202);
+  });
+
+  it('defaults the success response to no content', async () => {
+    assertEqual((await application.request('/default')).status, 204);
+  });
+
+  it('accepts a numeric failure status', async () => {
+    assertEqual((await application.request('/numeric-failure')).status, 409);
+  });
+
+  it('supports the imperative send path', async () => {
+    assertEqual((await application.request('/send')).status, 204);
+  });
+});

--- a/src/packages/emmett-honojs/src/responses.ts
+++ b/src/packages/emmett-honojs/src/responses.ts
@@ -117,3 +117,60 @@ export const sendProblem = (
   response.headers.set('Content-Type', 'application/problem+json');
   return response;
 };
+
+export type EventResponseSource<Event> = Event[] | { events: Event[] };
+
+type EventOf<Source> = Source extends (infer Event)[]
+  ? Event
+  : Source extends { events: (infer Event)[] }
+    ? Event
+    : never;
+
+export type EventSuccessResponse = StatusCode | Response;
+
+export type EventFailureResponse = StatusCode | Response;
+
+export type ResponseFromEventsOptions<
+  Source extends EventResponseSource<unknown>,
+> = {
+  context: Context;
+  events: Source;
+  success?: StatusCode | ((source: Source) => EventSuccessResponse);
+  failure?: (
+    event: EventOf<Source>,
+    source: Source,
+  ) => EventFailureResponse | undefined;
+};
+
+export const ResponseFromEvents = <
+  Source extends EventResponseSource<unknown>,
+>({
+  context,
+  events: source,
+  success = 204,
+  failure,
+}: ResponseFromEventsOptions<Source>): Response => {
+  const events = (
+    Array.isArray(source) ? source : source.events
+  ) as EventOf<Source>[];
+
+  if (failure) {
+    for (let index = events.length - 1; index >= 0; index--) {
+      const selected = failure(events[index]!, source);
+      if (selected === undefined) continue;
+      return typeof selected === 'number'
+        ? sendProblem(context, selected)
+        : selected;
+    }
+  }
+
+  const selected = typeof success === 'number' ? success : success(source);
+  return typeof selected === 'number' ? send(context, selected) : selected;
+};
+
+export const sendResponseFromEvents = <
+  Source extends EventResponseSource<unknown>,
+>(
+  context: Context,
+  options: Omit<ResponseFromEventsOptions<Source>, 'context'>,
+): Response => ResponseFromEvents({ ...options, context });

--- a/src/packages/emmett-honojs/src/responses.unit.spec.ts
+++ b/src/packages/emmett-honojs/src/responses.unit.spec.ts
@@ -9,13 +9,25 @@ import type { Context } from 'hono';
 import { ProblemDocument } from 'http-problem-details';
 import { describe, it } from 'vitest';
 import { toWeakETag } from './etag';
+import { Conflict, NoContent } from './handler';
 import {
+  ResponseFromEvents,
   send,
   sendAccepted,
   sendCreated,
   sendNoContent,
   sendProblem,
 } from './responses';
+
+type ProductItemAdded = {
+  type: 'ProductItemAdded';
+  data: { productId: string };
+};
+type ProductItemOutOfStock = {
+  type: 'ProductItemOutOfStock';
+  data: { availableQuantity: number };
+};
+type ShoppingCartEvent = ProductItemAdded | ProductItemOutOfStock;
 
 // Helper: build a one-shot Hono app, call handler with context, return the Response
 const withContext = async (
@@ -54,6 +66,81 @@ void describe('send', () => {
       send(c, 200, { eTag: toWeakETag(42), body: 'x' }),
     );
     assertEqual(response.headers.get('etag'), 'W/"42"');
+  });
+});
+
+void describe('ResponseFromEvents', () => {
+  void it('uses a numeric success status when no event maps to a failure', async () => {
+    const response = await withContext((context) =>
+      ResponseFromEvents({
+        context,
+        events: [
+          { type: 'ProductItemAdded', data: { productId: 'product-1' } },
+        ],
+        success: 202,
+      }),
+    );
+
+    assertEqual(response.status, 202);
+  });
+
+  void it('maps a matching event from a complete handler result', async () => {
+    const result = {
+      events: [
+        {
+          type: 'ProductItemOutOfStock',
+          data: { availableQuantity: 2 },
+        },
+        { type: 'ProductItemAdded', data: { productId: 'product-1' } },
+      ] as ShoppingCartEvent[],
+      appendedEvents: [],
+      nextExpectedStreamVersion: 4n,
+    };
+
+    const response = await withContext((context) => {
+      return ResponseFromEvents({
+        context,
+        events: result,
+        success: 204,
+        failure: (event) => {
+          switch (event.type) {
+            case 'ProductItemOutOfStock':
+              return Conflict({
+                context,
+                problemDetails: `Only ${event.data.availableQuantity} items are available`,
+              });
+          }
+          return undefined;
+        },
+      });
+    });
+
+    assertEqual(response.status, 409);
+    assertMatches(await response.json(), {
+      status: 409,
+      detail: 'Only 2 items are available',
+    });
+  });
+
+  void it('uses the complete result in a success response callback', async () => {
+    const result = {
+      events: [{ type: 'ProductItemAdded', data: { productId: 'product-1' } }],
+      nextExpectedStreamVersion: 4n,
+    };
+    const response = await withContext((context) =>
+      ResponseFromEvents({
+        context,
+        events: result,
+        success: (handled) =>
+          NoContent({
+            context,
+            eTag: toWeakETag(handled.nextExpectedStreamVersion),
+          }),
+      }),
+    );
+
+    assertEqual(response.status, 204);
+    assertEqual(response.headers.get('etag'), 'W/"4"');
   });
 });
 

--- a/src/packages/emmett/src/commandHandling/handleCommand.middleware.unit.spec.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.middleware.unit.spec.ts
@@ -1,11 +1,22 @@
 import { randomUUID } from 'node:crypto';
 import { describe, it } from 'vitest';
 import { IllegalStateError } from '../errors';
-import { getInMemoryEventStore, type EventStore } from '../eventStore';
-import { assertThrowsAsync, assertTrue } from '../testing';
+import {
+  ExpectedVersionConflictError,
+  getInMemoryEventStore,
+} from '../eventStore';
+import { assertDeepEqual, assertEqual, assertThrowsAsync } from '../testing';
 import type { Event } from '../typing';
-import { CommandHandler, type HandleOptions } from './handleCommand';
-
+import { CommandHandler } from './handleCommand';
+import {
+  after,
+  before,
+  rejectOn,
+  skipOn,
+  stopAfter,
+  stopOn,
+  throwOn,
+} from './middleware';
 // Events & Entity
 
 type PricedProductItem = { productId: string; quantity: number; price: number };
@@ -13,14 +24,54 @@ type PricedProductItem = { productId: string; quantity: number; price: number };
 type ShoppingCart = {
   productItems: PricedProductItem[];
   totalAmount: number;
+  status: 'Opened' | 'Confirmed' | 'Cancelled';
 };
 
 type ProductItemAdded = Event<
   'ProductItemAdded',
   { productItem: PricedProductItem }
 >;
+type DiscountApplied = Event<'DiscountApplied', { percent: number }>;
+type ShoppingCartConfirmed = Event<
+  'ShoppingCartConfirmed',
+  { confirmedAt: Date }
+>;
+type ShoppingCartCancelled = Event<
+  'ShoppingCartCancelled',
+  { canceledAt: Date }
+>;
+type ProductItemOutOfStock = Event<
+  'ProductItemOutOfStock',
+  {
+    productId: string;
+    requestedQuantity: number;
+    availableQuantity: number;
+  }
+>;
+type ShoppingCartItemLimitReached = Event<
+  'ShoppingCartItemLimitReached',
+  { maximumItems: number; requestedProductId: string }
+>;
+type ProductItemAlreadyInCart = Event<
+  'ProductItemAlreadyInCart',
+  { productId: string }
+>;
+type ShoppingCartConfirmationFailed = Event<
+  'ShoppingCartConfirmationFailed',
+  { reason: 'PaymentAuthorizationFailed' }
+>;
 
-type ShoppingCartEvent = ProductItemAdded;
+// #region event-union
+type ShoppingCartEvent =
+  | ProductItemAdded
+  | DiscountApplied
+  | ShoppingCartConfirmed
+  | ShoppingCartCancelled
+  | ProductItemOutOfStock
+  | ShoppingCartItemLimitReached
+  | ProductItemAlreadyInCart
+  | ShoppingCartConfirmationFailed;
+// #endregion event-union
 
 const evolve = (
   state: ShoppingCart,
@@ -30,16 +81,31 @@ const evolve = (
     case 'ProductItemAdded': {
       const productItem = data.productItem;
       return {
+        ...state,
         productItems: [...state.productItems, productItem],
         totalAmount:
           state.totalAmount + productItem.price * productItem.quantity,
       };
     }
+    case 'DiscountApplied':
+      return {
+        ...state,
+        totalAmount: state.totalAmount * (1 - data.percent),
+      };
+    case 'ShoppingCartConfirmed':
+      return { ...state, status: 'Confirmed' };
+    case 'ShoppingCartCancelled':
+      return { ...state, status: 'Cancelled' };
+    case 'ProductItemOutOfStock':
+    case 'ShoppingCartItemLimitReached':
+    case 'ProductItemAlreadyInCart':
+    case 'ShoppingCartConfirmationFailed':
+      return state;
   }
 };
 
 const initialState = (): ShoppingCart => {
-  return { productItems: [], totalAmount: 0 };
+  return { productItems: [], totalAmount: 0, status: 'Opened' };
 };
 
 // Decision making
@@ -49,6 +115,7 @@ type AddProductItem = Event<
   { productItem: PricedProductItem }
 >;
 
+// #region single-event-decision
 const addProductItem = (
   command: AddProductItem,
   _state: ShoppingCart,
@@ -59,95 +126,416 @@ const addProductItem = (
   };
 };
 
-const rawCommandHandler = CommandHandler<ShoppingCart, ShoppingCartEvent>({
-  evolve,
-  initialState,
-});
+// #region decision-handling-business-logic
+const addProductItemWithStock = (
+  command: AddProductItem,
+  availableQuantity: number,
+  state: ShoppingCart,
+): ShoppingCartEvent =>
+  command.data.productItem.quantity > availableQuantity
+    ? {
+        type: 'ProductItemOutOfStock',
+        data: {
+          productId: command.data.productItem.productId,
+          requestedQuantity: command.data.productItem.quantity,
+          availableQuantity,
+        },
+      }
+    : addProductItem(command, state);
 
-type RequestHeaders = {
-  authToken: string;
+const addProductItemWithinLimit = (
+  command: AddProductItem,
+  maximumItems: number,
+  state: ShoppingCart,
+): ShoppingCartEvent =>
+  state.productItems.length >= maximumItems
+    ? {
+        type: 'ShoppingCartItemLimitReached',
+        data: {
+          maximumItems,
+          requestedProductId: command.data.productItem.productId,
+        },
+      }
+    : addProductItem(command, state);
+
+const addProductItemOnce = (
+  command: AddProductItem,
+  state: ShoppingCart,
+): ShoppingCartEvent =>
+  state.productItems.some(
+    (item) => item.productId === command.data.productItem.productId,
+  )
+    ? {
+        type: 'ProductItemAlreadyInCart',
+        data: { productId: command.data.productItem.productId },
+      }
+    : addProductItem(command, state);
+
+const confirmAfterPaymentAuthorization = (
+  command: ConfirmShoppingCart,
+  paymentAuthorized: boolean,
+  state: ShoppingCart,
+): ShoppingCartEvent[] | ShoppingCartEvent =>
+  paymentAuthorized
+    ? confirm(command, state)
+    : {
+        type: 'ShoppingCartConfirmationFailed',
+        data: { reason: 'PaymentAuthorizationFailed' },
+      };
+// #endregion decision-handling-business-logic
+// #endregion single-event-decision
+
+type ConfirmShoppingCart = Event<'ConfirmShoppingCart', { now: Date }>;
+
+// #region confirm-decision
+const confirm = (
+  command: ConfirmShoppingCart,
+  state: ShoppingCart,
+): ShoppingCartEvent[] => {
+  // Already confirmed: nothing left to do, so append nothing
+  if (state.status === 'Confirmed') return [];
+
+  if (state.productItems.length === 0)
+    throw new IllegalStateError('Cannot confirm an empty shopping cart');
+
+  return [
+    { type: 'ShoppingCartConfirmed', data: { confirmedAt: command.data.now } },
+  ];
 };
+// #endregion confirm-decision
 
-const VALID_AUTH_TOKEN = 'VALID_AUTH_TOKEN';
-const INVALID_AUTH_TOKEN = 'INVALID_AUTH_TOKEN';
-
-export const authorize = (requestHeaders: RequestHeaders): Promise<void> => {
-  if (requestHeaders.authToken !== VALID_AUTH_TOKEN)
-    return Promise.reject(new IllegalStateError('Authorization failed!'));
-
-  return Promise.resolve();
-};
-
-export const handleCommand = async <Store extends EventStore>(
-  store: Store,
-  id: string,
-  decide: (state: ShoppingCart) => ShoppingCartEvent | ShoppingCartEvent[],
-  handleOptions: HandleOptions<Store> & { requestHeaders: RequestHeaders },
-) =>
-  rawCommandHandler(
-    store,
-    id,
-    async (
-      state: ShoppingCart,
-    ): Promise<ShoppingCartEvent | ShoppingCartEvent[]> => {
-      await authorize(handleOptions.requestHeaders);
-
-      return decide(state);
-    },
-    handleOptions,
-  );
-
-void describe('Command Handler', () => {
+void describe('CommandHandler middleware', () => {
   const eventStore = getInMemoryEventStore();
 
-  void it('Succeeds when middleware allows processing', async () => {
-    const productItem: PricedProductItem = {
-      productId: '123',
-      quantity: 10,
-      price: 3,
-    };
-
+  void it('rejects a complete shopping-cart batch on an out-of-stock outcome', async () => {
     const shoppingCartId = randomUUID();
-    const command: AddProductItem = {
+    const availableProduct: AddProductItem = {
       type: 'AddProductItem',
-      data: { productItem },
+      data: {
+        productItem: { productId: 'product-1', quantity: 1, price: 10 },
+      },
+    };
+    const unavailableProduct: AddProductItem = {
+      type: 'AddProductItem',
+      data: {
+        productItem: { productId: 'product-2', quantity: 3, price: 15 },
+      },
+    };
+    const confirmCart: ConfirmShoppingCart = {
+      type: 'ConfirmShoppingCart',
+      data: { now: new Date() },
     };
 
-    const { createdNewStream } = await handleCommand(
-      eventStore,
-      shoppingCartId,
-      (state) => addProductItem(command, state),
-      { requestHeaders: { authToken: VALID_AUTH_TOKEN } },
-    );
+    // #region command-handler-reject-on
+    const addAvailableProduct = (state: ShoppingCart) =>
+      addProductItemWithStock(availableProduct, 5, state);
 
-    assertTrue(createdNewStream);
+    const addUnavailableProduct = (state: ShoppingCart) =>
+      addProductItemWithStock(unavailableProduct, 2, state);
+
+    const confirmTheCart = (state: ShoppingCart) => confirm(confirmCart, state);
+
+    // #region command-handler-reject-on-setup
+    const handle = CommandHandler<ShoppingCart, ShoppingCartEvent>({
+      evolve,
+      initialState,
+      // An out-of-stock result cancels every change made by this batch.
+      middleware: [rejectOn((event) => event.type === 'ProductItemOutOfStock')],
+    });
+    // #endregion command-handler-reject-on-setup
+
+    const result = await handle(eventStore, shoppingCartId, [
+      // Saved only if the complete batch can finish.
+      addAvailableProduct,
+      // This reports ProductItemOutOfStock and rejects the complete batch.
+      addUnavailableProduct,
+      // Rejection stops the batch, so confirmation is not called.
+      confirmTheCart,
+    ]);
+    // #endregion command-handler-reject-on
+
+    assertDeepEqual(
+      result.events.map((event) => event.type),
+      ['ProductItemAdded', 'ProductItemOutOfStock'],
+    );
+    assertDeepEqual(result.appendedEvents, []);
+    assertDeepEqual(result.newState, initialState());
   });
 
-  void it('Fails when middleware rejects processing', async () => {
-    const productItem: PricedProductItem = {
-      productId: '123',
-      quantity: 10,
-      price: 3,
-    };
-
+  void it('stops a batch while retaining earlier accepted decisions', async () => {
     const shoppingCartId = randomUUID();
-    const command: AddProductItem = {
+    const availableProduct: AddProductItem = {
       type: 'AddProductItem',
-      data: { productItem },
+      data: {
+        productItem: { productId: 'product-1', quantity: 1, price: 10 },
+      },
+    };
+    const confirmCart: ConfirmShoppingCart = {
+      type: 'ConfirmShoppingCart',
+      data: { now: new Date() },
     };
 
-    await assertThrowsAsync<IllegalStateError>(
-      async () => {
-        await handleCommand(
-          eventStore,
-          shoppingCartId,
-          (state) => addProductItem(command, state),
-          { requestHeaders: { authToken: INVALID_AUTH_TOKEN } },
-        );
-      },
-      (error: Error) =>
-        error instanceof IllegalStateError &&
-        error.message === 'Authorization failed!',
+    // #region command-handler-stop-on
+    const addAvailableProduct = (state: ShoppingCart) =>
+      addProductItemWithStock(availableProduct, 5, state);
+
+    const confirmWithoutPayment = (state: ShoppingCart) =>
+      confirmAfterPaymentAuthorization(confirmCart, false, state);
+
+    const addAnotherProduct = (state: ShoppingCart) =>
+      addProductItem(availableProduct, state);
+
+    // #region command-handler-stop-on-setup
+    const handle = CommandHandler<ShoppingCart, ShoppingCartEvent>({
+      evolve,
+      initialState,
+      middleware: [
+        stopOn((event) => event.type === 'ShoppingCartConfirmationFailed'),
+      ],
+    });
+    // #endregion command-handler-stop-on-setup
+
+    const result = await handle(eventStore, shoppingCartId, [
+      addAvailableProduct,
+      confirmWithoutPayment,
+      addAnotherProduct,
+    ]);
+    // #endregion command-handler-stop-on
+
+    assertDeepEqual(
+      result.appendedEvents.map((event) => event.type),
+      ['ProductItemAdded'],
     );
+    assertDeepEqual(result.newState.productItems, [
+      availableProduct.data.productItem,
+    ]);
+  });
+
+  void it('skips a duplicate product and continues the cart batch', async () => {
+    const shoppingCartId = randomUUID();
+    const availableProduct: AddProductItem = {
+      type: 'AddProductItem',
+      data: {
+        productItem: { productId: 'product-1', quantity: 1, price: 10 },
+      },
+    };
+    const confirmCart: ConfirmShoppingCart = {
+      type: 'ConfirmShoppingCart',
+      data: { now: new Date() },
+    };
+
+    // #region command-handler-skip-on
+    const addAvailableProduct = (state: ShoppingCart) =>
+      addProductItemOnce(availableProduct, state);
+
+    const addTheSameProductAgain = (state: ShoppingCart) =>
+      addProductItemOnce(availableProduct, state);
+
+    const confirmTheCart = (state: ShoppingCart) => confirm(confirmCart, state);
+
+    // #region command-handler-skip-on-setup
+    const handle = CommandHandler<ShoppingCart, ShoppingCartEvent>({
+      evolve,
+      initialState,
+      middleware: [
+        skipOn((event) => event.type === 'ProductItemAlreadyInCart'),
+      ],
+    });
+    // #endregion command-handler-skip-on-setup
+
+    const result = await handle(eventStore, shoppingCartId, [
+      addAvailableProduct,
+      addTheSameProductAgain,
+      confirmTheCart,
+    ]);
+    // #endregion command-handler-skip-on
+
+    assertDeepEqual(
+      result.events.map((event) => event.type),
+      ['ProductItemAdded', 'ProductItemAlreadyInCart', 'ShoppingCartConfirmed'],
+    );
+    assertDeepEqual(
+      result.appendedEvents.map((event) => event.type),
+      ['ProductItemAdded', 'ShoppingCartConfirmed'],
+    );
+  });
+
+  void it('records a terminal business failure and stops later decisions', async () => {
+    const shoppingCartId = randomUUID();
+    const firstProduct: AddProductItem = {
+      type: 'AddProductItem',
+      data: {
+        productItem: { productId: 'product-1', quantity: 1, price: 10 },
+      },
+    };
+    const productOverTheLimit: AddProductItem = {
+      type: 'AddProductItem',
+      data: {
+        productItem: { productId: 'product-2', quantity: 1, price: 15 },
+      },
+    };
+    const productThatMustNotBeAdded: AddProductItem = {
+      type: 'AddProductItem',
+      data: {
+        productItem: { productId: 'product-3', quantity: 1, price: 20 },
+      },
+    };
+    const maximumItems = 1;
+
+    // #region command-handler-stop-after
+    const addFirstProduct = (state: ShoppingCart) =>
+      addProductItemWithinLimit(firstProduct, maximumItems, state);
+
+    const reachTheItemLimit = (state: ShoppingCart) =>
+      addProductItemWithinLimit(productOverTheLimit, maximumItems, state);
+
+    const addAnotherProduct = (state: ShoppingCart) =>
+      addProductItemWithinLimit(productThatMustNotBeAdded, maximumItems, state);
+
+    // #region command-handler-stop-after-setup
+    const handle = CommandHandler<ShoppingCart, ShoppingCartEvent>({
+      evolve,
+      initialState,
+      middleware: [
+        stopAfter((event) => event.type === 'ShoppingCartItemLimitReached'),
+      ],
+    });
+    // #endregion command-handler-stop-after-setup
+
+    const result = await handle(eventStore, shoppingCartId, [
+      addFirstProduct,
+      reachTheItemLimit,
+      addAnotherProduct,
+    ]);
+    // #endregion command-handler-stop-after
+
+    assertDeepEqual(
+      result.appendedEvents.map((event) => event.type),
+      ['ProductItemAdded', 'ShoppingCartItemLimitReached'],
+    );
+    assertDeepEqual(result.newState.productItems, [
+      firstProduct.data.productItem,
+    ]);
+  });
+
+  void it('authorizes once and can turn a failure event into an exception', async () => {
+    const shoppingCartId = randomUUID();
+    const unavailableProduct: AddProductItem = {
+      type: 'AddProductItem',
+      data: {
+        productItem: { productId: 'product-2', quantity: 3, price: 15 },
+      },
+    };
+    class ProductItemOutOfStockError extends Error {}
+    const authorizeRequest = (): Promise<void> => Promise.resolve();
+
+    // #region command-handler-before-all-throw-on
+    const addUnavailableProduct = (state: ShoppingCart) =>
+      addProductItemWithStock(unavailableProduct, 2, state);
+
+    const handle = CommandHandler<ShoppingCart, ShoppingCartEvent>({
+      evolve,
+      initialState,
+      middleware: {
+        beforeAll: authorizeRequest,
+        decision: [
+          throwOn(
+            (event) => event.type === 'ProductItemOutOfStock',
+            (event) => new ProductItemOutOfStockError(event.type),
+          ),
+        ],
+      },
+    });
+
+    // #endregion command-handler-before-all-throw-on
+
+    await assertThrowsAsync(
+      () => handle(eventStore, shoppingCartId, addUnavailableProduct),
+      (error) => error instanceof ProductItemOutOfStockError,
+    );
+
+    assertDeepEqual((await eventStore.readStream(shoppingCartId)).events, []);
+  });
+
+  void it('runs beforeAll once and decision middleware for each retry attempt', async () => {
+    const shoppingCartId = randomUUID();
+    const product: AddProductItem = {
+      type: 'AddProductItem',
+      data: {
+        productItem: { productId: 'product-1', quantity: 1, price: 10 },
+      },
+    };
+    let authorizationChecks = 0;
+    let measuredDecisions = 0;
+    let measuredInvocations = 0;
+
+    const authorizeRequest = () => {
+      authorizationChecks++;
+    };
+    const recordDecisionMetric = () => {
+      measuredDecisions++;
+    };
+
+    // #region command-middleware-retry
+    const handleWithRetrySafeMiddleware = CommandHandler<
+      ShoppingCart,
+      ShoppingCartEvent
+    >({
+      evolve,
+      initialState,
+      middleware: {
+        beforeAll: authorizeRequest,
+        afterAll: () => {
+          measuredInvocations++;
+        },
+        decision: [before(recordDecisionMetric)],
+      },
+      retry: { onVersionConflict: true },
+    });
+
+    await handleWithRetrySafeMiddleware(eventStore, shoppingCartId, (state) =>
+      addProductItem(product, state),
+    );
+    // #endregion command-middleware-retry
+
+    authorizationChecks = 0;
+    measuredDecisions = 0;
+    measuredInvocations = 0;
+    const handleThatSimulatesAConflict = CommandHandler<
+      ShoppingCart,
+      ShoppingCartEvent
+    >({
+      evolve,
+      initialState,
+      middleware: {
+        beforeAll: authorizeRequest,
+        afterAll: () => {
+          measuredInvocations++;
+        },
+        decision: [
+          before(recordDecisionMetric),
+          after((result) => {
+            if (measuredDecisions === 1)
+              throw new ExpectedVersionConflictError(0n, 1n);
+            return result;
+          }),
+        ],
+      },
+      retry: {
+        retries: 1,
+        minTimeout: 1,
+        factor: 1,
+        shouldRetryError: (error) =>
+          error instanceof ExpectedVersionConflictError,
+      },
+    });
+
+    await handleThatSimulatesAConflict(eventStore, randomUUID(), (state) =>
+      addProductItem(product, state),
+    );
+
+    assertEqual(authorizationChecks, 1);
+    assertEqual(measuredDecisions, 2);
+    assertEqual(measuredInvocations, 1);
   });
 });

--- a/src/packages/emmett/src/commandHandling/handleCommand.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.ts
@@ -22,6 +22,13 @@ import {
   commandObservability,
   type CommandObservabilityConfig,
 } from './observability';
+import {
+  append,
+  composeMiddleware,
+  resolveMiddleware,
+  type DecisionHandlingResult,
+  type MiddlewareOptions,
+} from './middleware';
 
 export const CommandHandlerStreamVersionConflictRetryOptions: AsyncRetryOptions =
   {
@@ -40,8 +47,37 @@ export type CommandHandlerResult<
   Store extends EventStore,
 > = AppendStreamResultOfEventStore<Store> & {
   newState: State;
+  events: StreamEvent[];
+  appendedEvents: StreamEvent[];
+  /** @deprecated Use appendedEvents. */
   newEvents: StreamEvent[];
 };
+
+export type CommandMiddlewareContext = undefined;
+
+export type BeforeAllContext<Store extends EventStore = EventStore> = {
+  streamName: string;
+  handleOptions: HandleOptions<Store> | undefined;
+};
+
+export type CommandHandlerMiddlewareOptions<
+  State,
+  StreamEvent extends Event,
+> = MiddlewareOptions<
+  State,
+  CommandMiddlewareContext,
+  StreamEvent,
+  (
+    handle:
+      | CommandHandlerFunction<State, StreamEvent>
+      | CommandHandlerFunction<State, StreamEvent>[],
+    context: BeforeAllContext,
+  ) => void | Promise<void>,
+  <Store extends EventStore>(
+    result: CommandHandlerResult<State, StreamEvent, Store>,
+    context: BeforeAllContext<Store>,
+  ) => void | Promise<void>
+>;
 
 export type CommandHandlerOptions<
   State,
@@ -60,6 +96,7 @@ export type CommandHandlerOptions<
   };
   name?: string;
   commandType?: string | string[];
+  middleware?: CommandHandlerMiddlewareOptions<State, StreamEvent>;
 } & JSONSerializationOptions & {
     observability?: CommandObservabilityConfig;
   };
@@ -79,7 +116,7 @@ export type HandleOptions<Store extends EventStore> = Parameters<
     observability?: OperationObservabilityOptions;
   };
 
-type CommandHandlerFunction<State, StreamEvent extends Event> = (
+export type CommandHandlerFunction<State, StreamEvent extends Event> = (
   state: State,
 ) => StreamEvent | StreamEvent[] | Promise<StreamEvent | StreamEvent[]>;
 
@@ -103,6 +140,14 @@ export const CommandHandler =
     const collector = commandHandlerCollector(observability);
     const streamName = (options.mapToStreamId ?? ((id: string) => id))(id);
 
+    const {
+      decision: decisionMiddleware,
+      beforeAll,
+      afterAll,
+    } = resolveMiddleware(options.middleware);
+
+    await beforeAll?.(handle, { streamName, handleOptions });
+
     // TODO: for array-of-handlers we record all types as an
     // `emmett.command.type` array attribute on the parent span and drop the
     // type label from the handling-duration histogram (OTel metric labels
@@ -124,7 +169,7 @@ export const CommandHandler =
       EventPayloadType
     >(handleOptions);
 
-    return collector.startScope(
+    const result = await collector.startScope(
       {
         streamName,
         commandType,
@@ -167,22 +212,45 @@ export const CommandHandler =
                   ...restOfAggregationResult
                 } = aggregationResult;
 
-                let state = aggregationResult.state;
+                const stateBeforeBatch = aggregationResult.state;
+                let state = stateBeforeBatch;
 
                 const handlers = Array.isArray(handle) ? handle : [handle];
                 let eventsToAppend: StreamEvent[] = [];
+                let events: StreamEvent[] = [];
 
                 // 3. Run business logic
                 for (const handler of handlers) {
-                  const result = await handler(state);
+                  const decision = composeMiddleware<
+                    State,
+                    CommandMiddlewareContext,
+                    StreamEvent
+                  >(async (decisionState) => {
+                    const result = await handler(decisionState);
+                    return isDecisionHandlingResult<StreamEvent>(result)
+                      ? result
+                      : append(Array.isArray(result) ? result : [result]);
+                  }, decisionMiddleware);
+                  const result = await decision(state, undefined);
+                  events = [...events, ...result.outputs];
 
-                  const newEvents = Array.isArray(result) ? result : [result];
-
-                  if (newEvents.length > 0) {
-                    state = newEvents.reduce(evolve, state);
+                  if (
+                    result.type === 'APPEND' ||
+                    result.type === 'APPEND_AND_STOP'
+                  ) {
+                    state = result.outputs.reduce(evolve, state);
+                    eventsToAppend = [...eventsToAppend, ...result.outputs];
                   }
-
-                  eventsToAppend = [...eventsToAppend, ...newEvents];
+                  if (result.type === 'REJECT') {
+                    eventsToAppend = [];
+                    state = stateBeforeBatch;
+                    break;
+                  }
+                  if (
+                    result.type === 'STOP' ||
+                    result.type === 'APPEND_AND_STOP'
+                  )
+                    break;
                 }
 
                 //const newEvents = Array.isArray(result) ? result : [result];
@@ -195,6 +263,8 @@ export const CommandHandler =
                   );
                   return {
                     ...restOfAggregationResult,
+                    events,
+                    appendedEvents: [],
                     newEvents: [],
                     newState: state,
 
@@ -247,6 +317,8 @@ export const CommandHandler =
                 // 5. Return result with updated state
                 return {
                   ...appendResult,
+                  events,
+                  appendedEvents: eventsToAppend,
                   newEvents: eventsToAppend,
                   newState: state,
                 } as unknown as CommandHandlerResult<State, StreamEvent, Store>;
@@ -260,6 +332,9 @@ export const CommandHandler =
         ),
       commandScopeOptions,
     );
+
+    await afterAll?.(result, { streamName, handleOptions });
+    return result;
   };
 
 const withSession = <EventStoreType extends EventStore, T = unknown>(
@@ -332,3 +407,15 @@ const handlerNames = <State, StreamEvent extends Event>(
   }
   return handle.name || undefined;
 };
+
+const isDecisionHandlingResult = <Output>(
+  value: unknown,
+): value is DecisionHandlingResult<Output> =>
+  typeof value === 'object' &&
+  value !== null &&
+  'type' in value &&
+  ['APPEND', 'SKIP', 'STOP', 'REJECT', 'APPEND_AND_STOP'].includes(
+    (value as { type: string }).type,
+  ) &&
+  'outputs' in value &&
+  Array.isArray((value as { outputs: unknown }).outputs);

--- a/src/packages/emmett/src/commandHandling/handleCommand.unit.spec.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.unit.spec.ts
@@ -45,13 +45,37 @@ type ShoppingCartCancelled = Event<
   'ShoppingCartCancelled',
   { canceledAt: Date }
 >;
+type ProductItemOutOfStock = Event<
+  'ProductItemOutOfStock',
+  {
+    productId: string;
+    requestedQuantity: number;
+    availableQuantity: number;
+  }
+>;
+type ShoppingCartItemLimitReached = Event<
+  'ShoppingCartItemLimitReached',
+  { maximumItems: number; requestedProductId: string }
+>;
+type ProductItemAlreadyInCart = Event<
+  'ProductItemAlreadyInCart',
+  { productId: string }
+>;
+type ShoppingCartConfirmationFailed = Event<
+  'ShoppingCartConfirmationFailed',
+  { reason: 'PaymentAuthorizationFailed' }
+>;
 
 // #region event-union
 type ShoppingCartEvent =
   | ProductItemAdded
   | DiscountApplied
   | ShoppingCartConfirmed
-  | ShoppingCartCancelled;
+  | ShoppingCartCancelled
+  | ProductItemOutOfStock
+  | ShoppingCartItemLimitReached
+  | ProductItemAlreadyInCart
+  | ShoppingCartConfirmationFailed;
 // #endregion event-union
 
 const evolve = (
@@ -77,6 +101,11 @@ const evolve = (
       return { ...state, status: 'Confirmed' };
     case 'ShoppingCartCancelled':
       return { ...state, status: 'Cancelled' };
+    case 'ProductItemOutOfStock':
+    case 'ShoppingCartItemLimitReached':
+    case 'ProductItemAlreadyInCart':
+    case 'ShoppingCartConfirmationFailed':
+      return state;
   }
 };
 
@@ -101,6 +130,7 @@ const addProductItem = (
     data: { productItem: command.data.productItem },
   };
 };
+
 // #endregion single-event-decision
 
 type ApplyDiscount = Event<'ApplyDiscount', { percent: number }>;

--- a/src/packages/emmett/src/commandHandling/handleCommandWithDecider.middleware.unit.spec.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommandWithDecider.middleware.unit.spec.ts
@@ -1,0 +1,273 @@
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { getInMemoryEventStore } from '../eventStore';
+import type { Event } from '../typing';
+import { DeciderCommandHandler } from './handleCommandWithDecider';
+import {
+  DecisionHandling,
+  after,
+  before,
+  rejectOn,
+  stopOn,
+  type Middleware,
+} from './middleware';
+
+type CartCommand =
+  | { type: 'AddItem'; data: { productId: string } }
+  | {
+      type: 'ReserveItem';
+      data: { productId: string; quantity: number; availableQuantity: number };
+    }
+  | { type: 'Confirm'; data: { confirmedAt: Date } };
+type CartEvent =
+  | Event<'ItemAdded', { productId: string }>
+  | Event<'CartConfirmed', { confirmedAt: Date }>
+  | Event<'ProductItemAlreadyInCart', { productId: string }>
+  | Event<
+      'ProductItemOutOfStock',
+      {
+        productId: string;
+        requestedQuantity: number;
+        availableQuantity: number;
+      }
+    >
+  | Event<'ShoppingCartConfirmationFailed', { reason: 'EmptyCart' }>
+  | Event<
+      'ShoppingCartItemLimitReached',
+      { maximumItems: number; requestedProductId: string }
+    >;
+type Cart = { items: string[]; confirmed: boolean };
+
+const maximumItems = 2;
+const initialState = (): Cart => ({ items: [], confirmed: false });
+const evolve = (state: Cart, event: CartEvent): Cart => {
+  if (event.type === 'ItemAdded')
+    return { ...state, items: [...state.items, event.data.productId] };
+  if (event.type === 'CartConfirmed') return { ...state, confirmed: true };
+  return state;
+};
+const decide = (command: CartCommand, state: Cart): CartEvent => {
+  if (command.type === 'AddItem')
+    return state.items.includes(command.data.productId)
+      ? {
+          type: 'ProductItemAlreadyInCart',
+          data: { productId: command.data.productId },
+        }
+      : { type: 'ItemAdded', data: { productId: command.data.productId } };
+  if (command.type === 'Confirm')
+    return state.items.length === 0
+      ? {
+          type: 'ShoppingCartConfirmationFailed',
+          data: { reason: 'EmptyCart' },
+        }
+      : { type: 'CartConfirmed', data: command.data };
+  if (command.data.quantity > command.data.availableQuantity)
+    return {
+      type: 'ProductItemOutOfStock',
+      data: {
+        productId: command.data.productId,
+        requestedQuantity: command.data.quantity,
+        availableQuantity: command.data.availableQuantity,
+      },
+    };
+  return state.items.length >= maximumItems
+    ? {
+        type: 'ShoppingCartItemLimitReached',
+        data: { maximumItems, requestedProductId: command.data.productId },
+      }
+    : { type: 'ItemAdded', data: { productId: command.data.productId } };
+};
+
+// #region custom-decision-middleware
+const { appendAndStop, reject, skip, stop } = DecisionHandling.result;
+
+const selectCartHandling: Middleware<CartCommand, Cart, CartEvent> =
+  (next) => async (command, state) => {
+    const result = await next(command, state);
+
+    if (
+      result.outputs.some((event) => event.type === 'ProductItemAlreadyInCart')
+    )
+      return skip(result.outputs);
+    if (
+      result.outputs.some(
+        (event) => event.type === 'ShoppingCartConfirmationFailed',
+      )
+    )
+      return stop(result.outputs);
+    if (result.outputs.some((event) => event.type === 'ProductItemOutOfStock'))
+      return reject(result.outputs);
+    if (
+      result.outputs.some(
+        (event) => event.type === 'ShoppingCartItemLimitReached',
+      )
+    )
+      return appendAndStop(result.outputs);
+    return result;
+  };
+// #endregion custom-decision-middleware
+
+describe('DeciderCommandHandler middleware', () => {
+  it('runs invocation hooks once and decision hooks for every command', async () => {
+    const eventStore = getInMemoryEventStore();
+    const shoppingCartId = randomUUID();
+    const lifecycle: string[] = [];
+    const authorizeCommands = (commands: CartCommand | CartCommand[]) => {
+      lifecycle.push(`batch:${Array.isArray(commands) ? commands.length : 1}`);
+    };
+    const authorizeCommand = (command: CartCommand) => {
+      lifecycle.push(`command:${command.type}`);
+    };
+    const logResult = (command: CartCommand, result: { type: string }) => {
+      lifecycle.push(`decision:${command.type}:${result.type}`);
+    };
+    const recordInvocation = (result: { appendedEvents: CartEvent[] }) => {
+      lifecycle.push(`appended:${result.appendedEvents.length}`);
+    };
+
+    // #region decider-command-middleware
+    const handle = DeciderCommandHandler<Cart, CartCommand, CartEvent>({
+      evolve,
+      initialState,
+      decide,
+      middleware: {
+        beforeAll: authorizeCommands,
+        afterAll: recordInvocation,
+        decision: [
+          before(authorizeCommand),
+          after((result, command) => {
+            logResult(command, result);
+            return result;
+          }),
+        ],
+      },
+    });
+
+    const commands: CartCommand[] = [
+      { type: 'AddItem', data: { productId: 'product-1' } },
+      { type: 'Confirm', data: { confirmedAt: new Date() } },
+    ];
+    const result = await handle(eventStore, shoppingCartId, commands);
+    // #endregion decider-command-middleware
+
+    expect(result.appendedEvents.map((event) => event.type)).toEqual([
+      'ItemAdded',
+      'CartConfirmed',
+    ]);
+    expect(lifecycle).toEqual([
+      'batch:2',
+      'command:AddItem',
+      'decision:AddItem:APPEND',
+      'command:Confirm',
+      'decision:Confirm:APPEND',
+      'appended:2',
+    ]);
+  });
+
+  it('passes rebuilt state to each command middleware call', async () => {
+    const itemCounts: number[] = [];
+    const handle = DeciderCommandHandler({
+      evolve,
+      initialState,
+      decide,
+      middleware: [
+        before((_command, state) => {
+          itemCounts.push(state.items.length);
+        }),
+      ],
+    });
+
+    await handle(getInMemoryEventStore(), randomUUID(), [
+      { type: 'AddItem', data: { productId: 'product-1' } },
+      { type: 'AddItem', data: { productId: 'product-2' } },
+    ]);
+
+    expect(itemCounts).toEqual([0, 1]);
+  });
+
+  it('distinguishes stopping a batch from rejecting it', async () => {
+    const commands: CartCommand[] = [
+      { type: 'AddItem', data: { productId: 'product-1' } },
+      {
+        type: 'ReserveItem',
+        data: {
+          productId: 'product-2',
+          quantity: 3,
+          availableQuantity: 2,
+        },
+      },
+      { type: 'Confirm', data: { confirmedAt: new Date() } },
+    ];
+    const createHandler = (
+      middleware: Middleware<CartCommand, Cart, CartEvent>,
+    ) =>
+      DeciderCommandHandler({
+        evolve,
+        initialState,
+        decide,
+        middleware: [middleware],
+      });
+
+    const stopped = await createHandler(
+      stopOn((event) => event.type === 'ProductItemOutOfStock'),
+    )(getInMemoryEventStore(), randomUUID(), commands);
+    const rejected = await createHandler(
+      rejectOn((event) => event.type === 'ProductItemOutOfStock'),
+    )(getInMemoryEventStore(), randomUUID(), commands);
+
+    expect(stopped.appendedEvents.map((event) => event.type)).toEqual([
+      'ItemAdded',
+    ]);
+    expect(rejected.appendedEvents).toEqual([]);
+  });
+
+  it('supports all handling results from custom middleware', async () => {
+    const handle = DeciderCommandHandler({
+      evolve,
+      initialState,
+      decide,
+      middleware: [selectCartHandling],
+    });
+
+    const duplicate = await handle(getInMemoryEventStore(), randomUUID(), [
+      { type: 'AddItem', data: { productId: 'product-1' } },
+      { type: 'AddItem', data: { productId: 'product-1' } },
+    ]);
+    const stopped = await handle(getInMemoryEventStore(), randomUUID(), {
+      type: 'Confirm',
+      data: { confirmedAt: new Date() },
+    });
+    const rejected = await handle(getInMemoryEventStore(), randomUUID(), {
+      type: 'ReserveItem',
+      data: {
+        productId: 'product-1',
+        quantity: 2,
+        availableQuantity: 1,
+      },
+    });
+    const terminal = await handle(getInMemoryEventStore(), randomUUID(), [
+      { type: 'AddItem', data: { productId: 'product-1' } },
+      { type: 'AddItem', data: { productId: 'product-2' } },
+      {
+        type: 'ReserveItem',
+        data: {
+          productId: 'product-3',
+          quantity: 1,
+          availableQuantity: 1,
+        },
+      },
+      { type: 'Confirm', data: { confirmedAt: new Date() } },
+    ]);
+
+    expect(duplicate.appendedEvents.map((event) => event.type)).toEqual([
+      'ItemAdded',
+    ]);
+    expect(stopped.appendedEvents).toEqual([]);
+    expect(rejected.appendedEvents).toEqual([]);
+    expect(terminal.appendedEvents.map((event) => event.type)).toEqual([
+      'ItemAdded',
+      'ItemAdded',
+      'ShoppingCartItemLimitReached',
+    ]);
+  });
+});

--- a/src/packages/emmett/src/commandHandling/handleCommandWithDecider.observability.unit.spec.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommandWithDecider.observability.unit.spec.ts
@@ -6,33 +6,23 @@ import { EmmettAttributes } from '../observability/attributes';
 import type { Event } from '../typing';
 import { DeciderCommandHandler } from './handleCommandWithDecider';
 
-type AddItem = { type: 'AddItem'; data: { productId: string } };
-type Confirm = { type: 'Confirm'; data: Record<string, never> };
-type CartCommand = AddItem | Confirm;
-
-type ItemAdded = Event<'ItemAdded', { productId: string }>;
-type CartConfirmed = Event<'CartConfirmed', Record<string, never>>;
-type CartEvent = ItemAdded | CartConfirmed;
-
+type CartCommand =
+  | { type: 'AddItem'; data: { productId: string } }
+  | { type: 'Confirm'; data: { confirmedAt: Date } };
+type CartEvent =
+  | Event<'ItemAdded', { productId: string }>
+  | Event<'CartConfirmed', { confirmedAt: Date }>;
 type Cart = { items: string[]; confirmed: boolean };
 
-const decide = (command: CartCommand): CartEvent | CartEvent[] => {
-  switch (command.type) {
-    case 'AddItem':
-      return { type: 'ItemAdded', data: { productId: command.data.productId } };
-    case 'Confirm':
-      return { type: 'CartConfirmed', data: {} };
-  }
-};
+const decide = (command: CartCommand): CartEvent =>
+  command.type === 'AddItem'
+    ? { type: 'ItemAdded', data: command.data }
+    : { type: 'CartConfirmed', data: command.data };
 
-const evolve = (state: Cart, event: CartEvent): Cart => {
-  switch (event.type) {
-    case 'ItemAdded':
-      return { ...state, items: [...state.items, event.data.productId] };
-    case 'CartConfirmed':
-      return { ...state, confirmed: true };
-  }
-};
+const evolve = (state: Cart, event: CartEvent): Cart =>
+  event.type === 'ItemAdded'
+    ? { ...state, items: [...state.items, event.data.productId] }
+    : { ...state, confirmed: true };
 
 const initialState = (): Cart => ({ items: [], confirmed: false });
 
@@ -77,7 +67,7 @@ describe('DeciderCommandHandler observability', () => {
       .when(async (handler) =>
         handler(getInMemoryEventStore(), streamId, [
           { type: 'AddItem', data: { productId: 'p1' } },
-          { type: 'Confirm', data: {} },
+          { type: 'Confirm', data: { confirmedAt: new Date() } },
         ]),
       )
       .then(({ spans }) => {

--- a/src/packages/emmett/src/commandHandling/handleCommandWithDecider.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommandWithDecider.ts
@@ -3,9 +3,17 @@ import type { Command, Event } from '../typing';
 import type { Decider } from '../typing/decider';
 import {
   CommandHandler,
+  type BeforeAllContext,
   type CommandHandlerOptions,
+  type CommandHandlerResult,
   type HandleOptions,
 } from './handleCommand';
+import {
+  append,
+  composeMiddleware,
+  resolveMiddleware,
+  type MiddlewareOptions,
+} from './middleware';
 
 const commandTypesOf = (commands: Command | Command[]): string | string[] =>
   Array.isArray(commands) ? commands.map((c) => c.type) : commands.type;
@@ -16,8 +24,22 @@ export type DeciderCommandHandlerOptions<
   State,
   CommandType extends Command,
   StreamEvent extends Event,
-> = CommandHandlerOptions<State, StreamEvent> &
-  Decider<State, CommandType, StreamEvent>;
+> = Omit<CommandHandlerOptions<State, StreamEvent>, 'middleware'> &
+  Decider<State, CommandType, StreamEvent> & {
+    middleware?: MiddlewareOptions<
+      CommandType,
+      State,
+      StreamEvent,
+      (
+        commands: CommandType | CommandType[],
+        context: BeforeAllContext,
+      ) => void | Promise<void>,
+      <Store extends EventStore>(
+        result: CommandHandlerResult<State, StreamEvent, Store>,
+        context: BeforeAllContext<Store>,
+      ) => void | Promise<void>
+    >;
+  };
 
 export const DeciderCommandHandler =
   <State, CommandType extends Command, StreamEvent extends Event>(
@@ -29,19 +51,49 @@ export const DeciderCommandHandler =
     commands: CommandType | CommandType[],
     handleOptions?: HandleOptions<Store>,
   ) => {
-    const { decide, ...rest } = options;
+    const { decide, middleware, ...rest } = options;
+    const {
+      decision: decisionMiddleware,
+      beforeAll,
+      afterAll,
+    } = resolveMiddleware(middleware);
 
     const deciders = (Array.isArray(commands) ? commands : [commands]).map(
-      (command) => (state: State) => decide(command, state),
+      (command) => async (state: State) => {
+        const handler = composeMiddleware<CommandType, State, StreamEvent>(
+          (input, decisionState) => {
+            const result = decide(input, decisionState);
+            return Promise.resolve(
+              append(Array.isArray(result) ? result : [result]),
+            );
+          },
+          decisionMiddleware,
+        );
+        return (await handler(command, state)) as unknown as StreamEvent[];
+      },
     );
 
     // TODO: forwarding an array of command types to a single span attribute
     // mirrors the array-of-handlers case in CommandHandler: revisit once we
     // decide on per-command child scopes vs. a single parent with an array
     // attribute.
-    return CommandHandler<State, StreamEvent>(rest)(eventStore, id, deciders, {
+    const result = await CommandHandler<State, StreamEvent>({
+      ...rest,
+      middleware: beforeAll
+        ? {
+            beforeAll: (_handlers, context) =>
+              beforeAll(commands, { ...context, handleOptions }),
+          }
+        : undefined,
+    })(eventStore, id, deciders, {
       commandType: commandTypesOf(commands),
       ...handleOptions,
     });
+
+    await afterAll?.(result, {
+      streamName: (rest.mapToStreamId ?? ((streamId: string) => streamId))(id),
+      handleOptions,
+    });
+    return result;
   };
 // #endregion command-handler

--- a/src/packages/emmett/src/commandHandling/index.ts
+++ b/src/packages/emmett/src/commandHandling/index.ts
@@ -1,2 +1,3 @@
 export * from './handleCommand';
 export * from './handleCommandWithDecider';
+export * from './middleware';

--- a/src/packages/emmett/src/commandHandling/middleware.ts
+++ b/src/packages/emmett/src/commandHandling/middleware.ts
@@ -1,0 +1,156 @@
+export type AppendResult<Output> = { type: 'APPEND'; outputs: Output[] };
+export type SkipResult<Output> = { type: 'SKIP'; outputs: Output[] };
+export type StopResult<Output> = { type: 'STOP'; outputs: Output[] };
+export type RejectResult<Output> = { type: 'REJECT'; outputs: Output[] };
+export type AppendAndStopResult<Output> = {
+  type: 'APPEND_AND_STOP';
+  outputs: Output[];
+};
+
+export type DecisionHandlingResult<Output> =
+  | AppendResult<Output>
+  | SkipResult<Output>
+  | StopResult<Output>
+  | RejectResult<Output>
+  | AppendAndStopResult<Output>;
+
+export type Handler<Input, Context, Output> = (
+  input: Input,
+  context: Context,
+) => Promise<DecisionHandlingResult<Output>>;
+
+export type Middleware<Input, Context, Output> = (
+  next: Handler<Input, Context, Output>,
+) => Handler<Input, Context, Output>;
+
+export type MiddlewareOptions<Input, Context, Output, BeforeAll, AfterAll> =
+  | Middleware<Input, Context, Output>[]
+  | {
+      beforeAll?: BeforeAll;
+      afterAll?: AfterAll;
+      decision?: Middleware<Input, Context, Output>[];
+    };
+
+export const resolveMiddleware = <Input, Context, Output, BeforeAll, AfterAll>(
+  middleware:
+    MiddlewareOptions<Input, Context, Output, BeforeAll, AfterAll> | undefined,
+): {
+  beforeAll: BeforeAll | undefined;
+  afterAll: AfterAll | undefined;
+  decision: Middleware<Input, Context, Output>[] | undefined;
+} =>
+  Array.isArray(middleware)
+    ? { beforeAll: undefined, afterAll: undefined, decision: middleware }
+    : {
+        beforeAll: middleware?.beforeAll,
+        afterAll: middleware?.afterAll,
+        decision: middleware?.decision,
+      };
+
+export const append = <Output>(outputs: Output[]): AppendResult<Output> => ({
+  type: 'APPEND',
+  outputs,
+});
+export const skip = <Output>(outputs: Output[]): SkipResult<Output> => ({
+  type: 'SKIP',
+  outputs,
+});
+export const stop = <Output>(outputs: Output[]): StopResult<Output> => ({
+  type: 'STOP',
+  outputs,
+});
+export const reject = <Output>(outputs: Output[]): RejectResult<Output> => ({
+  type: 'REJECT',
+  outputs,
+});
+export const appendAndStop = <Output>(
+  outputs: Output[],
+): AppendAndStopResult<Output> => ({ type: 'APPEND_AND_STOP', outputs });
+
+export const DecisionHandling = {
+  result: { append, skip, stop, reject, appendAndStop },
+};
+
+export const composeMiddleware = <Input, Context, Output>(
+  handler: Handler<Input, Context, Output>,
+  middleware: Middleware<Input, Context, Output>[] = [],
+): Handler<Input, Context, Output> =>
+  middleware.reduceRight((next, current) => current(next), handler);
+
+type Callback<Input, Context> = (
+  input: Input,
+  context: Context,
+) => void | Promise<void>;
+
+export const before =
+  <Input, Context, Output>(
+    callback: Callback<Input, Context>,
+  ): Middleware<Input, Context, Output> =>
+  (next) =>
+  async (input, context) => {
+    await callback(input, context);
+    return next(input, context);
+  };
+
+export const after =
+  <Input, Context, Output>(
+    callback: (
+      result: DecisionHandlingResult<Output>,
+      input: Input,
+      context: Context,
+    ) =>
+      DecisionHandlingResult<Output> | Promise<DecisionHandlingResult<Output>>,
+  ): Middleware<Input, Context, Output> =>
+  (next) =>
+  async (input, context) =>
+    callback(await next(input, context), input, context);
+
+export type OutputPredicate<Output, Input = unknown, Context = unknown> = (
+  output: Output,
+  input: Input,
+  context: Context,
+) => boolean;
+
+const mapOn =
+  <Input, Context, Output>(
+    predicate: OutputPredicate<Output, Input, Context>,
+    map: (outputs: Output[]) => DecisionHandlingResult<Output>,
+  ): Middleware<Input, Context, Output> =>
+  (next) =>
+  async (input, context) => {
+    const result = await next(input, context);
+    return result.outputs.some((output) => predicate(output, input, context))
+      ? map(result.outputs)
+      : result;
+  };
+
+export const skipOn = <Output, Input = unknown, Context = unknown>(
+  predicate: OutputPredicate<Output, Input, Context>,
+): Middleware<Input, Context, Output> => mapOn(predicate, skip);
+
+export const stopOn = <Output, Input = unknown, Context = unknown>(
+  predicate: OutputPredicate<Output, Input, Context>,
+): Middleware<Input, Context, Output> => mapOn(predicate, stop);
+
+export const rejectOn = <Output, Input = unknown, Context = unknown>(
+  predicate: OutputPredicate<Output, Input, Context>,
+): Middleware<Input, Context, Output> => mapOn(predicate, reject);
+
+export const stopAfter = <Output, Input = unknown, Context = unknown>(
+  predicate: OutputPredicate<Output, Input, Context>,
+): Middleware<Input, Context, Output> => mapOn(predicate, appendAndStop);
+
+export const throwOn =
+  <Output, Input = unknown, Context = unknown>(
+    predicate: OutputPredicate<Output, Input, Context>,
+    errorFactory: (output: Output, input: Input, context: Context) => unknown,
+  ): Middleware<Input, Context, Output> =>
+  (next) =>
+  async (input, context) => {
+    const result = await next(input, context);
+    const output = result.outputs.find((candidate) =>
+      predicate(candidate, input, context),
+    );
+    if (output !== undefined) throw errorFactory(output, input, context);
+    return result;
+  };

--- a/src/packages/emmett/src/commandHandling/middleware.unit.spec.ts
+++ b/src/packages/emmett/src/commandHandling/middleware.unit.spec.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import {
+  after,
+  append,
+  appendAndStop,
+  before,
+  composeMiddleware,
+  reject,
+  rejectOn,
+  resolveMiddleware,
+  skip,
+  skipOn,
+  stop,
+  stopAfter,
+  stopOn,
+  throwOn,
+} from './middleware';
+
+describe('decision middleware', () => {
+  it('composes the first middleware as the outermost wrapper', async () => {
+    const calls: string[] = [];
+    const handler = composeMiddleware(() => {
+      calls.push('decision');
+      return Promise.resolve(append(['event']));
+    }, [
+      before(() => {
+        calls.push('first before');
+      }),
+      after((result) => {
+        calls.push('second after');
+        return result;
+      }),
+    ]);
+
+    await handler('input', {});
+
+    expect(calls).toEqual(['first before', 'decision', 'second after']);
+  });
+
+  it('constructs each result without transport or error details', () => {
+    expect(append([1])).toEqual({ type: 'APPEND', outputs: [1] });
+    expect(skip([1])).toEqual({ type: 'SKIP', outputs: [1] });
+    expect(stop([1])).toEqual({ type: 'STOP', outputs: [1] });
+    expect(reject([1])).toEqual({ type: 'REJECT', outputs: [1] });
+    expect(appendAndStop([1])).toEqual({
+      type: 'APPEND_AND_STOP',
+      outputs: [1],
+    });
+  });
+
+  it('normalizes array shorthand and lifecycle object configuration', () => {
+    const decision = [before<string, object, string>(() => undefined)];
+    const beforeAll = () => undefined;
+    const afterAll = () => undefined;
+
+    expect(resolveMiddleware(decision)).toEqual({
+      beforeAll: undefined,
+      afterAll: undefined,
+      decision,
+    });
+    expect(resolveMiddleware({ beforeAll, afterAll, decision })).toEqual({
+      beforeAll,
+      afterAll,
+      decision,
+    });
+  });
+
+  it.each([
+    [skipOn, 'SKIP'],
+    [stopOn, 'STOP'],
+    [rejectOn, 'REJECT'],
+    [stopAfter, 'APPEND_AND_STOP'],
+  ] as const)(
+    '%s applies an any-output match to the whole decision',
+    async (create, type) => {
+      const handler = composeMiddleware(
+        () => Promise.resolve(append(['keep', 'match', 'keep too'])),
+        [create((output) => output === 'match')],
+      );
+
+      expect(await handler('input', {})).toEqual({
+        type,
+        outputs: ['keep', 'match', 'keep too'],
+      });
+    },
+  );
+
+  it('throwOn creates and propagates an exception for the matching output', async () => {
+    const error = new Error('rejected');
+    const handler = composeMiddleware(
+      () => Promise.resolve(append(['ok', 'bad'])),
+      [
+        throwOn(
+          (output) => output === 'bad',
+          () => error,
+        ),
+      ],
+    );
+
+    await expect(handler('input', {})).rejects.toBe(error);
+  });
+});

--- a/src/packages/emmett/src/workflows/handleWorkflow.middleware.unit.spec.ts
+++ b/src/packages/emmett/src/workflows/handleWorkflow.middleware.unit.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { after, before, rejectOn } from '../commandHandling';
+import {
+  ExpectedVersionConflictError,
+  getInMemoryEventStore,
+} from '../eventStore';
+import { WorkflowHandler, workflowStreamName } from './handleWorkflow';
+import {
+  workflowOptions,
+  type GroupCheckoutOutput,
+  type InitiateGroupCheckout,
+} from './workflow.testHelpers';
+
+const initiateGroupCheckout = (
+  groupCheckoutId: string,
+  guestStayAccountIds = ['guest-stay-1', 'guest-stay-2'],
+): InitiateGroupCheckout => ({
+  type: 'InitiateGroupCheckout',
+  data: {
+    groupCheckoutId,
+    clerkId: 'clerk-1',
+    guestStayAccountIds,
+    now: new Date('2026-01-01T10:00:00Z'),
+  },
+});
+
+describe('WorkflowHandler middleware', () => {
+  it('returns rejected workflow outputs while retaining the durable input', async () => {
+    const eventStore = getInMemoryEventStore();
+    const input = initiateGroupCheckout('group-checkout-1', []);
+    // #region workflow-output-rejection
+    const handle = WorkflowHandler({
+      ...workflowOptions,
+      middleware: [
+        rejectOn(
+          (message: GroupCheckoutOutput) =>
+            message.type === 'GroupCheckoutRejected',
+        ),
+      ],
+    });
+
+    const result = await handle(eventStore, input);
+    // #endregion workflow-output-rejection
+
+    expect(result.messages.map((message) => message.type)).toEqual([
+      'GroupCheckoutRejected',
+    ]);
+    expect(result.appendedMessages).toEqual([]);
+
+    const streamName = workflowStreamName({
+      workflowName: workflowOptions.workflow.name,
+      workflowId: input.data.groupCheckoutId,
+    });
+    expect(
+      (await eventStore.readStream(streamName)).events.map(
+        (event) => event.type,
+      ),
+    ).toEqual(['GroupCheckoutWorkflow:InitiateGroupCheckout']);
+  });
+
+  it('runs invocation hooks once and decision middleware for every retry', async () => {
+    const eventStore = getInMemoryEventStore();
+    const input = initiateGroupCheckout('group-checkout-retry');
+    let authorizationChecks = 0;
+    let measuredDecisions = 0;
+    let measuredInvocations = 0;
+    const handle = WorkflowHandler({
+      ...workflowOptions,
+      middleware: {
+        beforeAll: () => {
+          authorizationChecks++;
+        },
+        afterAll: () => {
+          measuredInvocations++;
+        },
+        decision: [
+          before(() => {
+            measuredDecisions++;
+          }),
+          after((result) => {
+            if (measuredDecisions === 1)
+              throw new ExpectedVersionConflictError(0n, 1n);
+            return result;
+          }),
+        ],
+      },
+      retry: {
+        retries: 1,
+        minTimeout: 1,
+        factor: 1,
+        shouldRetryError: (error) =>
+          error instanceof ExpectedVersionConflictError,
+      },
+    });
+
+    const result = await handle(eventStore, input);
+
+    expect(authorizationChecks).toBe(1);
+    expect(measuredDecisions).toBe(2);
+    expect(measuredInvocations).toBe(1);
+    expect(result.messages).toEqual(result.appendedMessages);
+  });
+});

--- a/src/packages/emmett/src/workflows/handleWorkflow.ts
+++ b/src/packages/emmett/src/workflows/handleWorkflow.ts
@@ -31,6 +31,12 @@ import type {
   WorkflowMessageAction,
 } from './workflow';
 import type { WorkflowOptions } from './workflowProcessor';
+import {
+  append,
+  composeMiddleware,
+  resolveMiddleware,
+  type MiddlewareOptions,
+} from '../commandHandling/middleware';
 
 export const WorkflowHandlerStreamVersionConflictRetryOptions: AsyncRetryOptions =
   {
@@ -67,6 +73,9 @@ export type WorkflowHandlerResult<
   Output extends AnyEvent | AnyCommand,
   Store extends EventStore,
 > = AppendStreamResultOfEventStore<Store> & {
+  messages: Output[];
+  appendedMessages: Output[];
+  /** @deprecated Use appendedMessages. */
   newMessages: Output[];
 };
 
@@ -89,6 +98,8 @@ const emptyHandlerResult = <
   nextExpectedStreamVersion: bigint = 0n,
 ): WorkflowHandlerResult<Output, Store> =>
   ({
+    messages: [] as Output[],
+    appendedMessages: [] as Output[],
     newMessages: [] as Output[],
     createdNewStream: false,
     nextExpectedStreamVersion,
@@ -200,6 +211,25 @@ export type WorkflowHandlerOptions<
 > & {
   retry?: WorkflowHandlerRetryOptions;
   observability?: WorkflowObservabilityConfig;
+  middleware?: MiddlewareOptions<
+    Input,
+    State,
+    Output,
+    (
+      input: Input | RecordedMessage<Input, MessageMetadataType>,
+      context: {
+        streamName: string;
+        handleOptions: WorkflowHandleOptions<EventStore> | undefined;
+      },
+    ) => void | Promise<void>,
+    <Store extends EventStore>(
+      result: WorkflowHandlerResult<Output, Store>,
+      context: {
+        streamName: string;
+        handleOptions: WorkflowHandleOptions<Store> | undefined;
+      },
+    ) => void | Promise<void>
+  >;
 };
 
 export const WorkflowHandler =
@@ -240,8 +270,22 @@ export const WorkflowHandler =
       sourceMetadata?.correlationId ??
       observability.contextGenerator.generateCorrelationId();
     const causationId = handleOptions?.causationId ?? inputMessageId;
+    const resolvedStreamName = options.mapWorkflowId
+      ? options.mapWorkflowId(workflowId)
+      : workflowStreamName({ workflowName: workflowType, workflowId });
 
-    return collector.startScope(
+    const {
+      decision: decisionMiddleware,
+      beforeAll,
+      afterAll,
+    } = resolveMiddleware(options.middleware);
+
+    await beforeAll?.(message, {
+      streamName: resolvedStreamName,
+      handleOptions,
+    });
+
+    const result = await collector.startScope(
       { workflowId, workflowType, inputType },
       async (scope) =>
         asyncRetry(
@@ -329,6 +373,8 @@ export const WorkflowHandler =
 
                   return {
                     ...appendResult,
+                    messages: [] as Output[],
+                    appendedMessages: [] as Output[],
                     newMessages: [] as Output[],
                   } as unknown as WorkflowHandlerResult<Output, Store>;
                 }
@@ -397,7 +443,21 @@ export const WorkflowHandler =
                     } as Input)
                   : (messageWithMetadata as Input);
 
-                const result = decide(messageForDecide, state);
+                const decision = composeMiddleware<Input, State, Output>(
+                  (input, decisionState) => {
+                    const result = decide(input, decisionState);
+                    return Promise.resolve(
+                      append(
+                        (Array.isArray(result) ? result : [result]).filter(
+                          (output): output is Output =>
+                            output !== undefined && output !== null,
+                        ),
+                      ),
+                    );
+                  },
+                  decisionMiddleware,
+                );
+                const handlingResult = await decision(messageForDecide, state);
 
                 const inputMetadata = createInputMetadata(
                   inputMessageId,
@@ -411,20 +471,26 @@ export const WorkflowHandler =
                   metadata: inputMetadata,
                 } as StoredMessage;
 
-                const outputMessages = (
-                  Array.isArray(result) ? result : [result]
-                ).filter(
+                const outputMessages = handlingResult.outputs.filter(
                   (msg): msg is Output => msg !== undefined && msg !== null,
                 );
 
+                const appendedOutputMessages =
+                  handlingResult.type === 'APPEND' ||
+                  handlingResult.type === 'APPEND_AND_STOP'
+                    ? outputMessages
+                    : [];
+
                 const outputCommandTypes = options.outputs?.commands ?? [];
-                const taggedOutputMessages = outputMessages.map((msg) => {
-                  const action: WorkflowMessageAction =
-                    outputCommandTypes.includes(msg.type as string)
-                      ? 'Sent'
-                      : 'Published';
-                  return tagOutputMessage(msg, action);
-                });
+                const taggedOutputMessages = appendedOutputMessages.map(
+                  (msg) => {
+                    const action: WorkflowMessageAction =
+                      outputCommandTypes.includes(msg.type as string)
+                        ? 'Sent'
+                        : 'Published';
+                    return tagOutputMessage(msg, action);
+                  },
+                );
 
                 const messagesToAppend =
                   options.separateInputInboxFromProcessing && hasWorkflowPrefix
@@ -476,7 +542,9 @@ export const WorkflowHandler =
                 collector.recordOutputs(scope, outputMessages);
                 return {
                   ...appendResult,
-                  newMessages: outputMessages,
+                  messages: outputMessages,
+                  appendedMessages: appendedOutputMessages,
+                  newMessages: appendedOutputMessages,
                 } as unknown as WorkflowHandlerResult<Output, Store>;
               },
             ),
@@ -488,6 +556,12 @@ export const WorkflowHandler =
         ),
       handleOptions?.observability,
     );
+
+    await afterAll?.(result, {
+      streamName: resolvedStreamName,
+      handleOptions,
+    });
+    return result;
   };
 // #endregion stream-handler
 

--- a/src/packages/emmett/src/workflows/workflow.testHelpers.ts
+++ b/src/packages/emmett/src/workflows/workflow.testHelpers.ts
@@ -76,6 +76,15 @@ export type GroupCheckoutInitiated = Event<
   }
 >;
 
+export type GroupCheckoutRejected = Event<
+  'GroupCheckoutRejected',
+  {
+    groupCheckoutId: string;
+    reason: 'NoGuestStays';
+    rejectedAt: Date;
+  }
+>;
+
 export type GroupCheckoutCompleted = Event<
   'GroupCheckoutCompleted',
   {
@@ -155,6 +164,7 @@ export type GroupCheckoutInput =
 
 export type GroupCheckoutOutput =
   | GroupCheckoutInitiated
+  | GroupCheckoutRejected
   | CheckOut
   | GroupCheckoutCompleted
   | GroupCheckoutFailed
@@ -183,6 +193,8 @@ export const evolve = (
         ),
       };
     }
+    case 'GroupCheckoutRejected':
+      return state;
     case 'GuestCheckedOut':
     case 'GuestCheckoutFailed': {
       if (state.status !== 'Pending') return state;
@@ -269,6 +281,7 @@ export const workflowOptions: WorkflowOptions<
     events: [
       'GroupCheckoutCompleted',
       'GroupCheckoutFailed',
+      'GroupCheckoutRejected',
       'GroupCheckoutTimedOut',
     ],
   },
@@ -352,8 +365,18 @@ export const groupCheckoutWorkflowProcessor = workflowProcessor({
 const initiateGroupCheckout = (
   { data }: InitiateGroupCheckout,
   state: GroupCheckout,
-): [GroupCheckoutInitiated, ...CheckOut[]] | [] => {
+): [GroupCheckoutInitiated, ...CheckOut[]] | GroupCheckoutRejected | [] => {
   if (state.status !== 'NotExisting') return [];
+
+  if (data.guestStayAccountIds.length === 0)
+    return {
+      type: 'GroupCheckoutRejected',
+      data: {
+        groupCheckoutId: data.groupCheckoutId,
+        reason: 'NoGuestStays',
+        rejectedAt: data.now,
+      },
+    };
 
   const checkoutGuestStays: CheckOut[] = data.guestStayAccountIds.map((id) => ({
     type: 'CheckOut',


### PR DESCRIPTION
Ok, so @MateuszNaKodach motivated me with his [question on LinkedIn](https://www.linkedin.com/feed/update/urn:li:activity:7483560145575153664?commentUrn=urn%3Ali%3Acomment%3A%28activity%3A7483560145575153664%2C7484391306232864769%29&dashCommentUrn=urn%3Ali%3Afsd_comment%3A%287484391306232864769%2Curn%3Ali%3Aactivity%3A7483560145575153664%29) about how to map events to the HTTP statuses result.

It was possible even without any changes by doing one of (or combination of):
- checking the outcome of business logic, and throwing erros,
- accepting that each event is appended, so we record all "failure" decisions and map it,
- doing custom handling on event store methods.

Yet, none of that was accessible at the level I'd like, so I added options to specify the middleware that allows skipping, stopping processing or rejecting the whole batch.

Following the Boy Scout rule, I also added "before all" and "after all" processing. Bon apetit!