### PR TITLE
Enhance Command and Decider handlers to support StoredEvent type for schema versioning

### DIFF
--- a/src/docs/api-reference/commandhandler.md
+++ b/src/docs/api-reference/commandhandler.md
@@ -13,11 +13,11 @@ It builds on the event store's [`aggregateStream`](/api-reference/eventstore#agg
 
 ## Construction
 
-`CommandHandler(options)` returns the handler function. It takes three type parameters: `State`, `StreamEvent` (the discriminated union written to the stream), and an optional `StoredEvent` (the stored shape when it differs from `StreamEvent`, used with schema versioning).
+`CommandHandler(options)` returns the handler function. It takes three type parameters: `State`, `StreamEvent` (the discriminated union written to the stream), and an optional `EventPayloadType` (the stored shape when it differs from `StreamEvent`, used with schema versioning).
 
 <<< @/snippets/gettingStarted/commandHandler.ts#command-handler
 
-`DeciderCommandHandler(options)` takes four: `State`, `CommandType`, `StreamEvent`, and an optional `StoredEvent`. On both handlers `StoredEvent` defaults to `StreamEvent`, so leaving it out types `schema.versioning.upcast` as if stored events already had the current shape. See [Schema versioning](#schema-versioning).
+`DeciderCommandHandler(options)` takes four: `State`, `CommandType`, `StreamEvent`, and an optional `StoredEvent` (the same stored shape, named for the decider's event-sourced context). On both handlers it defaults to `StreamEvent`, so leaving it out types `schema.versioning.upcast` as if stored events already had the current shape. See [Schema versioning](#schema-versioning).
 
 ### CommandHandlerOptions
 
@@ -221,7 +221,7 @@ A decision throws to reject a command; the handler appends nothing and propagate
 
 `schema.versioning.upcast` maps a stored event to the current `StreamEvent` shape on read; `schema.versioning.downcast` maps a `StreamEvent` back to its stored shape on write. Together they carry a stream through event schema evolution.
 
-Pass the stored shape as the last type parameter — `StoredEvent`, on either handler — so both callbacks are checked against it. It defaults to `StreamEvent`, which is only correct while the stored and current shapes still match.
+Pass the stored shape as the last type parameter so both callbacks are checked against it: `EventPayloadType` on `CommandHandler`, `StoredEvent` on `DeciderCommandHandler`. Both default to `StreamEvent`, which is only correct while the stored and current shapes still match.
 
 <<< @./../packages/emmett/src/commandHandling/handleCommandWithDecider.versioning.unit.spec.ts#decider-upcasting
 

--- a/src/docs/api-reference/commandhandler.md
+++ b/src/docs/api-reference/commandhandler.md
@@ -13,11 +13,11 @@ It builds on the event store's [`aggregateStream`](/api-reference/eventstore#agg
 
 ## Construction
 
-`CommandHandler(options)` returns the handler function. It takes three type parameters: `State`, `StreamEvent` (the discriminated union written to the stream), and an optional `EventPayloadType` (the stored shape when it differs from `StreamEvent`, used with schema versioning).
+`CommandHandler(options)` returns the handler function. It takes three type parameters: `State`, `StreamEvent` (the discriminated union written to the stream), and an optional `EventPayloadType` (the stored shape when it differs from `StreamEvent`, used with [Schema versioning](#schema-versioning)).
 
 <<< @/snippets/gettingStarted/commandHandler.ts#command-handler
 
-`DeciderCommandHandler(options)` takes four: `State`, `CommandType`, `StreamEvent`, and an optional `StoredEvent` (the same stored shape, named for the decider's event-sourced context). On both handlers it defaults to `StreamEvent`, so leaving it out types `schema.versioning.upcast` as if stored events already had the current shape. See [Schema versioning](#schema-versioning).
+`DeciderCommandHandler(options)` adds a `CommandType` parameter representing the command type. In `DeciderCommandHandler` we're not passing the decision callback.
 
 ### CommandHandlerOptions
 
@@ -221,9 +221,15 @@ A decision throws to reject a command; the handler appends nothing and propagate
 
 `schema.versioning.upcast` maps a stored event to the current `StreamEvent` shape on read; `schema.versioning.downcast` maps a `StreamEvent` back to its stored shape on write. Together they carry a stream through event schema evolution.
 
-Pass the stored shape as the last type parameter so both callbacks are checked against it: `EventPayloadType` on `CommandHandler`, `StoredEvent` on `DeciderCommandHandler`. Both default to `StreamEvent`, which is only correct while the stored and current shapes still match.
+Pass the stored shape as the last type parameter, `EventPayloadType`, on either handler so both callbacks are checked against it. It defaults to `StreamEvent`, which is only correct while the stored and current shapes still match.
+
+Define the transform against both shapes. Here older events stored the product item's fields flat and kept `addedAt` as the ISO string JSON persists a `Date` as; the current shape groups those fields and rebuilds the `Date`:
 
 <<< @./../packages/emmett/src/commandHandling/handleCommandWithDecider.versioning.unit.spec.ts#decider-upcasting
+
+Then register it under `schema.versioning` on the handler:
+
+<<< @./../packages/emmett/src/commandHandling/handleCommandWithDecider.versioning.unit.spec.ts#decider-upcasting-register
 
 ### Serialization
 

--- a/src/docs/api-reference/commandhandler.md
+++ b/src/docs/api-reference/commandhandler.md
@@ -13,9 +13,11 @@ It builds on the event store's [`aggregateStream`](/api-reference/eventstore#agg
 
 ## Construction
 
-`CommandHandler(options)` returns the handler function. It takes three type parameters: `State`, `StreamEvent` (the discriminated union written to the stream), and an optional `EventPayloadType` (the stored shape when it differs from `StreamEvent`, used with schema versioning).
+`CommandHandler(options)` returns the handler function. It takes three type parameters: `State`, `StreamEvent` (the discriminated union written to the stream), and an optional `StoredEvent` (the stored shape when it differs from `StreamEvent`, used with schema versioning).
 
 <<< @/snippets/gettingStarted/commandHandler.ts#command-handler
+
+`DeciderCommandHandler(options)` takes four: `State`, `CommandType`, `StreamEvent`, and an optional `StoredEvent`. On both handlers `StoredEvent` defaults to `StreamEvent`, so leaving it out types `schema.versioning.upcast` as if stored events already had the current shape. See [Schema versioning](#schema-versioning).
 
 ### CommandHandlerOptions
 
@@ -215,9 +217,13 @@ A decision throws to reject a command; the handler appends nothing and propagate
 
 ## Advanced
 
-### Schema versioning
+### Schema versioning {#schema-versioning}
 
 `schema.versioning.upcast` maps a stored event to the current `StreamEvent` shape on read; `schema.versioning.downcast` maps a `StreamEvent` back to its stored shape on write. Together they carry a stream through event schema evolution.
+
+Pass the stored shape as the last type parameter — `StoredEvent`, on either handler — so both callbacks are checked against it. It defaults to `StreamEvent`, which is only correct while the stored and current shapes still match.
+
+<<< @./../packages/emmett/src/commandHandling/handleCommandWithDecider.versioning.unit.spec.ts#decider-upcasting
 
 ### Serialization
 
@@ -229,7 +235,7 @@ A decision throws to reject a command; the handler appends nothing and propagate
 
 ## Type Source
 
-For the full signatures, see [`handleCommand.ts`](https://github.com/event-driven-io/emmett/blob/main/src/packages/emmett/src/commandHandling/handleCommand.ts) in the source.
+For the full signatures, see [`handleCommand.ts`](https://github.com/event-driven-io/emmett/blob/main/src/packages/emmett/src/commandHandling/handleCommand.ts) and [`handleCommandWithDecider.ts`](https://github.com/event-driven-io/emmett/blob/main/src/packages/emmett/src/commandHandling/handleCommandWithDecider.ts) in the source.
 
 ## See also {#see-also}
 

--- a/src/packages/emmett/src/commandHandling/handleCommand.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.ts
@@ -121,8 +121,12 @@ export type CommandHandlerFunction<State, StreamEvent extends Event> = (
 ) => StreamEvent | StreamEvent[] | Promise<StreamEvent | StreamEvent[]>;
 
 export const CommandHandler =
-  <State, StreamEvent extends Event, StoredEvent extends Event = StreamEvent>(
-    options: CommandHandlerOptions<State, StreamEvent, StoredEvent>,
+  <
+    State,
+    StreamEvent extends Event,
+    EventPayloadType extends Event = StreamEvent,
+  >(
+    options: CommandHandlerOptions<State, StreamEvent, EventPayloadType>,
   ) =>
   async <Store extends EventStore>(
     store: Store,
@@ -162,7 +166,7 @@ export const CommandHandler =
     const appendOptionsFromHandle = toAppendOptions<
       Store,
       StreamEvent,
-      StoredEvent
+      EventPayloadType
     >(handleOptions);
 
     const result = await collector.startScope(
@@ -184,7 +188,7 @@ export const CommandHandler =
                 const aggregationResult = await eventStore.aggregateStream<
                   State,
                   StreamEvent,
-                  StoredEvent
+                  EventPayloadType
                 >(streamName, {
                   evolve,
                   initialState,
@@ -366,10 +370,10 @@ const fromCommandHandlerRetryOptions = (
 const toAppendOptions = <
   Store extends EventStore,
   StreamEvent extends Event,
-  StoredEvent extends Event,
+  EventPayloadType extends Event,
 >(
   options: HandleOptions<Store> | undefined,
-): AppendToStreamOptions<StreamEvent, StoredEvent> | undefined => {
+): AppendToStreamOptions<StreamEvent, EventPayloadType> | undefined => {
   if (!options) return undefined;
 
   return {
@@ -380,7 +384,7 @@ const toAppendOptions = <
       ? {
           schema: options.schema as AppendToStreamOptions<
             StreamEvent,
-            StoredEvent
+            EventPayloadType
           >['schema'],
         }
       : {}),

--- a/src/packages/emmett/src/commandHandling/handleCommand.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.ts
@@ -82,7 +82,7 @@ export type CommandHandlerMiddlewareOptions<
 export type CommandHandlerOptions<
   State,
   StreamEvent extends Event,
-  StoredEvent extends Event = StreamEvent,
+  EventPayloadType extends Event = StreamEvent,
 > = {
   evolve: (state: State, event: StreamEvent) => State;
   initialState: () => State;
@@ -90,8 +90,8 @@ export type CommandHandlerOptions<
   retry?: CommandHandlerRetryOptions;
   schema?: {
     versioning?: {
-      upcast?: (event: StoredEvent) => StreamEvent;
-      downcast?: (event: StreamEvent) => StoredEvent;
+      upcast?: (event: EventPayloadType) => StreamEvent;
+      downcast?: (event: StreamEvent) => EventPayloadType;
     };
   };
   name?: string;
@@ -168,6 +168,7 @@ export const CommandHandler =
       StreamEvent,
       EventPayloadType
     >(handleOptions);
+    const appendSchema = appendOptionsFromHandle?.schema ?? options.schema;
 
     const result = await collector.startScope(
       {
@@ -295,6 +296,7 @@ export const CommandHandler =
                   eventsToAppend,
                   {
                     ...(appendOptionsFromHandle ?? {}),
+                    ...(appendSchema ? { schema: appendSchema } : {}),
                     expectedStreamVersion,
                     correlationId,
                     ...(causationId ? { causationId } : {}),

--- a/src/packages/emmett/src/commandHandling/handleCommand.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.ts
@@ -121,12 +121,8 @@ export type CommandHandlerFunction<State, StreamEvent extends Event> = (
 ) => StreamEvent | StreamEvent[] | Promise<StreamEvent | StreamEvent[]>;
 
 export const CommandHandler =
-  <
-    State,
-    StreamEvent extends Event,
-    EventPayloadType extends Event = StreamEvent,
-  >(
-    options: CommandHandlerOptions<State, StreamEvent, EventPayloadType>,
+  <State, StreamEvent extends Event, StoredEvent extends Event = StreamEvent>(
+    options: CommandHandlerOptions<State, StreamEvent, StoredEvent>,
   ) =>
   async <Store extends EventStore>(
     store: Store,
@@ -166,7 +162,7 @@ export const CommandHandler =
     const appendOptionsFromHandle = toAppendOptions<
       Store,
       StreamEvent,
-      EventPayloadType
+      StoredEvent
     >(handleOptions);
 
     const result = await collector.startScope(
@@ -188,7 +184,7 @@ export const CommandHandler =
                 const aggregationResult = await eventStore.aggregateStream<
                   State,
                   StreamEvent,
-                  EventPayloadType
+                  StoredEvent
                 >(streamName, {
                   evolve,
                   initialState,
@@ -370,10 +366,10 @@ const fromCommandHandlerRetryOptions = (
 const toAppendOptions = <
   Store extends EventStore,
   StreamEvent extends Event,
-  EventPayloadType extends Event,
+  StoredEvent extends Event,
 >(
   options: HandleOptions<Store> | undefined,
-): AppendToStreamOptions<StreamEvent, EventPayloadType> | undefined => {
+): AppendToStreamOptions<StreamEvent, StoredEvent> | undefined => {
   if (!options) return undefined;
 
   return {
@@ -384,7 +380,7 @@ const toAppendOptions = <
       ? {
           schema: options.schema as AppendToStreamOptions<
             StreamEvent,
-            EventPayloadType
+            StoredEvent
           >['schema'],
         }
       : {}),

--- a/src/packages/emmett/src/commandHandling/handleCommand.versioning.unit.spec.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommand.versioning.unit.spec.ts
@@ -1,50 +1,21 @@
 import { randomUUID } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 import { getInMemoryEventStore } from '../eventStore';
-import type { Command, Event } from '../typing';
-import { DeciderCommandHandler } from './handleCommandWithDecider';
+import type { Event } from '../typing';
+import { CommandHandler } from './handleCommand';
 
-type AddProductItem = Command<
-  'AddProductItem',
-  { productId: string; quantity: number }
->;
-
-// #region decider-upcasting
-// The shape older events were stored with: productId and quantity as flat
-// fields, addedAt as the ISO-8601 string JSON persists a Date as.
 type ProductItemAddedV1 = Event<
   'ProductItemAdded',
   { productId: string; quantity: number; addedAt: string }
 >;
 
-// The current shape: the product item is grouped under its own object and
-// addedAt is a Date. The event type name stays the same across versions.
 type ProductItemAdded = Event<
   'ProductItemAdded',
   { productItem: { productId: string; quantity: number }; addedAt: Date }
 >;
 
-// The events the domain works with, and the shapes the stream can hold: a
-// stream written across the change carries both versions.
 type ShoppingCartEvent = ProductItemAdded;
 type StoredShoppingCartEvent = ProductItemAddedV1 | ProductItemAdded;
-
-const upcast = (event: StoredShoppingCartEvent): ShoppingCartEvent => {
-  if ('productItem' in event.data)
-    return { type: 'ProductItemAdded', data: event.data };
-
-  return {
-    type: 'ProductItemAdded',
-    data: {
-      productItem: {
-        productId: event.data.productId,
-        quantity: event.data.quantity,
-      },
-      addedAt: new Date(event.data.addedAt),
-    },
-  };
-};
-// #endregion decider-upcasting
 
 type ProductItem = { productId: string; quantity: number; addedAt: Date };
 
@@ -62,30 +33,21 @@ const evolve = (
   ],
 });
 
-const decide = (
-  command: AddProductItem,
-  _state: ShoppingCart,
-): ShoppingCartEvent => ({
-  type: 'ProductItemAdded',
-  data: {
-    productItem: command.data,
-    addedAt: new Date('2024-03-01T09:00:00.000Z'),
-  },
-});
+const upcast = (event: StoredShoppingCartEvent): ShoppingCartEvent => {
+  if ('productItem' in event.data)
+    return { type: 'ProductItemAdded', data: event.data };
 
-// #region decider-upcasting-register
-const handle = DeciderCommandHandler<
-  ShoppingCart,
-  AddProductItem,
-  ShoppingCartEvent,
-  StoredShoppingCartEvent
->({
-  decide,
-  evolve,
-  initialState,
-  schema: { versioning: { upcast } },
-});
-// #endregion decider-upcasting-register
+  return {
+    type: 'ProductItemAdded',
+    data: {
+      productItem: {
+        productId: event.data.productId,
+        quantity: event.data.quantity,
+      },
+      addedAt: new Date(event.data.addedAt),
+    },
+  };
+};
 
 const downcast = (event: ShoppingCartEvent): StoredShoppingCartEvent => ({
   type: 'ProductItemAdded',
@@ -96,22 +58,29 @@ const downcast = (event: ShoppingCartEvent): StoredShoppingCartEvent => ({
   },
 });
 
-const handleWithDowncast = DeciderCommandHandler<
+const schema = { versioning: { upcast, downcast } };
+
+const handle = CommandHandler<
   ShoppingCart,
-  AddProductItem,
   ShoppingCartEvent,
   StoredShoppingCartEvent
 >({
-  decide,
   evolve,
   initialState,
-  schema: { versioning: { downcast } },
+  schema,
 });
 
-void describe('DeciderCommandHandler schema versioning', () => {
-  const eventStore = getInMemoryEventStore();
+const addSocks = () => ({
+  type: 'ProductItemAdded' as const,
+  data: {
+    productItem: { productId: 'socks', quantity: 3 },
+    addedAt: new Date('2024-03-01T09:00:00.000Z'),
+  },
+});
 
+void describe('CommandHandler schema versioning', () => {
   void it('upcasts a stream mixing old and current shapes', async () => {
+    const eventStore = getInMemoryEventStore();
     const shoppingCartId = randomUUID();
 
     await eventStore.appendToStream<StoredShoppingCartEvent>(shoppingCartId, [
@@ -132,10 +101,7 @@ void describe('DeciderCommandHandler schema versioning', () => {
       },
     ]);
 
-    const { newState } = await handle(eventStore, shoppingCartId, {
-      type: 'AddProductItem',
-      data: { productId: 'socks', quantity: 3 },
-    });
+    const { newState } = await handle(eventStore, shoppingCartId, addSocks);
 
     expect(newState).toEqual({
       productItems: [
@@ -159,13 +125,11 @@ void describe('DeciderCommandHandler schema versioning', () => {
     expect(newState.productItems[0]!.addedAt).toBeInstanceOf(Date);
   });
 
-  void it('downcasts decided events to the stored shape on append', async () => {
+  void it('downcasts to the stored shape on append', async () => {
+    const eventStore = getInMemoryEventStore();
     const shoppingCartId = randomUUID();
 
-    await handleWithDowncast(eventStore, shoppingCartId, {
-      type: 'AddProductItem',
-      data: { productId: 'socks', quantity: 3 },
-    });
+    await handle(eventStore, shoppingCartId, addSocks);
 
     const stored =
       await eventStore.readStream<ProductItemAddedV1>(shoppingCartId);
@@ -177,5 +141,35 @@ void describe('DeciderCommandHandler schema versioning', () => {
         addedAt: '2024-03-01T09:00:00.000Z',
       },
     ]);
+  });
+
+  void it('round-trips through downcast on append and upcast on read', async () => {
+    const eventStore = getInMemoryEventStore();
+    const shoppingCartId = randomUUID();
+
+    await handle(eventStore, shoppingCartId, addSocks);
+
+    const { newState } = await handle(eventStore, shoppingCartId, () => ({
+      type: 'ProductItemAdded',
+      data: {
+        productItem: { productId: 'hat', quantity: 1 },
+        addedAt: new Date('2024-03-02T09:00:00.000Z'),
+      },
+    }));
+
+    expect(newState).toEqual({
+      productItems: [
+        {
+          productId: 'socks',
+          quantity: 3,
+          addedAt: new Date('2024-03-01T09:00:00.000Z'),
+        },
+        {
+          productId: 'hat',
+          quantity: 1,
+          addedAt: new Date('2024-03-02T09:00:00.000Z'),
+        },
+      ],
+    });
   });
 });

--- a/src/packages/emmett/src/commandHandling/handleCommandWithDecider.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommandWithDecider.ts
@@ -24,8 +24,11 @@ export type DeciderCommandHandlerOptions<
   State,
   CommandType extends Command,
   StreamEvent extends Event,
-  StoredEvent extends Event = StreamEvent,
-> = Omit<CommandHandlerOptions<State, StreamEvent, StoredEvent>, 'middleware'> &
+  EventPayloadType extends Event = StreamEvent,
+> = Omit<
+  CommandHandlerOptions<State, StreamEvent, EventPayloadType>,
+  'middleware'
+> &
   Decider<State, CommandType, StreamEvent> & {
     middleware?: MiddlewareOptions<
       CommandType,
@@ -47,13 +50,13 @@ export const DeciderCommandHandler =
     State,
     CommandType extends Command,
     StreamEvent extends Event,
-    StoredEvent extends Event = StreamEvent,
+    EventPayloadType extends Event = StreamEvent,
   >(
     options: DeciderCommandHandlerOptions<
       State,
       CommandType,
       StreamEvent,
-      StoredEvent
+      EventPayloadType
     >,
   ) =>
   async <Store extends EventStore>(
@@ -88,7 +91,7 @@ export const DeciderCommandHandler =
     // mirrors the array-of-handlers case in CommandHandler: revisit once we
     // decide on per-command child scopes vs. a single parent with an array
     // attribute.
-    const result = await CommandHandler<State, StreamEvent, StoredEvent>({
+    const result = await CommandHandler<State, StreamEvent, EventPayloadType>({
       ...rest,
       middleware: beforeAll
         ? {

--- a/src/packages/emmett/src/commandHandling/handleCommandWithDecider.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommandWithDecider.ts
@@ -24,7 +24,8 @@ export type DeciderCommandHandlerOptions<
   State,
   CommandType extends Command,
   StreamEvent extends Event,
-> = Omit<CommandHandlerOptions<State, StreamEvent>, 'middleware'> &
+  StoredEvent extends Event = StreamEvent,
+> = Omit<CommandHandlerOptions<State, StreamEvent, StoredEvent>, 'middleware'> &
   Decider<State, CommandType, StreamEvent> & {
     middleware?: MiddlewareOptions<
       CommandType,
@@ -42,8 +43,18 @@ export type DeciderCommandHandlerOptions<
   };
 
 export const DeciderCommandHandler =
-  <State, CommandType extends Command, StreamEvent extends Event>(
-    options: DeciderCommandHandlerOptions<State, CommandType, StreamEvent>,
+  <
+    State,
+    CommandType extends Command,
+    StreamEvent extends Event,
+    StoredEvent extends Event = StreamEvent,
+  >(
+    options: DeciderCommandHandlerOptions<
+      State,
+      CommandType,
+      StreamEvent,
+      StoredEvent
+    >,
   ) =>
   async <Store extends EventStore>(
     eventStore: Store,
@@ -77,7 +88,7 @@ export const DeciderCommandHandler =
     // mirrors the array-of-handlers case in CommandHandler: revisit once we
     // decide on per-command child scopes vs. a single parent with an array
     // attribute.
-    const result = await CommandHandler<State, StreamEvent>({
+    const result = await CommandHandler<State, StreamEvent, StoredEvent>({
       ...rest,
       middleware: beforeAll
         ? {

--- a/src/packages/emmett/src/commandHandling/handleCommandWithDecider.versioning.unit.spec.ts
+++ b/src/packages/emmett/src/commandHandling/handleCommandWithDecider.versioning.unit.spec.ts
@@ -1,0 +1,95 @@
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { getInMemoryEventStore } from '../eventStore';
+import type { Command, Event } from '../typing';
+import { DeciderCommandHandler } from './handleCommandWithDecider';
+
+// #region decider-upcasting
+
+type AddProductItem = Command<
+  'AddProductItem',
+  { productId: string; quantity: number }
+>;
+
+// The shape currently written to the stream
+type ProductItemAdded = Event<
+  'ProductItemAdded',
+  { productId: string; quantity: number }
+>;
+
+// The shape older events were stored with
+type ProductItemAddedV1 = Event<
+  'ProductItemAdded',
+  { productId: string; quantity: string }
+>;
+
+type ShoppingCart = { productItems: { productId: string; quantity: number }[] };
+
+const initialState = (): ShoppingCart => ({ productItems: [] });
+
+const evolve = (
+  state: ShoppingCart,
+  event: ProductItemAdded,
+): ShoppingCart => ({
+  productItems: [...state.productItems, event.data],
+});
+
+const decide = (
+  command: AddProductItem,
+  _state: ShoppingCart,
+): ProductItemAdded => ({
+  type: 'ProductItemAdded',
+  data: command.data,
+});
+
+const handle = DeciderCommandHandler<
+  ShoppingCart,
+  AddProductItem,
+  ProductItemAdded,
+  ProductItemAddedV1
+>({
+  decide,
+  evolve,
+  initialState,
+  schema: {
+    versioning: {
+      // `event` is typed as ProductItemAddedV1, not ProductItemAdded
+      upcast: (event) => ({
+        type: 'ProductItemAdded',
+        data: {
+          productId: event.data.productId,
+          quantity: Number(event.data.quantity),
+        },
+      }),
+    },
+  },
+});
+
+// #endregion decider-upcasting
+
+void describe('DeciderCommandHandler schema versioning', () => {
+  const eventStore = getInMemoryEventStore();
+
+  void it('upcasts stored events before rebuilding the state', async () => {
+    const shoppingCartId = randomUUID();
+
+    await eventStore.appendToStream<ProductItemAddedV1>(shoppingCartId, [
+      {
+        type: 'ProductItemAdded',
+        data: { productId: 'shoes', quantity: '10' },
+      },
+    ]);
+
+    const { newState } = await handle(eventStore, shoppingCartId, {
+      type: 'AddProductItem',
+      data: { productId: 'socks', quantity: 3 },
+    });
+
+    expect(newState).toEqual({
+      productItems: [
+        { productId: 'shoes', quantity: 10 },
+        { productId: 'socks', quantity: 3 },
+      ],
+    });
+  });
+});

--- a/src/packages/emmett/src/eventStore/eventStore.ts
+++ b/src/packages/emmett/src/eventStore/eventStore.ts
@@ -100,27 +100,27 @@ export const nulloSessionFactory = <EventStoreType extends EventStore>(
 
 export type EventStoreReadSchemaOptions<
   StreamEvent extends Event = Event,
-  StoredEvent extends Event = StreamEvent,
+  EventPayloadType extends Event = StreamEvent,
 > = {
   versioning?: {
-    upcast?: (event: StoredEvent) => StreamEvent;
+    upcast?: (event: EventPayloadType) => StreamEvent;
   };
 };
 
 export type EventStoreAppendSchemaOptions<
   StreamEvent extends Event = Event,
-  StoredEvent extends Event = StreamEvent,
+  EventPayloadType extends Event = StreamEvent,
 > = {
   versioning?: {
-    downcast?: (event: StreamEvent) => StoredEvent;
+    downcast?: (event: StreamEvent) => EventPayloadType;
   };
 };
 
 export type EventStoreSchemaOptions<
   StreamEvent extends Event = Event,
-  StoredEvent extends Event = StreamEvent,
-> = EventStoreReadSchemaOptions<StreamEvent, StoredEvent> &
-  EventStoreAppendSchemaOptions<StreamEvent, StoredEvent>;
+  EventPayloadType extends Event = StreamEvent,
+> = EventStoreReadSchemaOptions<StreamEvent, EventPayloadType> &
+  EventStoreAppendSchemaOptions<StreamEvent, EventPayloadType>;
 
 ////////////////////////////////////////////////////////////////////
 /// ReadStream types

--- a/src/packages/emmett/src/eventStore/versioning/upcasting.ts
+++ b/src/packages/emmett/src/eventStore/versioning/upcasting.ts
@@ -47,6 +47,7 @@ export const upcastRecordedMessage = <
 
   return {
     ...recordedMessage,
+    type: upcasted.type as MessagePayloadType['type'],
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     data: upcasted.data,
     ...('metadata' in recordedMessage || 'metadata' in upcasted


### PR DESCRIPTION
There was no way to specify the `StoredEvent` type when using a `DeciderCommandHandler`, so when they differed,  the `upcast` function would issue a type error. Example:

```ts
type ProductItemAdded   = Event<'ProductItemAdded', { productId: string; quantity: number }>;
type ProductItemAddedV1 = Event<'ProductItemAdded', { productId: string; quantity: string }>;

DeciderCommandHandler<Cart, AddProductItem, ProductItemAdded>({
  decide, evolve, initialState,
  schema: {
    versioning: {
      upcast: (event: ProductItemAddedV1) => ({ /* ... */ }), // This would error - `upcast` function thinks the `event` type = `ProductItemAdded`
    },
  },
});
```

Now we can provide the `StoredType` as the fourth parameter:

```ts
DeciderCommandHandler<Cart, AddProductItem, ProductItemAdded, ProductItemAddedV1>({
  decide, evolve, initialState,
  schema: {
    versioning: {
      // event is inferred as ProductItemAddedV1 — no cast needed
      upcast: (event) => ({
        type: 'ProductItemAdded',
        data: {
          productId: event.data.productId,
          quantity: Number(event.data.quantity),
        },
      }),
    },
  },
});
```