### PR TITLE
Added whenCaughtUp and other lifetime hooks to consumers and processors

### DIFF
--- a/src/docs/guides/consumers/testingConsumers.snippet.ts
+++ b/src/docs/guides/consumers/testingConsumers.snippet.ts
@@ -1,0 +1,123 @@
+import { assertThatArray, type Event } from '@event-driven-io/emmett';
+import {
+  getSQLiteEventStore,
+  sqliteEventStoreConsumer,
+} from '@event-driven-io/emmett-sqlite';
+import { sqlite3EventStoreDriver } from '@event-driven-io/emmett-sqlite/sqlite3';
+import { v4 as uuid } from 'uuid';
+import { describe, it } from 'vitest';
+
+type GuestStayEvent = Event<
+  'GuestCheckedIn' | 'GuestCheckedOut',
+  { guestId: string }
+>;
+
+const fileName = `guestStay-${uuid()}.db`;
+
+void describe('Testing async consumers', () => {
+  void it('waits until the consumer catches up', async () => {
+    const eventStore = getSQLiteEventStore({
+      driver: sqlite3EventStoreDriver,
+      fileName,
+    });
+
+    // #region await-caught-up
+    const processed: GuestStayEvent[] = [];
+
+    const consumer = sqliteEventStoreConsumer({
+      driver: sqlite3EventStoreDriver,
+      fileName,
+    });
+    consumer.reactor<GuestStayEvent>({
+      processorId: uuid(),
+      eachMessage: (event) => {
+        processed.push(event);
+      },
+    });
+
+    const guestId = uuid();
+    const events: GuestStayEvent[] = [
+      { type: 'GuestCheckedIn', data: { guestId } },
+      { type: 'GuestCheckedOut', data: { guestId } },
+    ];
+
+    let consumerPromise: Promise<void> | undefined;
+    try {
+      consumerPromise = consumer.start();
+      await consumer.whenStarted();
+
+      await eventStore.appendToStream(`guestStay-${guestId}`, events);
+
+      // resolves once every processor has reached the store's tail
+      await consumer.whenCaughtUp();
+
+      assertThatArray(processed).containsElementsMatching(events);
+    } finally {
+      await consumer.close();
+      await consumerPromise;
+    }
+    // #endregion await-caught-up
+  });
+
+  void it('waits for a specific appended position', async () => {
+    const eventStore = getSQLiteEventStore({
+      driver: sqlite3EventStoreDriver,
+      fileName,
+    });
+    const consumer = sqliteEventStoreConsumer({
+      driver: sqlite3EventStoreDriver,
+      fileName,
+    });
+    const guestId = uuid();
+    consumer.reactor<GuestStayEvent>({
+      processorId: uuid(),
+      eachMessage: () => {},
+    });
+
+    let consumerPromise: Promise<void> | undefined;
+    try {
+      consumerPromise = consumer.start();
+      await consumer.whenStarted();
+
+      // #region await-processed
+      const appendResult = await eventStore.appendToStream(
+        `guestStay-${guestId}`,
+        [
+          { type: 'GuestCheckedIn', data: { guestId } },
+          { type: 'GuestCheckedOut', data: { guestId } },
+        ],
+      );
+
+      await consumer.whenProcessed(appendResult.lastEventGlobalPosition);
+      // #endregion await-processed
+    } finally {
+      await consumer.close();
+      await consumerPromise;
+    }
+  });
+
+  void it('fails fast instead of hanging', async () => {
+    const consumer = sqliteEventStoreConsumer({
+      driver: sqlite3EventStoreDriver,
+      fileName,
+    });
+    consumer.reactor<GuestStayEvent>({
+      processorId: uuid(),
+      eachMessage: () => {},
+    });
+
+    let consumerPromise: Promise<void> | undefined;
+    try {
+      consumerPromise = consumer.start();
+      await consumer.whenStarted();
+
+      // #region with-timeout
+      // rejects with a descriptive error after 5s rather than hanging
+      await consumer.whenCaughtUp({ timeout: 5000 });
+      // #endregion with-timeout
+    } finally {
+      await consumer.close();
+      await consumerPromise;
+    }
+  });
+});

--- a/src/docs/guides/testing.md
+++ b/src/docs/guides/testing.md
@@ -113,6 +113,22 @@ Emmett processes each event exactly once today: inline projections run inside th
 
 For raw SQL projections, deletion, and multi-stream projections, see [Test a Projection](/guides/projections#test) in the Read Models guide.
 
+## Test Async Consumers {#async-consumers}
+
+**An async consumer runs in the background, so a test has to wait for it to process what the test appended before asserting.** The unreliable ways to wait are a fixed `sleep`, which is either flaky or slow, and a stop condition that closes over a position assigned after the append, which races the poller and hangs when the poller wins. Wait on the consumer's own progress instead.
+
+Start the consumer, append, and let `whenCaughtUp` resolve once every processor has reached the store's tail as of the call. It observes committed checkpoints, so it resolves the moment processing catches up and never hangs on an append it has already passed:
+
+<<< ./consumers/testingConsumers.snippet.ts#await-caught-up
+
+When you care about one precise point rather than the whole tail, wait for the position the append returned:
+
+<<< ./consumers/testingConsumers.snippet.ts#await-processed
+
+Both waits observe checkpoints rather than a message callback, so they work for projectors too, which have no `eachMessage` to hook. Bound them with a `timeout` so a consumer that never catches up fails fast with a descriptive error instead of hanging until the test runner kills it:
+
+<<< ./consumers/testingConsumers.snippet.ts#with-timeout
+
 ## Choose the Right Level {#choose-level}
 
 **The proportion between the levels is up to you**, but one rule keeps it honest: put each test at the lowest level that can fail for the reason you care about.
@@ -137,6 +153,10 @@ Route the current time through command metadata and inject dependencies like the
 
 Share the container and store across a suite, but give each test a fresh stream id from `randomUUID` in `beforeEach`, so no test can see another's events. The [integration spec](https://github.com/event-driven-io/emmett/blob/main/src/docs/snippets/gettingStarted/webApi/apiBDD.int.spec.ts) shows the pattern.
 
+### Wait for a Point, Don't Race a Stop {#best-practices-wait}
+
+When a test drives an async consumer, wait on `whenCaughtUp` or `whenProcessed`, not on a stop condition that closes over a position assigned after `appendToStream`. The awaiters observe committed progress, so they resolve as soon as processing catches up and can't miss an append they already passed. A stop that races a late position is the classic source of a consumer test that passes locally and times out on CI.
+
 ## Troubleshooting {#troubleshooting}
 
 ### A Timestamp Assertion Fails By Milliseconds {#troubleshooting-timestamps}
@@ -146,6 +166,10 @@ The decision is reading the wall clock instead of an injected time. Route time t
 ### The Suite Is Slow {#troubleshooting-containers}
 
 A container is starting per test. Start one in `beforeAll`, reuse it, and give each test a fresh stream id instead. Close the store and stop the container in `afterAll` so connections get released.
+
+### A Consumer Test Hangs or Times Out {#troubleshooting-consumer-hang}
+
+The test is waiting on something the consumer never reaches. Replace any `sleep` or position-racing stop with `whenCaughtUp`, and pass a `timeout` so the wait rejects with a message naming the processor and the checkpoint it stopped at instead of hanging until the runner kills it. If a processor deliberately does not persist checkpoints, for example one resuming from an explicit in-memory position, its progress is invisible to `whenCaughtUp`; wait on a message from its handler instead.
 
 ## Further Readings {#readings}
 

--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.checkpointMapping.int.spec.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.checkpointMapping.int.spec.ts
@@ -1,0 +1,228 @@
+import {
+  assertEqual,
+  asyncRetry,
+  bigIntProcessorCheckpoint,
+  type Event,
+} from '@event-driven-io/emmett';
+import type { StartedEventStoreDBContainer } from '@event-driven-io/emmett-testcontainers';
+import { EventStoreDBContainer } from '@event-driven-io/emmett-testcontainers';
+import { BACKWARDS, END, type ResolvedEvent } from '@eventstore/db-client';
+import { v4 as uuid } from 'uuid';
+import { afterAll, beforeAll, describe, it } from 'vitest';
+import {
+  getEventStoreDBEventStore,
+  mapFromESDBEvent,
+  type EventStoreDBEventStore,
+} from '../eventstoreDBEventStore';
+import { $all } from './eventStoreDBEventStoreConsumer';
+
+const withDeadline = { timeout: 30000 };
+
+void describe('EventStoreDB checkpoint mapping', () => {
+  let eventStoreDB: StartedEventStoreDBContainer;
+  let eventStore: EventStoreDBEventStore;
+
+  beforeAll(async () => {
+    eventStoreDB = await new EventStoreDBContainer().start();
+    eventStore = getEventStoreDBEventStore(eventStoreDB.getClient());
+  });
+
+  afterAll(async () => {
+    try {
+      await eventStoreDB.stop();
+    } catch (error) {
+      console.log(error);
+    }
+  });
+
+  const readLastFromAll = async (
+    streamName: string,
+  ): Promise<ResolvedEvent<GuestStayEvent>> => {
+    const stream = eventStoreDB.getClient().readAll({
+      direction: BACKWARDS,
+      fromPosition: END,
+      resolveLinkTos: false,
+    });
+
+    for await (const resolvedEvent of stream) {
+      if (resolvedEvent.event?.streamId === streamName)
+        return resolvedEvent as ResolvedEvent<GuestStayEvent>;
+    }
+
+    throw new Error(`Expected to read event from ${streamName} in $all`);
+  };
+
+  const readLastFromProjection = async (
+    projectionStreamName: string,
+    streamName: string,
+  ): Promise<ResolvedEvent<GuestStayEvent>> =>
+    asyncRetry(
+      async () => {
+        const stream = eventStoreDB
+          .getClient()
+          .readStream<GuestStayEvent>(projectionStreamName, {
+            direction: BACKWARDS,
+            fromRevision: END,
+            resolveLinkTos: true,
+          });
+
+        for await (const resolvedEvent of stream) {
+          if (resolvedEvent.event?.streamId === streamName)
+            return resolvedEvent;
+        }
+
+        throw new Error(
+          `Expected to read event from ${streamName} in ${projectionStreamName}`,
+        );
+      },
+      {
+        retries: 100,
+        minTimeout: 50,
+        factor: 1,
+      },
+    );
+
+  void it(
+    'maps $all checkpoint to resumable global commit position',
+    withDeadline,
+    async () => {
+      const guestId = uuid();
+      const streamName = `guestStay-${guestId}`;
+      const events: GuestStayEvent[] = [
+        { type: 'GuestCheckedIn', data: { guestId } },
+        { type: 'GuestCheckedOut', data: { guestId } },
+      ];
+      const appendResult = await eventStore.appendToStream(streamName, events);
+
+      const resolvedEvent = await readLastFromAll(streamName);
+      const mapped = mapFromESDBEvent<GuestStayEvent>(resolvedEvent, {
+        stream: $all,
+      });
+
+      assertEqual(
+        mapped.metadata.checkpoint,
+        appendResult.lastEventGlobalPosition,
+      );
+      assertEqual(
+        mapped.metadata.globalPosition,
+        appendResult.lastEventGlobalPosition,
+      );
+    },
+  );
+
+  void it(
+    'maps category checkpoint to resumable category revision and keeps original global position',
+    withDeadline,
+    async () => {
+      const guestId = uuid();
+      const streamName = `guestStay-${guestId}`;
+      const events: GuestStayEvent[] = [
+        { type: 'GuestCheckedIn', data: { guestId } },
+        { type: 'GuestCheckedOut', data: { guestId } },
+      ];
+      await eventStore.appendToStream(streamName, events);
+
+      const resolvedEvent = await readLastFromProjection(
+        '$ce-guestStay',
+        streamName,
+      );
+      const mapped = mapFromESDBEvent<GuestStayEvent>(resolvedEvent, {
+        stream: '$ce-guestStay',
+        options: { resolveLinkTos: true },
+      });
+
+      assertEqual(
+        mapped.metadata.checkpoint,
+        bigIntProcessorCheckpoint(resolvedEvent.link!.revision),
+      );
+      assertEqual(
+        mapped.metadata.globalPosition,
+        bigIntProcessorCheckpoint(resolvedEvent.event!.position!.commit),
+      );
+      assertEqual(mapped.metadata.streamName, streamName);
+    },
+  );
+
+  void it(
+    'maps event type projection checkpoint to resumable projection revision and keeps original global position',
+    withDeadline,
+    async () => {
+      const guestId = uuid();
+      const streamName = `guestStay-${guestId}`;
+      const events: GuestStayEvent[] = [
+        { type: 'GuestCheckedIn', data: { guestId } },
+        { type: 'GuestCheckedOut', data: { guestId } },
+      ];
+      await eventStore.appendToStream(streamName, events);
+
+      const resolvedEvent = await readLastFromProjection(
+        '$et-GuestCheckedOut',
+        streamName,
+      );
+      const mapped = mapFromESDBEvent<GuestStayEvent>(resolvedEvent, {
+        stream: '$et-GuestCheckedOut',
+        options: { resolveLinkTos: true },
+      });
+
+      assertEqual(
+        mapped.metadata.checkpoint,
+        bigIntProcessorCheckpoint(resolvedEvent.link!.revision),
+      );
+      assertEqual(
+        mapped.metadata.globalPosition,
+        bigIntProcessorCheckpoint(resolvedEvent.event!.position!.commit),
+      );
+      assertEqual(mapped.metadata.streamName, streamName);
+      assertEqual(mapped.type, 'GuestCheckedOut');
+    },
+  );
+
+  void it(
+    'maps regular stream checkpoint to resumable stream revision and keeps global position when available',
+    withDeadline,
+    async () => {
+      const guestId = uuid();
+      const streamName = `guestStay-${guestId}`;
+      const events: GuestStayEvent[] = [
+        { type: 'GuestCheckedIn', data: { guestId } },
+        { type: 'GuestCheckedOut', data: { guestId } },
+      ];
+      const appendResult = await eventStore.appendToStream(streamName, events);
+
+      const stream = eventStoreDB
+        .getClient()
+        .readStream<GuestStayEvent>(streamName, {
+          direction: BACKWARDS,
+          fromRevision: END,
+          maxCount: 1,
+        });
+
+      for await (const resolvedEvent of stream) {
+        const mapped = mapFromESDBEvent<GuestStayEvent>(resolvedEvent, {
+          stream: streamName,
+        });
+
+        assertEqual(
+          mapped.metadata.checkpoint,
+          bigIntProcessorCheckpoint(appendResult.nextExpectedStreamVersion),
+        );
+        assertEqual(
+          mapped.metadata.globalPosition,
+          appendResult.lastEventGlobalPosition,
+        );
+        assertEqual(
+          mapped.metadata.streamPosition,
+          appendResult.nextExpectedStreamVersion,
+        );
+        return;
+      }
+
+      throw new Error(`Expected to read event from ${streamName}`);
+    },
+  );
+});
+
+type GuestCheckedIn = Event<'GuestCheckedIn', { guestId: string }>;
+type GuestCheckedOut = Event<'GuestCheckedOut', { guestId: string }>;
+
+type GuestStayEvent = GuestCheckedIn | GuestCheckedOut;

--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.handling.int.spec.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.handling.int.spec.ts
@@ -508,6 +508,73 @@ void describe('EventStoreDB event store started consumer', () => {
       );
     });
 
+    void describe('startFrom END across processors in one consumer', () => {
+      void it(
+        'does not flood END processor when mixed with BEGINNING processor in one consumer',
+        withDeadline,
+        async () => {
+          // Given
+          const guestId = uuid();
+          const otherGuestId = uuid();
+          const streamName = `guestStay-${guestId}`;
+
+          const initialEvents: GuestStayEvent[] = [
+            { type: 'GuestCheckedIn', data: { guestId } },
+            { type: 'GuestCheckedOut', data: { guestId } },
+          ];
+          await eventStore.appendToStream(streamName, initialEvents);
+
+          const newEvents: GuestStayEvent[] = [
+            { type: 'GuestCheckedIn', data: { guestId: otherGuestId } },
+            { type: 'GuestCheckedOut', data: { guestId: otherGuestId } },
+          ];
+
+          const fromBeginning: GuestStayEvent[] = [];
+          const fromEnd: GuestStayEvent[] = [];
+
+          // When
+          const consumer = eventStoreDBEventStoreConsumer({
+            connectionString,
+            from: { stream: $all },
+          });
+          consumer.reactor<GuestStayEvent>({
+            processorId: uuid(),
+            startFrom: 'BEGINNING',
+            eachMessage: (event) => {
+              if (event.metadata.streamName === streamName)
+                fromBeginning.push(event);
+            },
+          });
+          consumer.reactor<GuestStayEvent>({
+            processorId: uuid(),
+            startFrom: 'END',
+            eachMessage: (event) => {
+              if (event.metadata.streamName === streamName) fromEnd.push(event);
+            },
+          });
+
+          let consumerPromise: Promise<void> | undefined;
+          try {
+            consumerPromise = consumer.start();
+            await consumer.whenStarted();
+
+            await eventStore.appendToStream(streamName, newEvents);
+
+            await consumer.whenCaughtUp();
+
+            assertThatArray(fromBeginning).containsElementsMatching([
+              ...initialEvents,
+              ...newEvents,
+            ]);
+            assertThatArray(fromEnd).containsOnlyElementsMatching(newEvents);
+          } finally {
+            await consumer.close();
+            await consumerPromise;
+          }
+        },
+      );
+    });
+
     consumeFrom.forEach(([displayName, from]) => {
       void it(
         `handles all events from ${displayName} appended to event store BEFORE processor was started`,

--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.handling.int.spec.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.handling.int.spec.ts
@@ -347,7 +347,7 @@ void describe('EventStoreDB event store started consumer', () => {
         ];
 
         const result: GuestStayEvent[] = [];
-        let stopAfterStreamPosition: bigint | undefined = undefined;
+        const resultReachedEnd = asyncAwaiter();
 
         // When
         const consumer = eventStoreDBEventStoreConsumer({
@@ -359,27 +359,29 @@ void describe('EventStoreDB event store started consumer', () => {
           startFrom: {
             lastCheckpoint: bigIntProcessorCheckpoint(startPosition),
           },
-          stopAfter: (event) =>
-            event.metadata.streamPosition === stopAfterStreamPosition,
           eachMessage: (event) => {
             result.push(event);
+            if (
+              event.type === 'GuestCheckedOut' &&
+              event.data.guestId === otherGuestId
+            )
+              resultReachedEnd.resolve();
           },
         });
 
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterStreamPosition = appendResult.nextExpectedStreamVersion;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await resultReachedEnd.wait;
 
           assertThatArray(result).containsOnlyElementsMatching(events);
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -406,7 +408,7 @@ void describe('EventStoreDB event store started consumer', () => {
         ];
 
         const result: GuestStayEvent[] = [];
-        let stopAfterPosition: string | undefined = undefined;
+        const resultReachedEnd = asyncAwaiter();
 
         // When
         const consumer = eventStoreDBEventStoreConsumer({
@@ -418,27 +420,29 @@ void describe('EventStoreDB event store started consumer', () => {
           startFrom: {
             lastCheckpoint: startPosition,
           },
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
           eachMessage: (event) => {
             result.push(event);
+            if (
+              event.type === 'GuestCheckedOut' &&
+              event.data.guestId === otherGuestId
+            )
+              resultReachedEnd.resolve();
           },
         });
 
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await resultReachedEnd.wait;
 
           assertThatArray(result).containsOnlyElementsMatching(events);
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -494,11 +498,9 @@ void describe('EventStoreDB event store started consumer', () => {
           // Given
 
           const result: GuestStayEvent[] = [];
-          let stopAfterPosition: string | undefined = undefined;
 
           const guestId = uuid();
           const streamName = `guestStay-${guestId}`;
-          const waitForStart = asyncAwaiter();
 
           // When
           const consumer = eventStoreDBEventStoreConsumer({
@@ -507,10 +509,7 @@ void describe('EventStoreDB event store started consumer', () => {
           });
           consumer.reactor<GuestStayEvent>({
             processorId: uuid(),
-            stopAfter: (event) =>
-              event.metadata.globalPosition === stopAfterPosition,
-            eachMessage: async (event) => {
-              await waitForStart.wait;
+            eachMessage: (event) => {
               result.push(event);
             },
           });
@@ -520,21 +519,19 @@ void describe('EventStoreDB event store started consumer', () => {
             { type: 'GuestCheckedOut', data: { guestId } },
           ];
 
+          let consumerPromise: Promise<void> | undefined;
           try {
-            const consumerPromise = consumer.start();
+            consumerPromise = consumer.start();
+            await consumer.whenStarted();
 
-            const appendResult = await eventStore.appendToStream(
-              streamName,
-              events,
-            );
-            stopAfterPosition = appendResult.lastEventGlobalPosition;
-            waitForStart.resolve();
+            await eventStore.appendToStream(streamName, events);
 
-            await consumerPromise;
+            await consumer.whenCaughtUp();
 
             assertThatArray(result).containsElementsMatching(events);
           } finally {
             await consumer.close();
+            await consumerPromise;
           }
         },
       );
@@ -561,8 +558,6 @@ void describe('EventStoreDB event store started consumer', () => {
           ];
 
           const result: GuestStayEvent[] = [];
-          let stopAfterPosition: string | undefined = undefined;
-          const waitForStart = asyncAwaiter();
 
           // When
           const consumer = eventStoreDBEventStoreConsumer({
@@ -572,25 +567,19 @@ void describe('EventStoreDB event store started consumer', () => {
           consumer.reactor<GuestStayEvent>({
             processorId: uuid(),
             startFrom: 'CURRENT',
-            stopAfter: (event) =>
-              event.metadata.globalPosition === stopAfterPosition,
-            eachMessage: async (event) => {
-              await waitForStart.wait;
+            eachMessage: (event) => {
               result.push(event);
             },
           });
 
+          let consumerPromise: Promise<void> | undefined;
           try {
-            const consumerPromise = consumer.start();
+            consumerPromise = consumer.start();
+            await consumer.whenStarted();
 
-            const appendResult = await eventStore.appendToStream(
-              streamName,
-              events,
-            );
-            stopAfterPosition = appendResult.lastEventGlobalPosition;
-            waitForStart.resolve();
+            await eventStore.appendToStream(streamName, events);
 
-            await consumerPromise;
+            await consumer.whenCaughtUp();
 
             assertThatArray(result).containsElementsMatching([
               ...initialEvents,
@@ -598,6 +587,7 @@ void describe('EventStoreDB event store started consumer', () => {
             ]);
           } finally {
             await consumer.close();
+            await consumerPromise;
           }
         },
       );
@@ -615,8 +605,7 @@ void describe('EventStoreDB event store started consumer', () => {
             { type: 'GuestCheckedIn', data: { guestId } },
             { type: 'GuestCheckedOut', data: { guestId } },
           ];
-          const { lastEventGlobalPosition: startPosition } =
-            await eventStore.appendToStream(streamName, initialEvents);
+          await eventStore.appendToStream(streamName, initialEvents);
 
           const events: GuestStayEvent[] = [
             { type: 'GuestCheckedIn', data: { guestId: otherGuestId } },
@@ -624,9 +613,6 @@ void describe('EventStoreDB event store started consumer', () => {
           ];
 
           let result: GuestStayEvent[] = [];
-          let stopAfterPosition: string | undefined = startPosition;
-
-          const waitForStart = asyncAwaiter();
 
           // When
           const consumer = eventStoreDBEventStoreConsumer({
@@ -636,40 +622,31 @@ void describe('EventStoreDB event store started consumer', () => {
           consumer.reactor<GuestStayEvent>({
             processorId: uuid(),
             startFrom: 'CURRENT',
-            stopAfter: (event) =>
-              event.metadata.globalPosition === stopAfterPosition,
-            eachMessage: async (event) => {
-              await waitForStart.wait;
+            eachMessage: (event) => {
               result.push(event);
             },
           });
 
-          let consumerPromise = consumer.start();
-          waitForStart.resolve();
-          await consumerPromise;
+          let consumerPromise: Promise<void> | undefined = consumer.start();
+          await consumer.whenStarted();
+          await consumer.whenCaughtUp();
           await consumer.stop();
-
-          waitForStart.reset();
+          await consumerPromise;
 
           result = [];
 
-          stopAfterPosition = undefined;
-
           try {
             consumerPromise = consumer.start();
+            await consumer.whenStarted();
 
-            const appendResult = await eventStore.appendToStream(
-              streamName,
-              events,
-            );
-            stopAfterPosition = appendResult.lastEventGlobalPosition;
-            waitForStart.resolve();
+            await eventStore.appendToStream(streamName, events);
 
-            await consumerPromise;
+            await consumer.whenCaughtUp();
 
             assertThatArray(result).containsOnlyElementsMatching(events);
           } finally {
             await consumer.close();
+            await consumerPromise;
           }
         },
       );
@@ -687,8 +664,7 @@ void describe('EventStoreDB event store started consumer', () => {
             { type: 'GuestCheckedIn', data: { guestId } },
             { type: 'GuestCheckedOut', data: { guestId } },
           ];
-          const { lastEventGlobalPosition: startPosition } =
-            await eventStore.appendToStream(streamName, initialEvents);
+          await eventStore.appendToStream(streamName, initialEvents);
 
           const events: GuestStayEvent[] = [
             { type: 'GuestCheckedIn', data: { guestId: otherGuestId } },
@@ -696,16 +672,11 @@ void describe('EventStoreDB event store started consumer', () => {
           ];
 
           let result: GuestStayEvent[] = [];
-          let stopAfterPosition: string | undefined = startPosition;
 
-          const waitForStart = asyncAwaiter();
           const processorOptions: InMemoryReactorOptions<GuestStayEvent> = {
             processorId: uuid(),
             startFrom: 'CURRENT',
-            stopAfter: (event) =>
-              event.metadata.globalPosition === stopAfterPosition,
-            eachMessage: async (event) => {
-              await waitForStart.wait;
+            eachMessage: (event) => {
               result.push(event);
             },
             connectionOptions: { database },
@@ -716,19 +687,19 @@ void describe('EventStoreDB event store started consumer', () => {
             connectionString,
             from: from(streamName),
           });
+          let consumerPromise: Promise<void> | undefined;
           try {
             consumer.reactor<GuestStayEvent>(processorOptions);
 
-            waitForStart.resolve();
-            await consumer.start();
+            consumerPromise = consumer.start();
+            await consumer.whenStarted();
+            await consumer.whenCaughtUp();
           } finally {
             await consumer.close();
+            await consumerPromise;
           }
 
           result = [];
-
-          waitForStart.reset();
-          stopAfterPosition = undefined;
 
           const newConsumer = eventStoreDBEventStoreConsumer({
             connectionString,
@@ -736,21 +707,19 @@ void describe('EventStoreDB event store started consumer', () => {
           });
           newConsumer.reactor<GuestStayEvent>(processorOptions);
 
+          let newConsumerPromise: Promise<void> | undefined;
           try {
-            const consumerPromise = newConsumer.start();
+            newConsumerPromise = newConsumer.start();
+            await newConsumer.whenStarted();
 
-            const appendResult = await eventStore.appendToStream(
-              streamName,
-              events,
-            );
-            waitForStart.resolve();
-            stopAfterPosition = appendResult.lastEventGlobalPosition;
+            await eventStore.appendToStream(streamName, events);
 
-            await consumerPromise;
+            await newConsumer.whenCaughtUp();
 
             assertThatArray(result).containsOnlyElementsMatching(events);
           } finally {
             await newConsumer.close();
+            await newConsumerPromise;
           }
         },
       );

--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.handling.int.spec.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.handling.int.spec.ts
@@ -1,6 +1,5 @@
 import {
   assertThatArray,
-  asyncAwaiter,
   bigIntProcessorCheckpoint,
   delay,
   getInMemoryDatabase,
@@ -143,8 +142,8 @@ void describe('EventStoreDB event store started consumer', () => {
         consumer.reactor<GuestStayEvent>({
           processorId: uuid(),
           stopAfter: (event) =>
-            event.metadata.globalPosition ===
-            appendResult.lastEventGlobalPosition,
+            event.metadata.checkpoint ===
+            bigIntProcessorCheckpoint(appendResult.nextExpectedStreamVersion),
           eachMessage: (event) => {
             result.push(event);
           },
@@ -186,8 +185,8 @@ void describe('EventStoreDB event store started consumer', () => {
       consumer.reactor<NumberRecorded>({
         processorId: uuid(),
         stopAfter: (event) =>
-          event.metadata.globalPosition ===
-          appendResult.lastEventGlobalPosition,
+          event.metadata.checkpoint ===
+          bigIntProcessorCheckpoint(appendResult.nextExpectedStreamVersion),
         eachMessage: async (event) => {
           await delay(Math.floor(Math.random() * 200));
 
@@ -245,8 +244,8 @@ void describe('EventStoreDB event store started consumer', () => {
         consumer.reactor<NumberRecorded>({
           processorId: uuid(),
           stopAfter: (event) =>
-            event.metadata.globalPosition ===
-            appendResult.lastEventGlobalPosition,
+            event.metadata.checkpoint ===
+            bigIntProcessorCheckpoint(appendResult.nextExpectedStreamVersion),
           eachMessage: (event) => {
             if (shouldThrowRandomError) {
               return Promise.reject(new Error('Random error'));
@@ -347,7 +346,6 @@ void describe('EventStoreDB event store started consumer', () => {
         ];
 
         const result: GuestStayEvent[] = [];
-        const resultReachedEnd = asyncAwaiter();
 
         // When
         const consumer = eventStoreDBEventStoreConsumer({
@@ -361,11 +359,6 @@ void describe('EventStoreDB event store started consumer', () => {
           },
           eachMessage: (event) => {
             result.push(event);
-            if (
-              event.type === 'GuestCheckedOut' &&
-              event.data.guestId === otherGuestId
-            )
-              resultReachedEnd.resolve();
           },
         });
 
@@ -376,7 +369,7 @@ void describe('EventStoreDB event store started consumer', () => {
 
           await eventStore.appendToStream(streamName, events);
 
-          await resultReachedEnd.wait;
+          await consumer.whenCaughtUp();
 
           assertThatArray(result).containsOnlyElementsMatching(events);
         } finally {
@@ -408,7 +401,6 @@ void describe('EventStoreDB event store started consumer', () => {
         ];
 
         const result: GuestStayEvent[] = [];
-        const resultReachedEnd = asyncAwaiter();
 
         // When
         const consumer = eventStoreDBEventStoreConsumer({
@@ -422,11 +414,6 @@ void describe('EventStoreDB event store started consumer', () => {
           },
           eachMessage: (event) => {
             result.push(event);
-            if (
-              event.type === 'GuestCheckedOut' &&
-              event.data.guestId === otherGuestId
-            )
-              resultReachedEnd.resolve();
           },
         });
 
@@ -437,7 +424,7 @@ void describe('EventStoreDB event store started consumer', () => {
 
           await eventStore.appendToStream(streamName, events);
 
-          await resultReachedEnd.wait;
+          await consumer.whenCaughtUp();
 
           assertThatArray(result).containsOnlyElementsMatching(events);
         } finally {
@@ -446,6 +433,80 @@ void describe('EventStoreDB event store started consumer', () => {
         }
       },
     );
+
+    const projectionStreams: [
+      string,
+      EventStoreDBEventStoreConsumerType,
+      (events: GuestStayEvent[]) => GuestStayEvent[],
+    ][] = [
+      [
+        'category projection',
+        { stream: '$ce-guestStay', options: { resolveLinkTos: true } },
+        (events: GuestStayEvent[]) => events,
+      ],
+      [
+        'event type projection',
+        { stream: '$et-GuestCheckedOut', options: { resolveLinkTos: true } },
+        (events: GuestStayEvent[]) =>
+          events.filter((event) => event.type === 'GuestCheckedOut'),
+      ],
+    ];
+
+    projectionStreams.forEach(([displayName, from, expectedEvents]) => {
+      void it(
+        `handles only new events when starting from END for ${displayName}`,
+        withDeadline,
+        async () => {
+          // Given
+          const guestId = uuid();
+          const otherGuestId = uuid();
+          const streamName = `guestStay-${guestId}`;
+
+          const initialEvents: GuestStayEvent[] = [
+            { type: 'GuestCheckedIn', data: { guestId } },
+            { type: 'GuestCheckedOut', data: { guestId } },
+          ];
+          await eventStore.appendToStream(streamName, initialEvents);
+
+          const events: GuestStayEvent[] = [
+            { type: 'GuestCheckedIn', data: { guestId: otherGuestId } },
+            { type: 'GuestCheckedOut', data: { guestId: otherGuestId } },
+          ];
+
+          const result: GuestStayEvent[] = [];
+
+          // When
+          const consumer = eventStoreDBEventStoreConsumer({
+            connectionString,
+            from,
+          });
+          consumer.reactor<GuestStayEvent>({
+            processorId: uuid(),
+            startFrom: 'END',
+            eachMessage: (event) => {
+              result.push(event);
+            },
+          });
+
+          let consumerPromise: Promise<void> | undefined;
+          try {
+            consumerPromise = consumer.start();
+            await consumer.whenStarted();
+
+            await eventStore.appendToStream(streamName, events);
+
+            await consumer.whenCaughtUp();
+
+            assertThatArray(result).containsOnlyElementsMatching(
+              expectedEvents(events),
+            );
+          } finally {
+            await consumer.close();
+            await consumerPromise;
+          }
+        },
+      );
+    });
 
     consumeFrom.forEach(([displayName, from]) => {
       void it(

--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.inMemory.projections.int.spec.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.inMemory.projections.int.spec.ts
@@ -104,14 +104,10 @@ void describe('EventStoreDB event store started consumer', () => {
       withDeadline,
       async () => {
         // Given
-        let stopAfterPosition: string | undefined = undefined;
-
         const inMemoryProcessor = inMemoryProjector<ShoppingCartSummaryEvent>({
           processorId: uuid(),
           projection: shoppingCartsSummaryProjection,
           connectionOptions: { database },
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
         });
         const consumer =
           eventStoreDBEventStoreConsumer<ShoppingCartSummaryEvent>({
@@ -135,16 +131,14 @@ void describe('EventStoreDB event store started consumer', () => {
           },
         ];
 
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await consumer.whenCaughtUp();
 
           const summary = await summaries.findOne((d) => d._id === streamName);
 
@@ -156,6 +150,7 @@ void describe('EventStoreDB event store started consumer', () => {
           });
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -183,8 +178,6 @@ void describe('EventStoreDB event store started consumer', () => {
           },
         ];
 
-        let stopAfterPosition: string | undefined = undefined;
-
         const inMemoryProcessor = inMemoryProjector<ShoppingCartSummaryEvent>({
           processorId: uuid(),
           projection: shoppingCartsSummaryProjection,
@@ -192,8 +185,6 @@ void describe('EventStoreDB event store started consumer', () => {
           startFrom: {
             lastCheckpoint: startPosition,
           },
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
         });
 
         const consumer =
@@ -203,16 +194,14 @@ void describe('EventStoreDB event store started consumer', () => {
           });
 
         // When
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await consumer.whenCaughtUp({ timeout: 30000 });
 
           const summary = await summaries.findOne((d) => d._id === streamName);
 
@@ -224,6 +213,7 @@ void describe('EventStoreDB event store started consumer', () => {
           });
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -251,15 +241,11 @@ void describe('EventStoreDB event store started consumer', () => {
           },
         ];
 
-        let stopAfterPosition: string | undefined = undefined;
-
         const inMemoryProcessor = inMemoryProjector<ShoppingCartSummaryEvent>({
           processorId: uuid(),
           projection: shoppingCartsSummaryProjection,
           connectionOptions: { database },
           startFrom: 'CURRENT',
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
         });
 
         const consumer =
@@ -270,16 +256,14 @@ void describe('EventStoreDB event store started consumer', () => {
 
         // When
 
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await consumer.whenCaughtUp();
 
           const summary = await summaries.findOne((d) => d._id === streamName);
 
@@ -291,6 +275,7 @@ void describe('EventStoreDB event store started consumer', () => {
           });
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -307,8 +292,7 @@ void describe('EventStoreDB event store started consumer', () => {
           { type: 'ProductItemAdded', data: { productItem } },
           { type: 'ProductItemAdded', data: { productItem } },
         ];
-        const { lastEventGlobalPosition: startPosition } =
-          await eventStore.appendToStream(streamName, initialEvents);
+        await eventStore.appendToStream(streamName, initialEvents);
 
         const events: ShoppingCartSummaryEvent[] = [
           { type: 'ProductItemAdded', data: { productItem } },
@@ -318,15 +302,11 @@ void describe('EventStoreDB event store started consumer', () => {
           },
         ];
 
-        let stopAfterPosition: string | undefined = startPosition;
-
         const inMemoryProcessor = inMemoryProjector<ShoppingCartSummaryEvent>({
           processorId: uuid(),
           projection: shoppingCartsSummaryProjection,
           connectionOptions: { database },
           startFrom: 'CURRENT',
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
         });
 
         const consumer =
@@ -336,21 +316,19 @@ void describe('EventStoreDB event store started consumer', () => {
           });
 
         // When
-        await consumer.start();
+        let consumerPromise: Promise<void> | undefined = consumer.start();
+        await consumer.whenStarted();
+        await consumer.whenCaughtUp();
         await consumer.stop();
-
-        stopAfterPosition = undefined;
+        await consumerPromise;
 
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await consumer.whenCaughtUp();
 
           const summary = await summaries.findOne((d) => d._id === streamName);
 
@@ -362,6 +340,7 @@ void describe('EventStoreDB event store started consumer', () => {
           });
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -378,8 +357,7 @@ void describe('EventStoreDB event store started consumer', () => {
           { type: 'ProductItemAdded', data: { productItem } },
           { type: 'ProductItemAdded', data: { productItem } },
         ];
-        const { lastEventGlobalPosition: startPosition } =
-          await eventStore.appendToStream(streamName, initialEvents);
+        await eventStore.appendToStream(streamName, initialEvents);
 
         const events: ShoppingCartSummaryEvent[] = [
           { type: 'ProductItemAdded', data: { productItem } },
@@ -389,15 +367,11 @@ void describe('EventStoreDB event store started consumer', () => {
           },
         ];
 
-        let stopAfterPosition: string | undefined = startPosition;
-
         const inMemoryProcessor = inMemoryProjector<ShoppingCartSummaryEvent>({
           processorId: uuid(),
           projection: shoppingCartsSummaryProjection,
           connectionOptions: { database },
           startFrom: 'CURRENT',
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
         });
 
         const consumer =
@@ -407,29 +381,29 @@ void describe('EventStoreDB event store started consumer', () => {
           });
 
         // When
+        let consumerPromise: Promise<void> | undefined;
         try {
-          await consumer.start();
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
+          await consumer.whenCaughtUp();
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
-
-        stopAfterPosition = undefined;
 
         const newConsumer = eventStoreDBEventStoreConsumer({
           connectionString,
           processors: [inMemoryProcessor],
         });
 
+        let newConsumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = newConsumer.start();
+          newConsumerPromise = newConsumer.start();
+          await newConsumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await newConsumer.whenCaughtUp();
 
           const summary = await summaries.findOne((d) => d._id === streamName);
 
@@ -441,6 +415,7 @@ void describe('EventStoreDB event store started consumer', () => {
           });
         } finally {
           await newConsumer.close();
+          await newConsumerPromise;
         }
       },
     );

--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.int.spec.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.int.spec.ts
@@ -33,6 +33,7 @@ void describe('EventStoreDB event store consumer', () => {
     start: () => Promise.resolve('BEGINNING'),
     close: () => Promise.resolve(),
     handle: () => Promise.resolve(),
+    whenProcessed: () => Promise.resolve(),
     isActive: false,
   };
 

--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.ts
@@ -5,7 +5,6 @@ import type {
 } from '@event-driven-io/emmett';
 import {
   asyncAwaiter,
-  bigIntProcessorCheckpoint,
   CurrentMessageProcessorPosition,
   EmmettError,
   inMemoryProjector,
@@ -26,10 +25,7 @@ import {
   type WaitOptions,
 } from '@event-driven-io/emmett';
 import {
-  BACKWARDS,
-  END,
   EventStoreDBClient,
-  StreamNotFoundError,
   type SubscribeToAllOptions,
   type SubscribeToStreamOptions,
 } from '@eventstore/db-client';
@@ -38,6 +34,7 @@ import type { EventStoreDBReadEventMetadata } from '../eventstoreDBEventStore';
 import {
   DefaultEventStoreDBEventStoreProcessorBatchSize,
   eventStoreDBSubscription,
+  readLastCommittedMessageCheckpoint,
   type EventStoreDBSubscription,
 } from './subscriptions';
 
@@ -177,6 +174,16 @@ export const eventStoreDBEventStoreConsumer = <
 
   const stopProcessors = () => Promise.all(processors.map((p) => p.close({})));
 
+  const resolveStartFrom = async (
+    startFrom: CurrentMessageProcessorPosition,
+  ): Promise<CurrentMessageProcessorPosition> => {
+    if (startFrom !== 'END') return startFrom;
+
+    const tail = await readLastCommittedMessageCheckpoint(client, from);
+
+    return tail === undefined ? 'END' : { lastCheckpoint: tail };
+  };
+
   const stop = async () => {
     if (!isRunning) return;
     isRunning = false;
@@ -201,46 +208,11 @@ export const eventStoreDBEventStoreConsumer = <
         processors.map((p) => p.whenProcessed(position, options)),
       ).then(() => undefined),
     whenCaughtUp: async (options): Promise<void> => {
-      let tail: bigint | undefined;
-
-      if (!from || from.stream === $all) {
-        const stream = client.readAll({
-          direction: BACKWARDS,
-          fromPosition: END,
-          maxCount: 1,
-        });
-
-        for await (const resolved of stream) {
-          tail = (resolved.event?.position?.commit ??
-            resolved.link?.position?.commit)!;
-          break;
-        }
-      } else {
-        try {
-          const stream = client.readStream(from.stream, {
-            direction: BACKWARDS,
-            fromRevision: END,
-            maxCount: 1,
-          });
-
-          for await (const resolved of stream) {
-            tail = resolved.event?.revision ?? resolved.link?.revision;
-            break;
-          }
-        } catch (error) {
-          if (error instanceof StreamNotFoundError) return;
-          throw error;
-        }
-      }
+      const tail = await readLastCommittedMessageCheckpoint(client, from);
 
       if (tail === undefined) return;
-      const caughtUpTail = tail;
 
-      await Promise.all(
-        processors.map((p) =>
-          p.whenProcessed(bigIntProcessorCheckpoint(caughtUpTail), options),
-        ),
-      );
+      await Promise.all(processors.map((p) => p.whenProcessed(tail, options)));
     },
     processors,
     reactor: <MessageType extends AnyMessage = ConsumerMessageType>(
@@ -314,7 +286,11 @@ export const eventStoreDBEventStoreConsumer = <
             await Promise.all(processors.map((o) => o.start(client))),
           );
 
-          await subscription.start({ startFrom, started: startedAwaiter });
+          currentSubscription = subscription;
+          await subscription.start({
+            startFrom: await resolveStartFrom(startFrom),
+            started: startedAwaiter,
+          });
         } catch (error) {
           isRunning = false;
           startedAwaiter.reject(error);

--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.ts
@@ -5,7 +5,7 @@ import type {
 } from '@event-driven-io/emmett';
 import {
   asyncAwaiter,
-  CurrentMessageProcessorPosition,
+  ConsumerStartPositions,
   EmmettError,
   inMemoryProjector,
   inMemoryReactor,
@@ -111,6 +111,7 @@ export const eventStoreDBEventStoreConsumer = <
   const from = options.from;
   const processors = options.processors ?? [];
   let abortController: AbortController | null = null;
+  let startPositions: ConsumerStartPositions | undefined;
 
   let start: Promise<void>;
 
@@ -138,7 +139,11 @@ export const eventStoreDBEventStoreConsumer = <
     const result = await Promise.allSettled(
       activeProcessors.map(async (s) => {
         // TODO: Add here filtering to only pass messages that can be handled by
-        return await s.handle(messagesBatch, { client });
+        const batch =
+          startPositions?.afterStartPosition(s.id, messagesBatch) ??
+          messagesBatch;
+
+        return await s.handle(batch, { client });
       }),
     );
 
@@ -173,16 +178,6 @@ export const eventStoreDBEventStoreConsumer = <
   };
 
   const stopProcessors = () => Promise.all(processors.map((p) => p.close({})));
-
-  const resolveStartFrom = async (
-    startFrom: CurrentMessageProcessorPosition,
-  ): Promise<CurrentMessageProcessorPosition> => {
-    if (startFrom !== 'END') return startFrom;
-
-    const tail = await readLastCommittedMessageCheckpoint(client, from);
-
-    return tail === undefined ? 'END' : { lastCheckpoint: tail };
-  };
 
   const stop = async () => {
     if (!isRunning) return;
@@ -282,13 +277,22 @@ export const eventStoreDBEventStoreConsumer = <
             await init();
           }
 
-          const startFrom = CurrentMessageProcessorPosition.zip(
-            await Promise.all(processors.map((o) => o.start(client))),
-          );
+          startPositions = await ConsumerStartPositions.resolve({
+            processors,
+            handlerContext: client as never,
+            readLastMessageCheckpoint: async () => {
+              const tail = await readLastCommittedMessageCheckpoint(
+                client,
+                from,
+              );
+
+              return tail ?? null;
+            },
+          });
 
           currentSubscription = subscription;
           await subscription.start({
-            startFrom: await resolveStartFrom(startFrom),
+            startFrom: startPositions.earliestPosition,
             started: startedAwaiter,
           });
         } catch (error) {

--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.ts
@@ -5,6 +5,7 @@ import type {
 } from '@event-driven-io/emmett';
 import {
   asyncAwaiter,
+  bigIntProcessorCheckpoint,
   CurrentMessageProcessorPosition,
   EmmettError,
   inMemoryProjector,
@@ -21,9 +22,14 @@ import {
   type Message,
   type MessageConsumer,
   type MessageConsumerOptions,
+  type ProcessorCheckpoint,
+  type WaitOptions,
 } from '@event-driven-io/emmett';
 import {
+  BACKWARDS,
+  END,
   EventStoreDBClient,
+  StreamNotFoundError,
   type SubscribeToAllOptions,
   type SubscribeToStreamOptions,
 } from '@eventstore/db-client';
@@ -77,6 +83,12 @@ export type EventStoreDBEventStoreConsumer<
   ConsumerMessageType extends AnyMessage = any,
 > = MessageConsumer<ConsumerMessageType> &
   Readonly<{
+    whenProcessed: (
+      position: ProcessorCheckpoint,
+      options?: WaitOptions,
+    ) => Promise<void>;
+    whenCaughtUp: (options?: WaitOptions) => Promise<void>;
+
     reactor: <MessageType extends AnyMessage = ConsumerMessageType>(
       options: InMemoryReactorOptions<MessageType>,
     ) => InMemoryProcessor<MessageType>;
@@ -99,6 +111,7 @@ export const eventStoreDBEventStoreConsumer = <
   let isRunning = false;
   let isInitialized = false;
   const { pulling } = options;
+  const from = options.from;
   const processors = options.processors ?? [];
   let abortController: AbortController | null = null;
 
@@ -183,6 +196,52 @@ export const eventStoreDBEventStoreConsumer = <
       return isRunning;
     },
     whenStarted: (): Promise<void> => startedAwaiter.wait,
+    whenProcessed: (position, options): Promise<void> =>
+      Promise.all(
+        processors.map((p) => p.whenProcessed(position, options)),
+      ).then(() => undefined),
+    whenCaughtUp: async (options): Promise<void> => {
+      let tail: bigint | undefined;
+
+      if (!from || from.stream === $all) {
+        const stream = client.readAll({
+          direction: BACKWARDS,
+          fromPosition: END,
+          maxCount: 1,
+        });
+
+        for await (const resolved of stream) {
+          tail = (resolved.event?.position?.commit ??
+            resolved.link?.position?.commit)!;
+          break;
+        }
+      } else {
+        try {
+          const stream = client.readStream(from.stream, {
+            direction: BACKWARDS,
+            fromRevision: END,
+            maxCount: 1,
+          });
+
+          for await (const resolved of stream) {
+            tail = resolved.event?.revision ?? resolved.link?.revision;
+            break;
+          }
+        } catch (error) {
+          if (error instanceof StreamNotFoundError) return;
+          throw error;
+        }
+      }
+
+      if (tail === undefined) return;
+      const caughtUpTail = tail;
+
+      await Promise.all(
+        processors.map((p) =>
+          p.whenProcessed(bigIntProcessorCheckpoint(caughtUpTail), options),
+        ),
+      );
+    },
     processors,
     reactor: <MessageType extends AnyMessage = ConsumerMessageType>(
       processorOptions: InMemoryReactorOptions<MessageType>,

--- a/src/packages/emmett-esdb/src/eventStore/consumers/subscriptions/index.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/subscriptions/index.ts
@@ -31,6 +31,7 @@ import {
   $all,
   type EventStoreDBEventStoreConsumerType,
 } from '../eventStoreDBEventStoreConsumer';
+export { readLastCommittedMessageCheckpoint } from './readLastCommittedMessageCheckpoint';
 
 export const DefaultEventStoreDBEventStoreProcessorBatchSize = 100;
 export const DefaultEventStoreDBEventStoreProcessorPullingFrequencyInMs = 50;
@@ -236,7 +237,10 @@ export const eventStoreDBSubscription = <
               _encoding: string,
               done: () => void,
             ) {
-              if (!isRunning) return;
+              if (!isRunning) {
+                done();
+                return;
+              }
 
               if (isString(result)) {
                 options.startFrom = {

--- a/src/packages/emmett-esdb/src/eventStore/consumers/subscriptions/readLastCommittedMessageCheckpoint.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/subscriptions/readLastCommittedMessageCheckpoint.ts
@@ -1,0 +1,226 @@
+import {
+  asyncRetry,
+  bigIntProcessorCheckpoint,
+  getCheckpoint,
+  parseBigIntProcessorCheckpoint,
+  type AsyncRetryOptions,
+  type ProcessorCheckpoint,
+} from '@event-driven-io/emmett';
+import type { EventStoreDBClient } from '@eventstore/db-client';
+import {
+  BACKWARDS,
+  END,
+  StreamNotFoundError,
+  type AllStreamResolvedEvent,
+  type ResolvedEvent,
+} from '@eventstore/db-client';
+import { mapFromESDBEvent } from '../../eventstoreDBEventStore';
+import {
+  $all,
+  type EventStoreDBEventStoreConsumerType,
+} from '../eventStoreDBEventStoreConsumer';
+
+const ProjectionStreamWaitOptions: AsyncRetryOptions<
+  ProcessorCheckpoint | undefined
+> = {
+  retries: 100,
+  minTimeout: 50,
+  factor: 1,
+  shouldRetryError: (error) => error instanceof ProjectionStreamBehindError,
+};
+
+class ProjectionStreamBehindError extends Error {
+  constructor() {
+    super('EventStoreDB projection stream has not caught up yet');
+  }
+}
+
+const isSystemEvent = (resolvedEvent: AllStreamResolvedEvent): boolean =>
+  resolvedEvent.event?.type?.startsWith('$') ?? true;
+
+const isProjectionStreamWithLinks = (
+  from: EventStoreDBEventStoreConsumerType,
+): boolean =>
+  ['$ce-', '$et-'].some((prefix) => from.stream.startsWith(prefix)) &&
+  from.options?.resolveLinkTos === true;
+
+const streamNamePrefix = (projectionStream: string): string =>
+  projectionStream.substring('$ce-'.length);
+
+const eventType = (eventTypeStream: string): string =>
+  eventTypeStream.substring('$et-'.length);
+
+const isEventInProjection = (
+  resolvedEvent: AllStreamResolvedEvent,
+  projectionStream: string,
+): boolean => {
+  if (projectionStream.startsWith('$ce-'))
+    return (
+      resolvedEvent.event?.streamId.startsWith(
+        `${streamNamePrefix(projectionStream)}-`,
+      ) ?? false
+    );
+
+  if (projectionStream.startsWith('$et-'))
+    return resolvedEvent.event?.type === eventType(projectionStream);
+
+  return false;
+};
+
+const asProcessorCheckpoint = (
+  checkpoint: string | undefined,
+): ProcessorCheckpoint | undefined =>
+  checkpoint === undefined
+    ? undefined
+    : bigIntProcessorCheckpoint(BigInt(checkpoint));
+
+const readLastAllCheckpoint = async (
+  client: EventStoreDBClient,
+  from: EventStoreDBEventStoreConsumerType | undefined,
+): Promise<ProcessorCheckpoint | undefined> => {
+  const stream = client.readAll({
+    direction: BACKWARDS,
+    fromPosition: END,
+    resolveLinkTos: false,
+  });
+
+  for await (const resolvedEvent of stream) {
+    if (isSystemEvent(resolvedEvent)) continue;
+
+    return (
+      getCheckpoint(mapFromESDBEvent(resolvedEvent as ResolvedEvent, from)) ??
+      undefined
+    );
+  }
+
+  return undefined;
+};
+
+const readLastStreamCheckpoint = async (
+  client: EventStoreDBClient,
+  from: EventStoreDBEventStoreConsumerType,
+): Promise<ProcessorCheckpoint | undefined> => {
+  try {
+    const stream = client.readStream(from.stream, {
+      direction: BACKWARDS,
+      fromRevision: END,
+      maxCount: 1,
+      ...(from.options ?? {}),
+    });
+
+    for await (const resolvedEvent of stream) {
+      return getCheckpoint(mapFromESDBEvent(resolvedEvent, from)) ?? undefined;
+    }
+
+    return undefined;
+  } catch (error) {
+    if (error instanceof StreamNotFoundError) return undefined;
+    throw error;
+  }
+};
+
+const readLastProjectionStreamCheckpoint = async (
+  client: EventStoreDBClient,
+  from: EventStoreDBEventStoreConsumerType,
+): Promise<
+  | {
+      checkpoint: ProcessorCheckpoint;
+      originalGlobalCheckpoint: ProcessorCheckpoint | undefined;
+    }
+  | undefined
+> => {
+  try {
+    const stream = client.readStream(from.stream, {
+      direction: BACKWARDS,
+      fromRevision: END,
+      maxCount: 1,
+      ...(from.options ?? {}),
+    });
+
+    for await (const resolvedEvent of stream) {
+      const message = mapFromESDBEvent(resolvedEvent, from);
+      const checkpoint = getCheckpoint(message);
+
+      if (checkpoint === null) return undefined;
+
+      return {
+        checkpoint,
+        originalGlobalCheckpoint: asProcessorCheckpoint(
+          message.metadata.globalPosition,
+        ),
+      };
+    }
+
+    return undefined;
+  } catch (error) {
+    if (error instanceof StreamNotFoundError) return undefined;
+    throw error;
+  }
+};
+
+const readLastProjectionGlobalCheckpoint = async (
+  client: EventStoreDBClient,
+  from: EventStoreDBEventStoreConsumerType,
+): Promise<ProcessorCheckpoint | undefined> => {
+  const stream = client.readAll({
+    direction: BACKWARDS,
+    fromPosition: END,
+    resolveLinkTos: false,
+  });
+
+  for await (const resolvedEvent of stream) {
+    if (isSystemEvent(resolvedEvent)) continue;
+    if (!isEventInProjection(resolvedEvent, from.stream)) continue;
+
+    return (
+      getCheckpoint(
+        mapFromESDBEvent(resolvedEvent as ResolvedEvent, { stream: $all }),
+      ) ?? undefined
+    );
+  }
+
+  return undefined;
+};
+
+const waitForProjection = async (
+  client: EventStoreDBClient,
+  from: EventStoreDBEventStoreConsumerType,
+): Promise<ProcessorCheckpoint | undefined> =>
+  asyncRetry(async () => {
+    const lastProjectionGlobalCheckpoint =
+      await readLastProjectionGlobalCheckpoint(client, from);
+
+    if (lastProjectionGlobalCheckpoint === undefined) return undefined;
+
+    const projectionTail = await readLastProjectionStreamCheckpoint(
+      client,
+      from,
+    );
+
+    if (
+      projectionTail === undefined ||
+      projectionTail.originalGlobalCheckpoint === undefined ||
+      parseBigIntProcessorCheckpoint(projectionTail.originalGlobalCheckpoint) <
+        parseBigIntProcessorCheckpoint(lastProjectionGlobalCheckpoint)
+    )
+      throw new ProjectionStreamBehindError();
+
+    return projectionTail.checkpoint;
+  }, ProjectionStreamWaitOptions);
+
+/**
+ * Reads the checkpoint of the last committed message from the same logical stream
+ * the subscription consumes. Projection streams can lag behind writes, so they
+ * are retried until the standard EventStoreDB projection exposes the tail event.
+ */
+export const readLastCommittedMessageCheckpoint = async (
+  client: EventStoreDBClient,
+  from: EventStoreDBEventStoreConsumerType | undefined,
+): Promise<ProcessorCheckpoint | undefined> => {
+  if (from === undefined || from.stream === $all)
+    return readLastAllCheckpoint(client, from);
+
+  if (isProjectionStreamWithLinks(from)) return waitForProjection(client, from);
+
+  return readLastStreamCheckpoint(client, from);
+};

--- a/src/packages/emmett-esdb/src/eventStore/consumers/subscriptions/readLastCommittedMessageCheckpoint.unit.spec.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/subscriptions/readLastCommittedMessageCheckpoint.unit.spec.ts
@@ -1,0 +1,88 @@
+import {
+  assertEqual,
+  bigIntProcessorCheckpoint,
+} from '@event-driven-io/emmett';
+import type { EventStoreDBClient } from '@eventstore/db-client';
+import { describe, it } from 'vitest';
+import { readLastCommittedMessageCheckpoint } from './readLastCommittedMessageCheckpoint';
+
+void describe('readLastCommittedMessageCheckpoint', () => {
+  void it('reads regular $-prefixed named streams directly', async () => {
+    const streamName = '$custom-system-stream';
+    const expectedCheckpoint = bigIntProcessorCheckpoint(3n);
+    const client = {
+      readStream: asyncIterable([
+        {
+          event: {
+            id: 'event-id',
+            type: 'SomeEvent',
+            streamId: streamName,
+            revision: 3n,
+            data: {},
+            metadata: {},
+          },
+        },
+      ]),
+    } as unknown as EventStoreDBClient;
+
+    const checkpoint = await readLastCommittedMessageCheckpoint(client, {
+      stream: streamName,
+    });
+
+    assertEqual(checkpoint, expectedCheckpoint);
+  });
+
+  void it('waits for $et projection streams and returns the projection checkpoint', async () => {
+    const streamName = '$et-SomeEvent';
+    const expectedCheckpoint = bigIntProcessorCheckpoint(7n);
+    const client = {
+      readAll: asyncIterable([
+        {
+          event: {
+            id: 'original-event-id',
+            type: 'SomeEvent',
+            streamId: 'regular-stream',
+            revision: 3n,
+            position: { commit: 99n, prepare: 99n },
+            data: {},
+            metadata: {},
+          },
+        },
+      ]),
+      readStream: asyncIterable([
+        {
+          event: {
+            id: 'original-event-id',
+            type: 'SomeEvent',
+            streamId: 'regular-stream',
+            revision: 3n,
+            position: { commit: 99n, prepare: 99n },
+            data: {},
+            metadata: {},
+          },
+          link: {
+            id: 'link-event-id',
+            type: '$>',
+            streamId: streamName,
+            revision: 7n,
+            position: { commit: 101n, prepare: 101n },
+            data: {},
+            metadata: {},
+          },
+        },
+      ]),
+    } as unknown as EventStoreDBClient;
+
+    const checkpoint = await readLastCommittedMessageCheckpoint(client, {
+      stream: streamName,
+      options: { resolveLinkTos: true },
+    });
+
+    assertEqual(checkpoint, expectedCheckpoint);
+  });
+});
+
+const asyncIterable = <T>(items: T[]) =>
+  async function* (): AsyncIterable<T> {
+    yield* items;
+  };

--- a/src/packages/emmett-esdb/src/eventStore/consumers/subscriptions/readLastCommittedMessageCheckpoint.unit.spec.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/subscriptions/readLastCommittedMessageCheckpoint.unit.spec.ts
@@ -83,6 +83,7 @@ void describe('readLastCommittedMessageCheckpoint', () => {
 });
 
 const asyncIterable = <T>(items: T[]) =>
+  // eslint-disable-next-line @typescript-eslint/require-await
   async function* (): AsyncIterable<T> {
     yield* items;
   };

--- a/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.ts
+++ b/src/packages/emmett-esdb/src/eventStore/eventstoreDBEventStore.ts
@@ -376,6 +376,9 @@ export const mapFromESDBEvent = <MessageType extends AnyMessage = AnyMessage>(
   from?: EventStoreDBEventStoreConsumerType,
 ): RecordedMessage<MessageType, EventStoreDBReadEventMetadata> => {
   const event = resolvedEvent.event!;
+  const globalPosition =
+    event.position?.commit ?? resolvedEvent.link?.position?.commit;
+
   return <RecordedMessage<MessageType, EventStoreDBReadEventMetadata>>{
     type: event.type,
     data: event.data,
@@ -385,7 +388,9 @@ export const mapFromESDBEvent = <MessageType extends AnyMessage = AnyMessage>(
       eventId: event.id,
       streamName: event.streamId,
       streamPosition: event.revision,
-      globalPosition: bigIntProcessorCheckpoint(event.position!.commit),
+      ...(globalPosition !== undefined
+        ? { globalPosition: bigIntProcessorCheckpoint(globalPosition) }
+        : {}),
       checkpoint: bigIntProcessorCheckpoint(
         getESDBCheckpoint(resolvedEvent, from),
       ),

--- a/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBEventStoreConsumer.handling.int.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBEventStoreConsumer.handling.int.spec.ts
@@ -272,6 +272,82 @@ void describe('MongoDB event store started consumer', () => {
         }
       },
     );
+
+    void describe('startFrom END across processors in one consumer', () => {
+      void it(
+        'does not flood END processor when mixed with BEGINNING processor in one consumer',
+        withDeadline,
+        async () => {
+          // Given
+          const guestId = uuid();
+          const otherGuestId = uuid();
+          const streamName = `guestStay-${guestId}`;
+
+          const initialEvents: GuestStayEvent[] = [
+            { type: 'GuestCheckedIn', data: { guestId } },
+            { type: 'GuestCheckedOut', data: { guestId } },
+          ];
+          await eventStore.appendToStream(streamName, initialEvents);
+
+          const newEvents: GuestStayEvent[] = [
+            { type: 'GuestCheckedIn', data: { guestId: otherGuestId } },
+            { type: 'GuestCheckedOut', data: { guestId: otherGuestId } },
+          ];
+
+          const fromBeginning: GuestStayEvent[] = [];
+          const fromEnd: GuestStayEvent[] = [];
+          const compareCheckpoints = compareTwoMongoDBCheckpoints as (
+            a: ProcessorCheckpoint,
+            b: ProcessorCheckpoint,
+          ) => number;
+
+          // When
+          const consumer = mongoDBEventStoreConsumer({
+            connectionString,
+            clientOptions: { directConnection: true },
+            processors: [
+              inMemoryReactor<GuestStayEvent>({
+                processorId: uuid(),
+                startFrom: 'BEGINNING',
+                compareCheckpoints,
+                eachMessage: (event) => {
+                  if (event.metadata.streamName === streamName)
+                    fromBeginning.push(event);
+                },
+              }),
+              inMemoryReactor<GuestStayEvent>({
+                processorId: uuid(),
+                startFrom: 'END',
+                compareCheckpoints,
+                eachMessage: (event) => {
+                  if (event.metadata.streamName === streamName)
+                    fromEnd.push(event);
+                },
+              }),
+            ],
+          });
+
+          let consumerPromise: Promise<void> | undefined;
+          try {
+            consumerPromise = consumer.start();
+            await consumer.whenStarted();
+
+            await eventStore.appendToStream(streamName, newEvents);
+
+            await consumer.whenCaughtUp();
+
+            assertThatArray(fromBeginning).containsElementsMatching([
+              ...initialEvents,
+              ...newEvents,
+            ]);
+            assertThatArray(fromEnd).containsOnlyElementsMatching(newEvents);
+          } finally {
+            await consumer.close();
+            await consumerPromise;
+          }
+        },
+      );
+    });
   });
 });
 

--- a/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBEventStoreConsumer.handling.int.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBEventStoreConsumer.handling.int.spec.ts
@@ -216,57 +216,62 @@ void describe('MongoDB event store started consumer', () => {
       }
     });
 
-    void it(`PROBE whenProcessed after append`, withDeadline, async () => {
-      const guestId = uuid();
-      const streamName = `guestStay-${guestId}`;
-      const events: GuestStayEvent[] = [
-        { type: 'GuestCheckedIn', data: { guestId } },
-        { type: 'GuestCheckedOut', data: { guestId } },
-      ];
+    void it(
+      `resolves whenProcessed and whenCaughtUp for events appended after start`,
+      withDeadline,
+      async () => {
+        // Given
+        const guestId = uuid();
+        const streamName = `guestStay-${guestId}`;
+        const events: GuestStayEvent[] = [
+          { type: 'GuestCheckedIn', data: { guestId } },
+          { type: 'GuestCheckedOut', data: { guestId } },
+        ];
 
-      const result: GuestStayEvent[] = [];
-      let lastCheckpoint: string | undefined;
-      const reachedEnd = asyncAwaiter();
+        const result: GuestStayEvent[] = [];
+        let lastCheckpoint: ProcessorCheckpoint | undefined;
+        const reachedEnd = asyncAwaiter();
 
-      const consumer = mongoDBEventStoreConsumer({
-        connectionString,
-        clientOptions: { directConnection: true },
-        processors: [
-          inMemoryReactor<GuestStayEvent>({
-            processorId: uuid(),
-            compareCheckpoints: compareTwoMongoDBCheckpoints as (
-              a: ProcessorCheckpoint,
-              b: ProcessorCheckpoint,
-            ) => number,
-            eachMessage: (event) => {
-              if (event.metadata.streamName === streamName) {
+        // When
+        const consumer = mongoDBEventStoreConsumer({
+          connectionString,
+          clientOptions: { directConnection: true },
+          processors: [
+            inMemoryReactor<GuestStayEvent>({
+              processorId: uuid(),
+              compareCheckpoints: compareTwoMongoDBCheckpoints as (
+                a: ProcessorCheckpoint,
+                b: ProcessorCheckpoint,
+              ) => number,
+              eachMessage: (event) => {
+                if (event.metadata.streamName !== streamName) return;
                 result.push(event);
-                lastCheckpoint = event.metadata.checkpoint as string;
+                lastCheckpoint = event.metadata
+                  .checkpoint as ProcessorCheckpoint;
                 if (event.type === 'GuestCheckedOut') reachedEnd.resolve();
-              }
-            },
-          }),
-        ],
-      });
+              },
+            }),
+          ],
+        });
 
-      let consumerPromise: Promise<void> | undefined;
-      try {
-        consumerPromise = consumer.start();
-        await consumer.whenStarted();
+        let consumerPromise: Promise<void> | undefined;
+        try {
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-        await eventStore.appendToStream(streamName, events);
+          await eventStore.appendToStream(streamName, events);
 
-        await reachedEnd.wait;
-        console.log('PROBE lastCheckpoint', lastCheckpoint);
-        await consumer.whenProcessed(lastCheckpoint as never);
-        console.log('PROBE whenProcessed resolved');
+          await reachedEnd.wait;
+          await consumer.whenProcessed(lastCheckpoint!);
+          await consumer.whenCaughtUp();
 
-        assertThatArray(result).containsElementsMatching(events);
-      } finally {
-        await consumer.close();
-        await consumerPromise;
-      }
-    });
+          assertThatArray(result).containsElementsMatching(events);
+        } finally {
+          await consumer.close();
+          await consumerPromise;
+        }
+      },
+    );
   });
 });
 

--- a/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBEventStoreConsumer.handling.int.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBEventStoreConsumer.handling.int.spec.ts
@@ -1,10 +1,13 @@
 import {
   assertThatArray,
+  asyncAwaiter,
   delay,
   inMemoryReactor,
   type Closeable,
   type Event,
+  type ProcessorCheckpoint,
 } from '@event-driven-io/emmett';
+import { compareTwoMongoDBCheckpoints } from './subscriptions';
 import { getMongoDBStartedContainer } from '@event-driven-io/emmett-testcontainers';
 import type { StartedMongoDBContainer } from '@testcontainers/mongodb';
 import { v4 as uuid } from 'uuid';
@@ -213,436 +216,57 @@ void describe('MongoDB event store started consumer', () => {
       }
     });
 
-    // void it(
-    //   `handles ONLY events from stream AFTER provided global position`,
-    //   withDeadline,
-    //   async () => {
-    //     // Given
-    //     const guestId = uuid();
-    //     const otherGuestId = uuid();
-    //     const streamName = `guestStay-${guestId}`;
-
-    //     const initialEvents: GuestStayEvent[] = [
-    //       { type: 'GuestCheckedIn', data: { guestId } },
-    //       { type: 'GuestCheckedOut', data: { guestId } },
-    //     ];
-    //     const { nextExpectedStreamVersion: startPosition } =
-    //       await eventStore.appendToStream(streamName, initialEvents);
-
-    //     const events: GuestStayEvent[] = [
-    //       { type: 'GuestCheckedIn', data: { guestId: otherGuestId } },
-    //       { type: 'GuestCheckedOut', data: { guestId: otherGuestId } },
-    //     ];
-
-    //     const result: GuestStayEvent[] = [];
-    //     let stopAfterPosition: bigint | undefined = undefined;
-
-    //     // When
-    //     const consumer = mongoDBEventStoreConsumer({
-    //       connectionString,
-    //       from: { stream: streamName },
-    //     });
-    //     consumer.reactor<GuestStayEvent>({
-    //       processorId: uuid(),
-    //       startFrom: { lastCheckpoint: startPosition },
-    //       stopAfter: (event) =>
-    //         event.metadata.streamPosition === stopAfterPosition,
-    //       eachMessage: (event) => {
-    //         result.push(event);
-    //       },
-    //     });
-
-    //     try {
-    //       const consumerPromise = consumer.start();
-
-    //       const appendResult = await eventStore.appendToStream(
-    //         streamName,
-    //         events,
-    //       );
-    //       stopAfterPosition = appendResult.nextExpectedStreamVersion;
-
-    //       await consumerPromise;
-
-    //       assertThatArray(result).containsOnlyElementsMatching(events);
-    //     } finally {
-    //       await consumer.close();
-    //     }
-    //   },
-    // );
-
-    // void it(
-    //   `handles ONLY events from $all AFTER provided global position`,
-    //   withDeadline,
-    //   async () => {
-    //     // Given
-    //     const guestId = uuid();
-    //     const otherGuestId = uuid();
-    //     const streamName = `guestStay-${guestId}`;
-
-    //     const initialEvents: GuestStayEvent[] = [
-    //       { type: 'GuestCheckedIn', data: { guestId } },
-    //       { type: 'GuestCheckedOut', data: { guestId } },
-    //     ];
-    //     const { lastEventGlobalPosition: startPosition } =
-    //       await eventStore.appendToStream(streamName, initialEvents);
-
-    //     const events: GuestStayEvent[] = [
-    //       { type: 'GuestCheckedIn', data: { guestId: otherGuestId } },
-    //       { type: 'GuestCheckedOut', data: { guestId: otherGuestId } },
-    //     ];
-
-    //     const result: GuestStayEvent[] = [];
-    //     let stopAfterPosition: bigint | undefined = undefined;
-
-    //     // When
-    //     const consumer = mongoDBEventStoreConsumer({
-    //       connectionString,
-    //       from: { stream: $all },
-    //     });
-    //     consumer.reactor<GuestStayEvent>({
-    //       processorId: uuid(),
-    //       startFrom: { lastCheckpoint: startPosition },
-    //       stopAfter: (event) =>
-    //         event.metadata.globalPosition === stopAfterPosition,
-    //       eachMessage: (event) => {
-    //         result.push(event);
-    //       },
-    //     });
-
-    //     try {
-    //       const consumerPromise = consumer.start();
-
-    //       const appendResult = await eventStore.appendToStream(
-    //         streamName,
-    //         events,
-    //       );
-    //       stopAfterPosition = appendResult.lastEventGlobalPosition;
-
-    //       await consumerPromise;
-
-    //       assertThatArray(result).containsOnlyElementsMatching(events);
-    //     } finally {
-    //       await consumer.close();
-    //     }
-    //   },
-    // );
-
-    // consumeFrom.forEach(([displayName, from]) => {
-    //   void it(
-    //     `handles all events from ${displayName} appended to event store BEFORE processor was started`,
-    //     withDeadline,
-    //     async () => {
-    //       // Given
-    //       const guestId = uuid();
-    //       const streamName = `guestStay-${guestId}`;
-    //       const events: GuestStayEvent[] = [
-    //         { type: 'GuestCheckedIn', data: { guestId } },
-    //         { type: 'GuestCheckedOut', data: { guestId } },
-    //       ];
-    //       const appendResult = await eventStore.appendToStream(
-    //         streamName,
-    //         events,
-    //       );
-
-    //       const result: GuestStayEvent[] = [];
-
-    //       // When
-    //       const consumer = mongoDBEventStoreConsumer({
-    //         connectionString,
-    //         from: from(streamName),
-    //       });
-    //       consumer.reactor<GuestStayEvent>({
-    //         processorId: uuid(),
-    //         stopAfter: (event) =>
-    //           event.metadata.globalPosition ===
-    //           appendResult.lastEventGlobalPosition,
-    //         eachMessage: (event) => {
-    //           result.push(event);
-    //         },
-    //       });
-
-    //       try {
-    //         await consumer.start();
-
-    //         assertThatArray(result).containsElementsMatching(events);
-    //       } finally {
-    //         await consumer.close();
-    //       }
-    //     },
-    //   );
-
-    //   void it(
-    //     `handles all events from ${displayName} appended to event store AFTER processor was started`,
-    //     withDeadline,
-    //     async () => {
-    //       // Given
-
-    //       const result: GuestStayEvent[] = [];
-    //       let stopAfterPosition: bigint | undefined = undefined;
-
-    //       const guestId = uuid();
-    //       const streamName = `guestStay-${guestId}`;
-    //       const waitForStart = asyncAwaiter();
-
-    //       // When
-    //       const consumer = mongoDBEventStoreConsumer({
-    //         connectionString,
-    //         from: from(streamName),
-    //       });
-    //       consumer.reactor<GuestStayEvent>({
-    //         processorId: uuid(),
-    //         stopAfter: (event) =>
-    //           event.metadata.globalPosition === stopAfterPosition,
-    //         eachMessage: async (event) => {
-    //           await waitForStart.wait;
-    //           result.push(event);
-    //         },
-    //       });
-
-    //       const events: GuestStayEvent[] = [
-    //         { type: 'GuestCheckedIn', data: { guestId } },
-    //         { type: 'GuestCheckedOut', data: { guestId } },
-    //       ];
-
-    //       try {
-    //         const consumerPromise = consumer.start();
-
-    //         const appendResult = await eventStore.appendToStream(
-    //           streamName,
-    //           events,
-    //         );
-    //         stopAfterPosition = appendResult.lastEventGlobalPosition;
-    //         waitForStart.resolve();
-
-    //         await consumerPromise;
-
-    //         assertThatArray(result).containsElementsMatching(events);
-    //       } finally {
-    //         await consumer.close();
-    //       }
-    //     },
-    //   );
-
-    //   void it(
-    //     `handles all events from ${displayName} when CURRENT position is NOT stored`,
-    //     withDeadline,
-    //     async () => {
-    //       // Given
-    //       const guestId = uuid();
-    //       const otherGuestId = uuid();
-    //       const streamName = `guestStay-${guestId}`;
-
-    //       const initialEvents: GuestStayEvent[] = [
-    //         { type: 'GuestCheckedIn', data: { guestId } },
-    //         { type: 'GuestCheckedOut', data: { guestId } },
-    //       ];
-
-    //       await eventStore.appendToStream(streamName, initialEvents);
-
-    //       const events: GuestStayEvent[] = [
-    //         { type: 'GuestCheckedIn', data: { guestId: otherGuestId } },
-    //         { type: 'GuestCheckedOut', data: { guestId: otherGuestId } },
-    //       ];
-
-    //       const result: GuestStayEvent[] = [];
-    //       let stopAfterPosition: bigint | undefined = undefined;
-    //       const waitForStart = asyncAwaiter();
-
-    //       // When
-    //       const consumer = mongoDBEventStoreConsumer({
-    //         connectionString,
-    //         from: from(streamName),
-    //       });
-    //       consumer.reactor<GuestStayEvent>({
-    //         processorId: uuid(),
-    //         startFrom: 'CURRENT',
-    //         stopAfter: (event) =>
-    //           event.metadata.globalPosition === stopAfterPosition,
-    //         eachMessage: async (event) => {
-    //           await waitForStart.wait;
-    //           result.push(event);
-    //         },
-    //       });
-
-    //       try {
-    //         const consumerPromise = consumer.start();
-
-    //         const appendResult = await eventStore.appendToStream(
-    //           streamName,
-    //           events,
-    //         );
-    //         stopAfterPosition = appendResult.lastEventGlobalPosition;
-    //         waitForStart.resolve();
-
-    //         await consumerPromise;
-
-    //         assertThatArray(result).containsElementsMatching([
-    //           ...initialEvents,
-    //           ...events,
-    //         ]);
-    //       } finally {
-    //         await consumer.close();
-    //       }
-    //     },
-    //   );
-
-    //   void it(
-    //     `handles only new events when CURRENT position is stored for restarted consumer from ${displayName}`,
-    //     withDeadline,
-    //     async () => {
-    //       // Given
-    //       const guestId = uuid();
-    //       const otherGuestId = uuid();
-    //       const streamName = `guestStay-${guestId}`;
-
-    //       const initialEvents: GuestStayEvent[] = [
-    //         { type: 'GuestCheckedIn', data: { guestId } },
-    //         { type: 'GuestCheckedOut', data: { guestId } },
-    //       ];
-    //       const { lastEventGlobalPosition } = await eventStore.appendToStream(
-    //         streamName,
-    //         initialEvents,
-    //       );
-
-    //       const events: GuestStayEvent[] = [
-    //         { type: 'GuestCheckedIn', data: { guestId: otherGuestId } },
-    //         { type: 'GuestCheckedOut', data: { guestId: otherGuestId } },
-    //       ];
-
-    //       let result: GuestStayEvent[] = [];
-    //       let stopAfterPosition: bigint | undefined = lastEventGlobalPosition;
-
-    //       const waitForStart = asyncAwaiter();
-
-    //       // When
-    //       const consumer = mongoDBEventStoreConsumer({
-    //         connectionString,
-    //         from: from(streamName),
-    //       });
-    //       consumer.reactor<GuestStayEvent>({
-    //         processorId: uuid(),
-    //         startFrom: 'CURRENT',
-    //         stopAfter: (event) =>
-    //           event.metadata.globalPosition === stopAfterPosition,
-    //         eachMessage: async (event) => {
-    //           await waitForStart.wait;
-    //           result.push(event);
-    //         },
-    //       });
-
-    //       let consumerPromise = consumer.start();
-    //       waitForStart.resolve();
-    //       await consumerPromise;
-    //       await consumer.stop();
-
-    //       waitForStart.reset();
-
-    //       result = [];
-
-    //       stopAfterPosition = undefined;
-
-    //       try {
-    //         consumerPromise = consumer.start();
-
-    //         const appendResult = await eventStore.appendToStream(
-    //           streamName,
-    //           events,
-    //         );
-    //         stopAfterPosition = appendResult.lastEventGlobalPosition;
-    //         waitForStart.resolve();
-
-    //         await consumerPromise;
-
-    //         assertThatArray(result).containsOnlyElementsMatching(events);
-    //       } finally {
-    //         await consumer.close();
-    //       }
-    //     },
-    //   );
-
-    //   void it(
-    //     `handles only new events when CURRENT position is stored for a new consumer from ${displayName}`,
-    //     withDeadline,
-    //     async () => {
-    //       // Given
-    //       const guestId = uuid();
-    //       const otherGuestId = uuid();
-    //       const streamName = `guestStay-${guestId}`;
-
-    //       const initialEvents: GuestStayEvent[] = [
-    //         { type: 'GuestCheckedIn', data: { guestId } },
-    //         { type: 'GuestCheckedOut', data: { guestId } },
-    //       ];
-    //       const { lastEventGlobalPosition } = await eventStore.appendToStream(
-    //         streamName,
-    //         initialEvents,
-    //       );
-
-    //       const events: GuestStayEvent[] = [
-    //         { type: 'GuestCheckedIn', data: { guestId: otherGuestId } },
-    //         { type: 'GuestCheckedOut', data: { guestId: otherGuestId } },
-    //       ];
-
-    //       let result: GuestStayEvent[] = [];
-    //       let stopAfterPosition: bigint | undefined = lastEventGlobalPosition;
-
-    //       const waitForStart = asyncAwaiter();
-    //       const processorOptions: InMemoryReactorOptions<GuestStayEvent> = {
-    //         processorId: uuid(),
-    //         startFrom: 'CURRENT',
-    //         stopAfter: (event) =>
-    //           event.metadata.globalPosition === stopAfterPosition,
-    //         eachMessage: async (event) => {
-    //           await waitForStart.wait;
-    //           result.push(event);
-    //         },
-    //         connectionOptions: { database },
-    //       };
-
-    //       // When
-    //       const consumer = mongoDBEventStoreConsumer({
-    //         connectionString,
-    //         from: from(streamName),
-    //       });
-    //       try {
-    //         consumer.reactor<GuestStayEvent>(processorOptions);
-
-    //         waitForStart.resolve();
-    //         await consumer.start();
-    //       } finally {
-    //         await consumer.close();
-    //       }
-
-    //       result = [];
-
-    //       waitForStart.reset();
-    //       stopAfterPosition = undefined;
-
-    //       const newConsumer = mongoDBEventStoreConsumer({
-    //         connectionString,
-    //         from: from(streamName),
-    //       });
-    //       newConsumer.reactor<GuestStayEvent>(processorOptions);
-
-    //       try {
-    //         const consumerPromise = newConsumer.start();
-
-    //         const appendResult = await eventStore.appendToStream(
-    //           streamName,
-    //           events,
-    //         );
-    //         waitForStart.resolve();
-    //         stopAfterPosition = appendResult.lastEventGlobalPosition;
-
-    //         await consumerPromise;
-
-    //         assertThatArray(result).containsOnlyElementsMatching(events);
-    //       } finally {
-    //         await newConsumer.close();
-    //       }
-    //     },
-    //   );
-    // });
+    void it(`PROBE whenProcessed after append`, withDeadline, async () => {
+      const guestId = uuid();
+      const streamName = `guestStay-${guestId}`;
+      const events: GuestStayEvent[] = [
+        { type: 'GuestCheckedIn', data: { guestId } },
+        { type: 'GuestCheckedOut', data: { guestId } },
+      ];
+
+      const result: GuestStayEvent[] = [];
+      let lastCheckpoint: string | undefined;
+      const reachedEnd = asyncAwaiter();
+
+      const consumer = mongoDBEventStoreConsumer({
+        connectionString,
+        clientOptions: { directConnection: true },
+        processors: [
+          inMemoryReactor<GuestStayEvent>({
+            processorId: uuid(),
+            compareCheckpoints: compareTwoMongoDBCheckpoints as (
+              a: ProcessorCheckpoint,
+              b: ProcessorCheckpoint,
+            ) => number,
+            eachMessage: (event) => {
+              if (event.metadata.streamName === streamName) {
+                result.push(event);
+                lastCheckpoint = event.metadata.checkpoint as string;
+                if (event.type === 'GuestCheckedOut') reachedEnd.resolve();
+              }
+            },
+          }),
+        ],
+      });
+
+      let consumerPromise: Promise<void> | undefined;
+      try {
+        consumerPromise = consumer.start();
+        await consumer.whenStarted();
+
+        await eventStore.appendToStream(streamName, events);
+
+        await reachedEnd.wait;
+        console.log('PROBE lastCheckpoint', lastCheckpoint);
+        await consumer.whenProcessed(lastCheckpoint as never);
+        console.log('PROBE whenProcessed resolved');
+
+        assertThatArray(result).containsElementsMatching(events);
+      } finally {
+        await consumer.close();
+        await consumerPromise;
+      }
+    });
   });
 });
 

--- a/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBEventStoreConsumer.inMemory.projections.int.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBEventStoreConsumer.inMemory.projections.int.spec.ts
@@ -1,10 +1,13 @@
 import {
   assertMatches,
+  asyncAwaiter,
   getInMemoryDatabase,
   inMemoryProjector,
+  inMemoryReactor,
   inMemorySingleStreamProjection,
   type Closeable,
   type InMemoryDocumentsCollection,
+  type ProcessorCheckpoint,
   type ReadEvent,
 } from '@event-driven-io/emmett';
 import type { StartedMongoDBContainer } from '@testcontainers/mongodb';
@@ -20,10 +23,20 @@ import {
 } from '../mongoDBEventStore';
 import { mongoDBEventStoreConsumer } from './mongoDBEventStoreConsumer';
 import { getMongoDBStartedContainer } from '@event-driven-io/emmett-testcontainers';
+import { compareTwoMongoDBCheckpoints } from './subscriptions';
 
 const withDeadline = { timeout: 30000 };
 
-void describe.skip('mongoDB event store started consumer', () => {
+/**
+ * MongoDB checkpoints are resume tokens, not lexicographically ordered values,
+ * so processors must compare them via the MongoDB-specific comparator.
+ */
+const compareCheckpoints = compareTwoMongoDBCheckpoints as (
+  a: ProcessorCheckpoint,
+  b: ProcessorCheckpoint,
+) => number;
+
+void describe('mongoDB event store started consumer', () => {
   let mongoDB: StartedMongoDBContainer;
   let connectionString: string;
   let eventStore: MongoDBEventStore & Closeable;
@@ -72,6 +85,7 @@ void describe.skip('mongoDB event store started consumer', () => {
           processorId: uuid(),
           projection: shoppingCartsSummaryProjection,
           connectionOptions: { database },
+          compareCheckpoints,
           stopAfter: (event) =>
             event.metadata.streamName === streamName &&
             event.metadata.streamPosition ===
@@ -93,8 +107,6 @@ void describe.skip('mongoDB event store started consumer', () => {
           assertMatches(summary, {
             _id: streamName,
             status: 'confirmed',
-            // TODO: ensure that _version and _id works like in Pongo
-            //_version: 2n,
             productItemsCount: productItem.quantity,
           });
         } finally {
@@ -110,15 +122,12 @@ void describe.skip('mongoDB event store started consumer', () => {
         // Given
         const shoppingCartId = `shoppingCart:${uuid()}`;
         const streamName = `shopping_cart-${shoppingCartId}`;
-        let stopAfterPosition: bigint | undefined = undefined;
 
         const inMemoryProcessor = inMemoryProjector<ShoppingCartSummaryEvent>({
           processorId: uuid(),
           projection: shoppingCartsSummaryProjection,
           connectionOptions: { database },
-          stopAfter: (event) =>
-            event.metadata.streamName === streamName &&
-            event.metadata.streamPosition === stopAfterPosition,
+          compareCheckpoints,
         });
         const consumer = mongoDBEventStoreConsumer<ShoppingCartSummaryEvent>({
           connectionString,
@@ -126,144 +135,124 @@ void describe.skip('mongoDB event store started consumer', () => {
           processors: [inMemoryProcessor],
         });
 
-        // When
         const events: ShoppingCartSummaryEvent[] = [
-          {
-            type: 'ProductItemAdded',
-            data: {
-              productItem,
-            },
-          },
-          {
-            type: 'ShoppingCartConfirmed',
-            data: { confirmedAt },
-          },
+          { type: 'ProductItemAdded', data: { productItem } },
+          { type: 'ShoppingCartConfirmed', data: { confirmedAt } },
         ];
 
+        // When
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.nextExpectedStreamVersion;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await consumer.whenCaughtUp();
 
           const summary = await summaries.findOne((d) => d._id === streamName);
 
           assertMatches(summary, {
             _id: streamName,
             status: 'confirmed',
-            //_version: 2n,
             productItemsCount: productItem.quantity,
           });
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
 
-    // void it(
-    //   'handles ONLY events AFTER provided global position',
-    //   withDeadline,
-    //   async () => {
-    //     // Given
-    //     const shoppingCartId = `shoppingCart:${uuid()}`;
-    //     const streamName = `shopping_cart-${shoppingCartId}`;
+    void it(
+      'handles ONLY events AFTER provided checkpoint',
+      withDeadline,
+      async () => {
+        // Given
+        const shoppingCartId = `shoppingCart:${uuid()}`;
+        const streamName = `shopping_cart-${shoppingCartId}`;
 
-    //     const initialEvents: ShoppingCartSummaryEvent[] = [
-    //       { type: 'ProductItemAdded', data: { productItem } },
-    //       { type: 'ProductItemAdded', data: { productItem } },
-    //     ];
-    //     const { nextExpectedStreamVersion } = await eventStore.appendToStream(
-    //       streamName,
-    //       initialEvents,
-    //     );
+        const initialEvents: ShoppingCartSummaryEvent[] = [
+          { type: 'ProductItemAdded', data: { productItem } },
+          { type: 'ProductItemAdded', data: { productItem } },
+        ];
+        await eventStore.appendToStream(streamName, initialEvents);
 
-    //     const events: ShoppingCartSummaryEvent[] = [
-    //       { type: 'ProductItemAdded', data: { productItem } },
-    //       {
-    //         type: 'ShoppingCartConfirmed',
-    //         data: { confirmedAt },
-    //       },
-    //     ];
+        // Capture the checkpoint of the last initial event without projecting it,
+        // as MongoDB checkpoints are resume tokens that cannot be synthesised.
+        let startCheckpoint: ProcessorCheckpoint | undefined;
+        let seen = 0;
+        const captured = asyncAwaiter();
+        const capturingConsumer = mongoDBEventStoreConsumer({
+          connectionString,
+          clientOptions: { directConnection: true },
+          processors: [
+            inMemoryReactor<ShoppingCartSummaryEvent>({
+              processorId: uuid(),
+              compareCheckpoints,
+              eachMessage: (event) => {
+                if (event.metadata.streamName !== streamName) return;
+                startCheckpoint = event.metadata
+                  .checkpoint as ProcessorCheckpoint;
+                if (++seen === initialEvents.length) captured.resolve();
+              },
+            }),
+          ],
+        });
 
-    //     let stopAfterPosition: bigint | undefined = nextExpectedStreamVersion;
-    //     let checkpoint: MongoDBCheckpoint | null | undefined = undefined;
+        let capturingPromise: Promise<void> | undefined;
+        try {
+          capturingPromise = capturingConsumer.start();
+          await capturingConsumer.whenStarted();
+          await captured.wait;
+        } finally {
+          await capturingConsumer.close();
+          await capturingPromise;
+        }
 
-    //     const projectorOptions: InMemoryProjectorOptions<ShoppingCartSummaryEvent> =
-    //       {
-    //         processorId: uuid(),
-    //         projection: shoppingCartsSummaryProjection,
-    //         connectionOptions: { database },
-    //         stopAfter: (event) => {
-    //           checkpoint = getCheckpoint(event);
-    //           return (
-    //             event.metadata.streamName === streamName &&
-    //             event.metadata.streamPosition === stopAfterPosition
-    //           );
-    //         },
-    //       };
+        const events: ShoppingCartSummaryEvent[] = [
+          { type: 'ProductItemAdded', data: { productItem } },
+          { type: 'ShoppingCartConfirmed', data: { confirmedAt } },
+        ];
 
-    //     let eartlierConsumer: MongoDBEventStoreConsumer<ShoppingCartSummaryEvent> =
-    //       undefined!;
+        // When
+        const inMemoryProcessor = inMemoryProjector<ShoppingCartSummaryEvent>({
+          processorId: uuid(),
+          projection: shoppingCartsSummaryProjection,
+          connectionOptions: { database },
+          compareCheckpoints,
+          startFrom: {
+            lastCheckpoint: startCheckpoint as ProcessorCheckpoint,
+          },
+        });
+        const consumer = mongoDBEventStoreConsumer<ShoppingCartSummaryEvent>({
+          connectionString,
+          clientOptions: { directConnection: true },
+          processors: [inMemoryProcessor],
+        });
 
-    //     try {
-    //       eartlierConsumer =
-    //         mongoDBEventStoreConsumer<ShoppingCartSummaryEvent>({
-    //           connectionString,
-    //           clientOptions: { directConnection: true },
-    //           processors: [
-    //             inMemoryProjector<ShoppingCartSummaryEvent>(projectorOptions),
-    //           ],
-    //         });
+        let consumerPromise: Promise<void> | undefined;
+        try {
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-    //       await eartlierConsumer.start();
-    //     } finally {
-    //       await eartlierConsumer.close();
-    //     }
+          await eventStore.appendToStream(streamName, events);
 
-    //     // When
-    //     let consumer: MongoDBEventStoreConsumer<ShoppingCartSummaryEvent> =
-    //       undefined!;
+          await consumer.whenCaughtUp();
 
-    //     try {
-    //       consumer = mongoDBEventStoreConsumer<ShoppingCartSummaryEvent>({
-    //         connectionString,
-    //         clientOptions: { directConnection: true },
-    //         processors: [
-    //           inMemoryProjector<ShoppingCartSummaryEvent>({
-    //             ...projectorOptions,
-    //             startFrom: checkpoint,
-    //           }),
-    //         ],
-    //       });
-    //       stopAfterPosition = undefined;
-    //       const consumerPromise = consumer.start();
+          const summary = await summaries.findOne((d) => d._id === streamName);
 
-    //       const appendResult = await eventStore.appendToStream(
-    //         streamName,
-    //         events,
-    //       );
-    //       stopAfterPosition = appendResult.nextExpectedStreamVersion;
-
-    //       await consumerPromise;
-
-    //       const summary = await summaries.findOne((d) => d._id === streamName);
-
-    //       assertMatches(summary, {
-    //         _id: streamName,
-    //         status: 'confirmed',
-    //         _version: 3n,
-    //         productItemsCount: productItem.quantity,
-    //       });
-    //     } finally {
-    //       await consumer.close();
-    //     }
-    //   },
-    // );
+          assertMatches(summary, {
+            _id: streamName,
+            status: 'confirmed',
+            productItemsCount: productItem.quantity,
+          });
+        } finally {
+          await consumer.close();
+          await consumerPromise;
+        }
+      },
+    );
 
     void it(
       'handles all events when CURRENT position is NOT stored',
@@ -282,22 +271,15 @@ void describe.skip('mongoDB event store started consumer', () => {
 
         const events: ShoppingCartSummaryEvent[] = [
           { type: 'ProductItemAdded', data: { productItem } },
-          {
-            type: 'ShoppingCartConfirmed',
-            data: { confirmedAt },
-          },
+          { type: 'ShoppingCartConfirmed', data: { confirmedAt } },
         ];
-
-        let stopAfterPosition: bigint | undefined = undefined;
 
         const inMemoryProcessor = inMemoryProjector<ShoppingCartSummaryEvent>({
           processorId: uuid(),
           projection: shoppingCartsSummaryProjection,
           connectionOptions: { database },
+          compareCheckpoints,
           startFrom: 'CURRENT',
-          stopAfter: (event) =>
-            event.metadata.streamName === streamName &&
-            event.metadata.streamPosition === stopAfterPosition,
         });
 
         const consumer = mongoDBEventStoreConsumer<ShoppingCartSummaryEvent>({
@@ -307,28 +289,25 @@ void describe.skip('mongoDB event store started consumer', () => {
         });
 
         // When
-
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.nextExpectedStreamVersion;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await consumer.whenCaughtUp();
 
           const summary = await summaries.findOne((d) => d._id === streamName);
 
           assertMatches(summary, {
             _id: streamName,
             status: 'confirmed',
-            // _version: 4n,
             productItemsCount: productItem.quantity * 3,
           });
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -345,29 +324,23 @@ void describe.skip('mongoDB event store started consumer', () => {
           { type: 'ProductItemAdded', data: { productItem } },
           { type: 'ProductItemAdded', data: { productItem } },
         ];
-        const { nextExpectedStreamVersion } = await eventStore.appendToStream(
-          streamName,
-          initialEvents,
-        );
+        const { nextExpectedStreamVersion: startPosition } =
+          await eventStore.appendToStream(streamName, initialEvents);
 
         const events: ShoppingCartSummaryEvent[] = [
           { type: 'ProductItemAdded', data: { productItem } },
-          {
-            type: 'ShoppingCartConfirmed',
-            data: { confirmedAt },
-          },
+          { type: 'ShoppingCartConfirmed', data: { confirmedAt } },
         ];
-
-        let stopAfterPosition: bigint | undefined = nextExpectedStreamVersion;
 
         const inMemoryProcessor = inMemoryProjector<ShoppingCartSummaryEvent>({
           processorId: uuid(),
           projection: shoppingCartsSummaryProjection,
           connectionOptions: { database },
+          compareCheckpoints,
           startFrom: 'CURRENT',
           stopAfter: (event) =>
             event.metadata.streamName === streamName &&
-            event.metadata.streamPosition === stopAfterPosition,
+            event.metadata.streamPosition === startPosition,
         });
 
         const consumer = mongoDBEventStoreConsumer<ShoppingCartSummaryEvent>({
@@ -380,116 +353,111 @@ void describe.skip('mongoDB event store started consumer', () => {
         await consumer.start();
         await consumer.stop();
 
-        stopAfterPosition = undefined;
-
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.nextExpectedStreamVersion;
-          console.log('stopAfterPosition', stopAfterPosition);
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-          const consumerPromise = consumer.start();
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await consumer.whenCaughtUp();
 
           const summary = await summaries.findOne((d) => d._id === streamName);
 
           assertMatches(summary, {
             _id: streamName,
             status: 'confirmed',
-            //_version: 4n,
             productItemsCount: productItem.quantity * 3,
           });
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
 
-    // void it(
-    //   'handles only new events when CURRENT position is stored for a new consumer',
-    //   withDeadline,
-    //   async () => {
-    //     // Given
-    //     const shoppingCartId = `shoppingCart:${uuid()}`;
-    //     const streamName = `shopping_cart-${shoppingCartId}`;
+    void it(
+      'handles only new events when CURRENT position is stored for a new consumer',
+      withDeadline,
+      async () => {
+        // Given
+        const shoppingCartId = `shoppingCart:${uuid()}`;
+        const streamName = `shopping_cart-${shoppingCartId}`;
 
-    //     const initialEvents: ShoppingCartSummaryEvent[] = [
-    //       { type: 'ProductItemAdded', data: { productItem } },
-    //       { type: 'ProductItemAdded', data: { productItem } },
-    //     ];
-    //     const { nextExpectedStreamVersion } = await eventStore.appendToStream(
-    //       streamName,
-    //       initialEvents,
-    //     );
+        const initialEvents: ShoppingCartSummaryEvent[] = [
+          { type: 'ProductItemAdded', data: { productItem } },
+          { type: 'ProductItemAdded', data: { productItem } },
+        ];
+        const { nextExpectedStreamVersion: startPosition } =
+          await eventStore.appendToStream(streamName, initialEvents);
 
-    //     const events: ShoppingCartSummaryEvent[] = [
-    //       { type: 'ProductItemAdded', data: { productItem } },
-    //       {
-    //         type: 'ShoppingCartConfirmed',
-    //         data: { confirmedAt },
-    //       },
-    //     ];
+        const events: ShoppingCartSummaryEvent[] = [
+          { type: 'ProductItemAdded', data: { productItem } },
+          { type: 'ShoppingCartConfirmed', data: { confirmedAt } },
+        ];
 
-    //     let stopAfterPosition: bigint | undefined = nextExpectedStreamVersion;
+        const processorId = uuid();
+        const inMemoryProcessor = inMemoryProjector<ShoppingCartSummaryEvent>({
+          processorId,
+          projection: shoppingCartsSummaryProjection,
+          connectionOptions: { database },
+          compareCheckpoints,
+          startFrom: 'CURRENT',
+          stopAfter: (event) =>
+            event.metadata.streamName === streamName &&
+            event.metadata.streamPosition === startPosition,
+        });
 
-    //     const inMemoryProcessor = inMemoryProjector<ShoppingCartSummaryEvent>({
-    //       processorId: uuid(),
-    //       projection: shoppingCartsSummaryProjection,
-    //       connectionOptions: { database },
-    //       startFrom: 'CURRENT',
-    //       stopAfter: (event) =>
-    //         event.metadata.streamName === streamName &&
-    //         event.metadata.streamPosition === stopAfterPosition,
-    //     });
+        // When
+        const consumer = mongoDBEventStoreConsumer<ShoppingCartSummaryEvent>({
+          connectionString,
+          clientOptions: { directConnection: true },
+          processors: [inMemoryProcessor],
+        });
+        try {
+          await consumer.start();
+        } finally {
+          await consumer.close();
+        }
 
-    //     const consumer = mongoDBEventStoreConsumer<ShoppingCartSummaryEvent>({
-    //       connectionString,
-    //       clientOptions: { directConnection: true },
-    //       processors: [inMemoryProcessor],
-    //     });
+        const newInMemoryProcessor =
+          inMemoryProjector<ShoppingCartSummaryEvent>({
+            processorId,
+            projection: shoppingCartsSummaryProjection,
+            connectionOptions: { database },
+            compareCheckpoints,
+            startFrom: 'CURRENT',
+          });
+        const newConsumer = mongoDBEventStoreConsumer<ShoppingCartSummaryEvent>(
+          {
+            connectionString,
+            clientOptions: { directConnection: true },
+            processors: [newInMemoryProcessor],
+          },
+        );
 
-    //     // When
-    //     try {
-    //       await consumer.start();
-    //     } finally {
-    //       await consumer.close();
-    //     }
+        let consumerPromise: Promise<void> | undefined;
+        try {
+          consumerPromise = newConsumer.start();
+          await newConsumer.whenStarted();
 
-    //     stopAfterPosition = undefined;
+          await eventStore.appendToStream(streamName, events);
 
-    //     const newConsumer = mongoDBEventStoreConsumer({
-    //       connectionString,
-    //       clientOptions: { directConnection: true },
-    //       processors: [inMemoryProcessor],
-    //     });
+          await newConsumer.whenCaughtUp();
 
-    //     try {
-    //       const consumerPromise = newConsumer.start();
+          const summary = await summaries.findOne((d) => d._id === streamName);
 
-    //       const appendResult = await eventStore.appendToStream(
-    //         streamName,
-    //         events,
-    //       );
-    //       stopAfterPosition = appendResult.nextExpectedStreamVersion;
-
-    //       await consumerPromise;
-
-    //       const summary = await summaries.findOne((d) => d._id === streamName);
-
-    //       assertMatches(summary, {
-    //         _id: streamName,
-    //         status: 'confirmed',
-    //         //_version: 4n,
-    //         productItemsCount: productItem.quantity * 3,
-    //       });
-    //     } finally {
-    //       await newConsumer.close();
-    //     }
-    //   },
-    // );
+          assertMatches(summary, {
+            _id: streamName,
+            status: 'confirmed',
+            productItemsCount: productItem.quantity * 3,
+          });
+        } finally {
+          await newConsumer.close();
+          await consumerPromise;
+        }
+      },
+    );
   });
 });
 

--- a/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBEventStoreConsumer.int.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBEventStoreConsumer.int.spec.ts
@@ -36,6 +36,7 @@ void describe('mongoDB event store consumer', () => {
     start: () => Promise.resolve('BEGINNING'),
     close: () => Promise.resolve(),
     handle: () => Promise.resolve(),
+    whenProcessed: () => Promise.resolve(),
     isActive: false,
   };
 

--- a/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBEventStoreConsumer.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBEventStoreConsumer.ts
@@ -29,16 +29,11 @@ import {
   type MongoDBProjectorOptions,
 } from './mongoDBProcessor';
 import {
-  getDatabaseVersionPolicies,
   mongoDBSubscription,
-  subscribe,
+  readLastCommittedMessageCheckpoint,
   zipMongoDBMessageBatchPullerStartFrom,
   type MongoDBSubscription,
 } from './subscriptions';
-import {
-  toMongoDBCheckpoint,
-  type MongoDBResumeToken,
-} from './subscriptions/mongoDBCheckpoint';
 
 export type MongoDBChangeStreamMessageMetadata =
   RecordedMessageMetadataWithoutGlobalPosition;
@@ -195,28 +190,11 @@ export const mongoDBEventStoreConsumer = <
         processors.map((p) => p.whenProcessed(position, options)),
       ).then(() => undefined),
     whenCaughtUp: async (options): Promise<void> => {
-      const db = client.db();
+      const tail = await readLastCommittedMessageCheckpoint(client.db());
 
-      const { changeStreamFullDocumentValuePolicy } =
-        await getDatabaseVersionPolicies(db);
+      if (tail === undefined) return;
 
-      const cs = subscribe(changeStreamFullDocumentValuePolicy, db)('END');
-
-      try {
-        await cs.tryNext();
-
-        const resumeToken = cs.resumeToken as MongoDBResumeToken | undefined;
-
-        if (resumeToken === undefined || resumeToken === null) return;
-
-        const tailCheckpoint = toMongoDBCheckpoint(resumeToken, 0);
-
-        await Promise.all(
-          processors.map((p) => p.whenProcessed(tailCheckpoint, options)),
-        );
-      } finally {
-        await cs.close();
-      }
+      await Promise.all(processors.map((p) => p.whenProcessed(tail, options)));
     },
     processors,
     reactor: <MessageType extends AnyMessage = ConsumerMessageType>(

--- a/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBEventStoreConsumer.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBEventStoreConsumer.ts
@@ -16,6 +16,8 @@ import {
   type Message,
   type MessageConsumer,
   type MessageConsumerOptions,
+  type ProcessorCheckpoint,
+  type WaitOptions,
 } from '@event-driven-io/emmett';
 import { MongoClient, type MongoClientOptions } from 'mongodb';
 import { v4 as uuid } from 'uuid';
@@ -27,10 +29,16 @@ import {
   type MongoDBProjectorOptions,
 } from './mongoDBProcessor';
 import {
+  getDatabaseVersionPolicies,
   mongoDBSubscription,
+  subscribe,
   zipMongoDBMessageBatchPullerStartFrom,
   type MongoDBSubscription,
 } from './subscriptions';
+import {
+  toMongoDBCheckpoint,
+  type MongoDBResumeToken,
+} from './subscriptions/mongoDBCheckpoint';
 
 export type MongoDBChangeStreamMessageMetadata =
   RecordedMessageMetadataWithoutGlobalPosition;
@@ -65,6 +73,12 @@ export type MongoDBEventStoreConsumer<
   ConsumerMessageType extends AnyMessage = any,
 > = MessageConsumer<ConsumerMessageType> &
   Readonly<{
+    whenProcessed: (
+      position: ProcessorCheckpoint,
+      options?: WaitOptions,
+    ) => Promise<void>;
+    whenCaughtUp: (options?: WaitOptions) => Promise<void>;
+
     reactor: <MessageType extends AnyMessage = ConsumerMessageType>(
       options: MongoDBProcessorOptions<MessageType>,
     ) => MongoDBProcessor<MessageType>;
@@ -176,6 +190,34 @@ export const mongoDBEventStoreConsumer = <
       return isRunning;
     },
     whenStarted: (): Promise<void> => startedAwaiter.wait,
+    whenProcessed: (position, options): Promise<void> =>
+      Promise.all(
+        processors.map((p) => p.whenProcessed(position, options)),
+      ).then(() => undefined),
+    whenCaughtUp: async (options): Promise<void> => {
+      const db = client.db();
+
+      const { changeStreamFullDocumentValuePolicy } =
+        await getDatabaseVersionPolicies(db);
+
+      const cs = subscribe(changeStreamFullDocumentValuePolicy, db)('END');
+
+      try {
+        await cs.tryNext();
+
+        const resumeToken = cs.resumeToken as MongoDBResumeToken | undefined;
+
+        if (resumeToken === undefined || resumeToken === null) return;
+
+        const tailCheckpoint = toMongoDBCheckpoint(resumeToken, 0);
+
+        await Promise.all(
+          processors.map((p) => p.whenProcessed(tailCheckpoint, options)),
+        );
+      } finally {
+        await cs.close();
+      }
+    },
     processors,
     reactor: <MessageType extends AnyMessage = ConsumerMessageType>(
       processorOptions: MongoDBProcessorOptions<MessageType>,

--- a/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBEventStoreConsumer.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBEventStoreConsumer.ts
@@ -5,6 +5,7 @@ import type {
 } from '@event-driven-io/emmett';
 import {
   asyncAwaiter,
+  ConsumerStartPositions,
   EmmettError,
   mergeObservability,
   type AnyEvent,
@@ -31,9 +32,9 @@ import {
 import {
   mongoDBSubscription,
   readLastCommittedMessageCheckpoint,
-  zipMongoDBMessageBatchPullerStartFrom,
   type MongoDBSubscription,
 } from './subscriptions';
+import { compareTwoMongoDBCheckpoints } from './subscriptions/mongoDBCheckpoint';
 
 export type MongoDBChangeStreamMessageMetadata =
   RecordedMessageMetadataWithoutGlobalPosition;
@@ -116,6 +117,7 @@ export const mongoDBEventStoreConsumer = <
   let stream: MongoDBSubscription | undefined;
   let isRunning = false;
   let isInitialized = false;
+  let startPositions: ConsumerStartPositions | undefined;
 
   const startedAwaiter: AsyncAwaiter<void> = asyncAwaiter<void>();
 
@@ -140,7 +142,11 @@ export const mongoDBEventStoreConsumer = <
     const result = await Promise.allSettled(
       activeProcessors.map(async (s) => {
         // TODO: Add here filtering to only pass messages that can be handled by
-        return await s.handle(messagesBatch, { client });
+        const batch =
+          startPositions?.afterStartPosition(s.id, messagesBatch) ??
+          messagesBatch;
+
+        return await s.handle(batch, { client });
       }),
     );
 
@@ -262,19 +268,25 @@ export const mongoDBEventStoreConsumer = <
             await init();
           }
 
-          const positions = await Promise.all(
-            processors.map((o) => o.start({ client })),
-          );
-          const startFrom = zipMongoDBMessageBatchPullerStartFrom(positions);
+          startPositions = await ConsumerStartPositions.resolve({
+            processors,
+            handlerContext: { client },
+            readLastMessageCheckpoint: async () =>
+              (await readLastCommittedMessageCheckpoint(client.db())) ?? null,
+            compareCheckpoints: compareTwoMongoDBCheckpoints as (
+              a: ProcessorCheckpoint,
+              b: ProcessorCheckpoint,
+            ) => number,
+          });
 
           stream = mongoDBSubscription<ConsumerMessageType>({
             client,
-            from: startFrom,
+            from: startPositions.earliestPosition,
             eachBatch,
           });
 
           await stream.start({
-            startFrom,
+            startFrom: startPositions.earliestPosition,
             started: startedAwaiter,
           });
         } catch (error) {

--- a/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBProcessor.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBProcessor.ts
@@ -9,6 +9,7 @@ import {
   type Event,
   type Message,
   type MessageProcessingScope,
+  type ProcessorCheckpoint,
   type ProjectorOptions,
   type ReactorOptions,
   type SingleMessageHandlerResult,
@@ -20,6 +21,7 @@ import { MongoClient } from 'mongodb';
 import type { MongoDBEventStoreConnectionOptions } from '../mongoDBEventStore';
 import { mongoDBCheckpointer } from './mongoDBCheckpointer';
 import type { MongoDBChangeStreamMessageMetadata } from './mongoDBEventStoreConsumer';
+import { compareTwoMongoDBCheckpoints } from './subscriptions';
 
 type MongoDBConnectionOptions = {
   connectionOptions: MongoDBEventStoreConnectionOptions;
@@ -115,6 +117,10 @@ export const mongoDBProjector = <EventType extends Event = Event>(
     }),
 
     checkpoints: mongoDBCheckpointer<EventType>(),
+    compareCheckpoints: compareTwoMongoDBCheckpoints as (
+      a: ProcessorCheckpoint,
+      b: ProcessorCheckpoint,
+    ) => number,
   });
 };
 
@@ -145,5 +151,9 @@ export const changeStreamReactor = <
       processorId: options.processorId,
     }),
     checkpoints: mongoDBCheckpointer<MessageType>(),
+    compareCheckpoints: compareTwoMongoDBCheckpoints as (
+      a: ProcessorCheckpoint,
+      b: ProcessorCheckpoint,
+    ) => number,
   });
 };

--- a/src/packages/emmett-mongodb/src/eventStore/consumers/subscriptions/index.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/consumers/subscriptions/index.ts
@@ -141,17 +141,19 @@ export const oplogChangeToMessages = (
       : [];
 
 /**
- * Returns the checkpoint of a change's first message, or undefined when it
- * carries none. Position 0 is used because every message emitted from a single
- * change shares that change's resume token and differs only by index, so it is
- * always at or before the processor's checkpoint for that change.
+ * Returns the checkpoint of a change's last message, or undefined when it
+ * carries none. MongoDB resume tokens identify the whole change; the message
+ * index keeps processor-level filtering precise inside multi-message changes.
  */
 export const oplogChangeToTailCheckpoint = (
   change: OplogChange<AnyMessage, RecordedMessageMetadata>,
-): MongoDBCheckpoint | undefined =>
-  oplogChangeToMessages(change).length > 0
-    ? toMongoDBCheckpoint(change._id, 0)
+): MongoDBCheckpoint | undefined => {
+  const messages = oplogChangeToMessages(change);
+
+  return messages.length > 0
+    ? toMongoDBCheckpoint(change._id, messages.length - 1)
     : undefined;
+};
 
 type SubscriptionSequentialHandlerOptions<
   MessageType extends AnyMessage = AnyMessage,

--- a/src/packages/emmett-mongodb/src/eventStore/consumers/subscriptions/index.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/consumers/subscriptions/index.ts
@@ -94,9 +94,7 @@ export type StreamSubscription<
     MongoDBChangeStreamMessageMetadata,
 > = ChangeStream<
   EventStream<Extract<EventType, { kind?: 'Event' }>, MessageMetadataType>,
-  MongoDBSubscriptionDocument<
-    EventStream<Extract<EventType, { kind?: 'Event' }>, RecordedMessageMetadata>
-  >
+  OplogChange<Extract<EventType, { kind?: 'Event' }>, RecordedMessageMetadata>
 >;
 export type MessageArrayElement = `messages.${string}`;
 export type UpdateDescription<T> = {
@@ -131,6 +129,30 @@ export type OplogChange<
       ReadEvent<Extract<EventType, { kind?: 'Event' }>, EventMetaDataType>
     >;
 
+export const oplogChangeToMessages = (
+  change: OplogChange<AnyMessage, RecordedMessageMetadata>,
+): ReadEvent[] =>
+  change.operationType === 'insert'
+    ? (change.fullDocument?.messages ?? [])
+    : change.operationType === 'update'
+      ? Object.entries(change.updateDescription.updatedFields)
+          .filter(([key]) => key.startsWith('messages.'))
+          .map(([, value]) => value as ReadEvent)
+      : [];
+
+/**
+ * Returns the checkpoint of a change's first message, or undefined when it
+ * carries none. Position 0 is used because every message emitted from a single
+ * change shares that change's resume token and differs only by index, so it is
+ * always at or before the processor's checkpoint for that change.
+ */
+export const oplogChangeToTailCheckpoint = (
+  change: OplogChange<AnyMessage, RecordedMessageMetadata>,
+): MongoDBCheckpoint | undefined =>
+  oplogChangeToMessages(change).length > 0
+    ? toMongoDBCheckpoint(change._id, 0)
+    : undefined;
+
 type SubscriptionSequentialHandlerOptions<
   MessageType extends AnyMessage = AnyMessage,
 > = MongoDBSubscriptionOptions<MessageType> & WritableOptions;
@@ -160,23 +182,10 @@ class SubscriptionSequentialHandler<
       }
 
       const changeStreamCheckpoint = change._id;
-      const streamChange =
-        change.operationType === 'insert'
-          ? change.fullDocument
-          : change.operationType === 'update'
-            ? {
-                messages: Object.entries(change.updateDescription.updatedFields)
-                  .filter(([key]) => key.startsWith('messages.'))
-                  .map(([, value]) => value as ReadEvent),
-              }
-            : void 0;
-
-      if (!streamChange) {
-        return;
-      }
+      const extractedMessages = oplogChangeToMessages(change);
 
       let lastCheckpoint: MongoDBCheckpoint | undefined = undefined;
-      const messages = streamChange.messages.map((message, index) => {
+      const messages = extractedMessages.map((message, index) => {
         lastCheckpoint = toMongoDBCheckpoint(changeStreamCheckpoint, index);
         return {
           kind: message.kind,
@@ -303,9 +312,7 @@ const createChangeStream = <EventType extends Message = AnyMessage>(
 
   return db.watch<
     EventStream<Extract<EventType, { kind?: 'Event' }>>,
-    MongoDBSubscriptionDocument<
-      EventStream<Extract<EventType, { kind?: 'Event' }>>
-    >
+    OplogChange<Extract<EventType, { kind?: 'Event' }>, RecordedMessageMetadata>
   >(pipeline, {
     useBigInt64: true,
     fullDocument: getFullDocumentValue(),
@@ -339,6 +346,40 @@ const subscribe =
     resumeToken?: MongoDBSubscriptionStartFrom,
   ) =>
     createChangeStream<EventType>(getFullDocumentValue, db, resumeToken);
+
+/**
+ * Reads the checkpoint of the last committed message, the MongoDB equivalent of
+ * PostgreSQL's readLastCommittedMessageCheckpoint. MongoDB has no queryable tail,
+ * so it drains a momentary change stream from the beginning and keeps the last
+ * message-producing change. Its resume token at position 0 is a real event the
+ * processor can reach, unlike a live "END" resume token, which sits ahead of the
+ * last event and never resolves.
+ */
+export const readLastCommittedMessageCheckpoint = async (
+  db: Db,
+): Promise<MongoDBCheckpoint | undefined> => {
+  const { changeStreamFullDocumentValuePolicy } =
+    await getDatabaseVersionPolicies(db);
+
+  const changeStream = subscribe(changeStreamFullDocumentValuePolicy, db)();
+
+  let currentCheckpoint: MongoDBCheckpoint | undefined;
+
+  try {
+    for (
+      let change = await changeStream.tryNext();
+      change !== null;
+      change = await changeStream.tryNext()
+    ) {
+      const checkpoint = oplogChangeToTailCheckpoint(change);
+      if (checkpoint !== undefined) currentCheckpoint = checkpoint;
+    }
+  } finally {
+    await changeStream.close();
+  }
+
+  return currentCheckpoint;
+};
 
 export const mongoDBSubscription = <MessageType extends Message = AnyMessage>({
   client,

--- a/src/packages/emmett-mongodb/src/eventStore/consumers/subscriptions/readLastCommittedMessageCheckpoint.unit.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/consumers/subscriptions/readLastCommittedMessageCheckpoint.unit.spec.ts
@@ -1,0 +1,26 @@
+import { assertEqual, type Event } from '@event-driven-io/emmett';
+import { describe, it } from 'vitest';
+import { oplogChangeToTailCheckpoint, type FullDocument } from './index';
+import { toMongoDBCheckpoint } from './mongoDBCheckpoint';
+
+void describe('readLastCommittedMessageCheckpoint', () => {
+  void it('maps a multi-message change to the checkpoint of the last message', () => {
+    const resumeToken = { _data: '010203' };
+    const change = {
+      _id: resumeToken,
+      operationType: 'insert',
+      fullDocument: {
+        streamName: 'guestStay-1',
+        messages: [
+          { type: 'GuestCheckedIn', data: { guestId: '1' }, metadata: {} },
+          { type: 'GuestCheckedOut', data: { guestId: '1' }, metadata: {} },
+        ],
+      },
+    } as unknown as FullDocument<Event>;
+
+    assertEqual(
+      toMongoDBCheckpoint(resumeToken, 1),
+      oplogChangeToTailCheckpoint(change),
+    );
+  });
+});

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.awaiters.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.awaiters.int.spec.ts
@@ -1,31 +1,18 @@
-import { JSONSerializer } from '@event-driven-io/dumbo';
-import {
-  sqlite3Connection,
-  sqlite3Pool,
-  type SQLite3Connection,
-  type SQLitePool,
-} from '@event-driven-io/dumbo/sqlite3';
 import {
   assertRejects,
   assertThatArray,
-  bigIntProcessorCheckpoint,
   type Event,
 } from '@event-driven-io/emmett';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { getPostgreSQLStartedContainer } from '@event-driven-io/emmett-testcontainers';
+import type { StartedPostgreSqlContainer } from '@testcontainers/postgresql';
 import { v4 as uuid } from 'uuid';
-import { afterEach, beforeEach, describe, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
 import {
-  sqlite3EventStoreDriver,
-  type SQLite3EventStoreOptions,
-} from '../../sqlite3';
-import { deleteSQLiteDatabaseFiles } from '../../testing/sqliteTestDatabase';
-import { createEventStoreSchema } from '../schema';
-import {
-  getSQLiteEventStore,
-  type SQLiteEventStore,
-} from '../SQLiteEventStore';
-import { sqliteEventStoreConsumer } from './sqliteEventStoreConsumer';
+  getPostgreSQLEventStore,
+  type PostgresEventStore,
+} from '../postgreSQLEventStore';
+import { PostgreSQLEventStoreCheckpoint } from '../schema';
+import { postgreSQLEventStoreConsumer } from './postgreSQLEventStoreConsumer';
 
 type GuestStayEvent = Event<
   'GuestCheckedIn' | 'GuestCheckedOut',
@@ -34,35 +21,32 @@ type GuestStayEvent = Event<
 
 const withDeadline = { timeout: 30000 };
 
-void describe('waiting for a SQLite consumer to catch up in a test', () => {
-  const testDatabasePath = path.dirname(fileURLToPath(import.meta.url));
-  const fileName = path.resolve(testDatabasePath, `awaiters.test.db`);
+void describe('waiting for a PostgreSQL consumer to catch up in a test', () => {
+  let postgres: StartedPostgreSqlContainer;
+  let connectionString: string;
+  let eventStore: PostgresEventStore;
 
-  let pool: SQLitePool<SQLite3Connection>;
-
-  const config: SQLite3EventStoreOptions = {
-    driver: sqlite3EventStoreDriver,
-    schema: { autoMigration: 'None' },
-    fileName,
-  };
-
-  let eventStore: SQLiteEventStore;
-
-  beforeEach(() => {
-    pool = sqlite3Pool({
-      fileName,
-      transactionOptions: { allowNestedTransactions: true },
-    });
-    eventStore = getSQLiteEventStore({ ...config, pool });
-    return createEventStoreSchema(
-      sqlite3Connection({ fileName, serializer: JSONSerializer }),
-    );
+  beforeAll(async () => {
+    postgres = await getPostgreSQLStartedContainer();
+    connectionString = postgres.getConnectionUri();
+    eventStore = getPostgreSQLEventStore(connectionString);
+    await eventStore.schema.migrate();
   });
 
-  afterEach(async () => {
-    await eventStore.close();
-    await pool.close();
-    deleteSQLiteDatabaseFiles(fileName);
+  beforeEach(async () => {
+    await eventStore.schema.dangerous.truncate({
+      resetSequences: true,
+      truncateProjections: true,
+    });
+  });
+
+  afterAll(async () => {
+    try {
+      await eventStore?.close();
+      await postgres?.stop();
+    } catch (error) {
+      console.log(error);
+    }
   });
 
   void it(
@@ -71,9 +55,8 @@ void describe('waiting for a SQLite consumer to catch up in a test', () => {
     async () => {
       // Given
       const processed: GuestStayEvent[] = [];
-      const consumer = sqliteEventStoreConsumer({
-        driver: sqlite3EventStoreDriver,
-        fileName,
+      const consumer = postgreSQLEventStoreConsumer({
+        connectionString,
       });
       consumer.reactor<GuestStayEvent>({
         processorId: uuid(),
@@ -113,9 +96,8 @@ void describe('waiting for a SQLite consumer to catch up in a test', () => {
     async () => {
       // Given
       const processed: GuestStayEvent[] = [];
-      const consumer = sqliteEventStoreConsumer({
-        driver: sqlite3EventStoreDriver,
-        fileName,
+      const consumer = postgreSQLEventStoreConsumer({
+        connectionString,
       });
       consumer.reactor<GuestStayEvent>({
         processorId: uuid(),
@@ -157,9 +139,8 @@ void describe('waiting for a SQLite consumer to catch up in a test', () => {
     withDeadline,
     async () => {
       // Given
-      const consumer = sqliteEventStoreConsumer({
-        driver: sqlite3EventStoreDriver,
-        fileName,
+      const consumer = postgreSQLEventStoreConsumer({
+        connectionString,
       });
       consumer.reactor<GuestStayEvent>({
         processorId: uuid(),
@@ -178,9 +159,15 @@ void describe('waiting for a SQLite consumer to catch up in a test', () => {
 
         // When / Then - a position far past the tail is never reached
         await assertRejects(
-          consumer.whenProcessed(bigIntProcessorCheckpoint(9_999_999_999n), {
-            timeout: 200,
-          }),
+          consumer.whenProcessed(
+            PostgreSQLEventStoreCheckpoint.toProcessorCheckpoint({
+              transactionId: 99_999_999_999_999_999_999n,
+              globalPosition: 9_999_999_999n,
+            }),
+            {
+              timeout: 200,
+            },
+          ),
         );
       } finally {
         await consumer.close();

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.handling.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.handling.int.spec.ts
@@ -4,6 +4,7 @@ import {
   assertEqual,
   assertThatArray,
   assertThrowsAsync,
+  asyncAwaiter,
   defaultTag,
   type Event,
 } from '@event-driven-io/emmett';
@@ -114,7 +115,6 @@ void describe('PostgreSQL event store started consumer', () => {
         // Given
 
         const result: GuestStayEvent[] = [];
-        let stopAfterPosition: string | undefined = undefined;
 
         // When
         const consumer = postgreSQLEventStoreConsumer({
@@ -122,8 +122,6 @@ void describe('PostgreSQL event store started consumer', () => {
         });
         consumer.reactor<GuestStayEvent>({
           processorId: uuid(),
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
           eachMessage: (event) => {
             result.push(event);
           },
@@ -136,20 +134,19 @@ void describe('PostgreSQL event store started consumer', () => {
           { type: 'GuestCheckedOut', data: { guestId } },
         ];
 
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await consumer.whenCaughtUp();
 
           assertThatArray(result).containsElementsMatching(events);
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -176,7 +173,7 @@ void describe('PostgreSQL event store started consumer', () => {
         ];
 
         const result: GuestStayEvent[] = [];
-        let stopAfterPosition: string | undefined = undefined;
+        const resultReachedEnd = asyncAwaiter();
 
         // When
         const consumer = postgreSQLEventStoreConsumer({
@@ -187,27 +184,29 @@ void describe('PostgreSQL event store started consumer', () => {
           startFrom: {
             lastCheckpoint: startPosition,
           },
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
           eachMessage: (event) => {
             result.push(event);
+            if (
+              event.type === 'GuestCheckedOut' &&
+              event.data.guestId === otherGuestId
+            )
+              resultReachedEnd.resolve();
           },
         });
 
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await resultReachedEnd.wait;
 
           assertThatArray(result).containsOnlyElementsMatching(events);
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -234,7 +233,6 @@ void describe('PostgreSQL event store started consumer', () => {
         ];
 
         const result: GuestStayEvent[] = [];
-        let stopAfterPosition: string | undefined = undefined;
 
         // When
         const consumer = postgreSQLEventStoreConsumer({
@@ -243,23 +241,19 @@ void describe('PostgreSQL event store started consumer', () => {
         consumer.reactor<GuestStayEvent>({
           processorId: uuid(),
           startFrom: 'CURRENT',
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
           eachMessage: (event) => {
             result.push(event);
           },
         });
 
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await consumer.whenCaughtUp();
 
           assertThatArray(result).containsElementsMatching([
             ...initialEvents,
@@ -267,6 +261,7 @@ void describe('PostgreSQL event store started consumer', () => {
           ]);
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -293,7 +288,6 @@ void describe('PostgreSQL event store started consumer', () => {
         ];
 
         let result: GuestStayEvent[] = [];
-        let stopAfterPosition: string | undefined = startPosition;
 
         // When
         const consumer = postgreSQLEventStoreConsumer({
@@ -302,8 +296,7 @@ void describe('PostgreSQL event store started consumer', () => {
         consumer.reactor<GuestStayEvent>({
           processorId: uuid(),
           startFrom: 'CURRENT',
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
+          stopAfter: (event) => event.metadata.globalPosition === startPosition,
           eachMessage: (event) => {
             result.push(event);
           },
@@ -314,22 +307,19 @@ void describe('PostgreSQL event store started consumer', () => {
 
         result = [];
 
-        stopAfterPosition = undefined;
-
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await consumer.whenCaughtUp();
 
           assertThatArray(result).containsOnlyElementsMatching(events);
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -356,13 +346,11 @@ void describe('PostgreSQL event store started consumer', () => {
         ];
 
         let result: GuestStayEvent[] = [];
-        let stopAfterPosition: string | undefined = startPosition;
 
         const processorOptions: PostgreSQLReactorOptions<GuestStayEvent> = {
           processorId: uuid(),
           startFrom: 'CURRENT',
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
+          stopAfter: (event) => event.metadata.globalPosition === startPosition,
           eachMessage: (event) => {
             result.push(event);
           },
@@ -382,27 +370,24 @@ void describe('PostgreSQL event store started consumer', () => {
 
         result = [];
 
-        stopAfterPosition = undefined;
-
         const newConsumer = postgreSQLEventStoreConsumer({
           connectionString,
         });
         newConsumer.reactor<GuestStayEvent>(processorOptions);
 
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = newConsumer.start();
+          consumerPromise = newConsumer.start();
+          await newConsumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await newConsumer.whenCaughtUp();
 
           assertThatArray(result).containsOnlyElementsMatching(events);
         } finally {
           await newConsumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -428,7 +413,6 @@ void describe('PostgreSQL event store started consumer', () => {
         ];
 
         const result: GuestStayEvent[] = [];
-        let stopAfterPosition: string | undefined = undefined;
 
         // When
         const consumer = postgreSQLEventStoreConsumer({
@@ -437,28 +421,26 @@ void describe('PostgreSQL event store started consumer', () => {
         consumer.reactor<GuestStayEvent>({
           processorId: uuid(),
           startFrom: 'END',
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
           eachMessage: (event) => {
             result.push(event);
           },
         });
 
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
           await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await consumer.whenCaughtUp();
 
           assertThatArray(result).containsOnlyElementsMatching(events);
+        } catch (error) {
+          console.log(error);
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -477,7 +459,6 @@ void describe('PostgreSQL event store started consumer', () => {
         ];
 
         const result: GuestStayEvent[] = [];
-        let stopAfterPosition: string | undefined = undefined;
 
         // When
         const consumer = postgreSQLEventStoreConsumer({
@@ -486,28 +467,24 @@ void describe('PostgreSQL event store started consumer', () => {
         consumer.reactor<GuestStayEvent>({
           processorId: uuid(),
           startFrom: 'END',
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
           eachMessage: (event) => {
             result.push(event);
           },
         });
 
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
           await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await consumer.whenCaughtUp();
 
           assertThatArray(result).containsElementsMatching(events);
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -534,7 +511,6 @@ void describe('PostgreSQL event store started consumer', () => {
         ];
 
         let result: GuestStayEvent[] = [];
-        let stopAfterPosition: string | undefined = undefined;
 
         const consumer = postgreSQLEventStoreConsumer({
           connectionString,
@@ -542,8 +518,6 @@ void describe('PostgreSQL event store started consumer', () => {
         consumer.reactor<GuestStayEvent>({
           processorId: uuid(),
           startFrom: 'END',
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
           eachMessage: (event) => {
             result.push(event);
           },
@@ -553,38 +527,32 @@ void describe('PostgreSQL event store started consumer', () => {
         const firstConsumerPromise = consumer.start();
         await consumer.whenStarted();
 
-        const firstAppend = await eventStore.appendToStream(
-          streamName,
-          firstBatch,
-        );
-        stopAfterPosition = firstAppend.lastEventGlobalPosition;
-        await firstConsumerPromise;
+        await eventStore.appendToStream(streamName, firstBatch);
+        await consumer.whenCaughtUp();
         await consumer.stop();
+        await firstConsumerPromise;
 
         // Run 2: restart and process second batch only
         result = [];
-        stopAfterPosition = undefined;
 
         const secondBatch: GuestStayEvent[] = [
           { type: 'GuestCheckedIn', data: { guestId: thirdGuestId } },
           { type: 'GuestCheckedOut', data: { guestId: thirdGuestId } },
         ];
 
+        let secondConsumerPromise: Promise<void> | undefined;
         try {
-          const secondConsumerPromise = consumer.start();
+          secondConsumerPromise = consumer.start();
           await consumer.whenStarted();
 
-          const secondAppend = await eventStore.appendToStream(
-            streamName,
-            secondBatch,
-          );
-          stopAfterPosition = secondAppend.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, secondBatch);
 
-          await secondConsumerPromise;
+          await consumer.whenCaughtUp();
 
           assertThatArray(result).containsOnlyElementsMatching(secondBatch);
         } finally {
           await consumer.close();
+          await secondConsumerPromise;
         }
       },
     );
@@ -612,7 +580,6 @@ void describe('PostgreSQL event store started consumer', () => {
 
           const fromBeginning: GuestStayEvent[] = [];
           const fromEnd: GuestStayEvent[] = [];
-          let stopAfterPosition: string | undefined = undefined;
 
           // When
           const consumer = postgreSQLEventStoreConsumer({
@@ -621,8 +588,6 @@ void describe('PostgreSQL event store started consumer', () => {
           consumer.reactor<GuestStayEvent>({
             processorId: uuid(),
             startFrom: 'BEGINNING',
-            stopAfter: (event) =>
-              event.metadata.globalPosition === stopAfterPosition,
             eachMessage: (event) => {
               fromBeginning.push(event);
             },
@@ -630,24 +595,19 @@ void describe('PostgreSQL event store started consumer', () => {
           consumer.reactor<GuestStayEvent>({
             processorId: uuid(),
             startFrom: 'END',
-            stopAfter: (event) =>
-              event.metadata.globalPosition === stopAfterPosition,
             eachMessage: (event) => {
               fromEnd.push(event);
             },
           });
 
+          let consumerPromise: Promise<void> | undefined;
           try {
-            const consumerPromise = consumer.start();
+            consumerPromise = consumer.start();
             await consumer.whenStarted();
 
-            const appendResult = await eventStore.appendToStream(
-              streamName,
-              newEvents,
-            );
-            stopAfterPosition = appendResult.lastEventGlobalPosition;
+            await eventStore.appendToStream(streamName, newEvents);
 
-            await consumerPromise;
+            await consumer.whenCaughtUp();
 
             // Then the BEGINNING processor sees the whole history,
             // while the END processor sees only messages appended after start
@@ -658,6 +618,7 @@ void describe('PostgreSQL event store started consumer', () => {
             assertThatArray(fromEnd).containsOnlyElementsMatching(newEvents);
           } finally {
             await consumer.close();
+            await consumerPromise;
           }
         },
       );
@@ -690,7 +651,8 @@ void describe('PostgreSQL event store started consumer', () => {
 
           const fromResuming: GuestStayEvent[] = [];
           const fromEnd: GuestStayEvent[] = [];
-          let stopAfterPosition: string | undefined = undefined;
+          const resumingReachedEnd = asyncAwaiter();
+          const endReachedEnd = asyncAwaiter();
 
           const consumer = postgreSQLEventStoreConsumer({
             connectionString,
@@ -698,33 +660,36 @@ void describe('PostgreSQL event store started consumer', () => {
           consumer.reactor<GuestStayEvent>({
             processorId: uuid(),
             startFrom: { lastCheckpoint: resumeCheckpoint },
-            stopAfter: (event) =>
-              event.metadata.globalPosition === stopAfterPosition,
             eachMessage: (event) => {
               fromResuming.push(event);
+              if (
+                event.type === 'GuestCheckedOut' &&
+                event.data.guestId === guestId
+              )
+                resumingReachedEnd.resolve();
             },
           });
           consumer.reactor<GuestStayEvent>({
             processorId: uuid(),
             startFrom: 'END',
-            stopAfter: (event) =>
-              event.metadata.globalPosition === stopAfterPosition,
             eachMessage: (event) => {
               fromEnd.push(event);
+              if (
+                event.type === 'GuestCheckedOut' &&
+                event.data.guestId === guestId
+              )
+                endReachedEnd.resolve();
             },
           });
 
+          let consumerPromise: Promise<void> | undefined;
           try {
-            const consumerPromise = consumer.start();
+            consumerPromise = consumer.start();
             await consumer.whenStarted();
 
-            const appendResult = await eventStore.appendToStream(
-              streamName,
-              newEvents,
-            );
-            stopAfterPosition = appendResult.lastEventGlobalPosition;
+            await eventStore.appendToStream(streamName, newEvents);
 
-            await consumerPromise;
+            await Promise.all([resumingReachedEnd.wait, endReachedEnd.wait]);
 
             assertThatArray(fromResuming).containsOnlyElementsMatching([
               ...backlogEvents,
@@ -733,6 +698,7 @@ void describe('PostgreSQL event store started consumer', () => {
             assertThatArray(fromEnd).containsOnlyElementsMatching(newEvents);
           } finally {
             await consumer.close();
+            await consumerPromise;
           }
         },
       );
@@ -757,7 +723,6 @@ void describe('PostgreSQL event store started consumer', () => {
 
           const firstEnd: GuestStayEvent[] = [];
           const secondEnd: GuestStayEvent[] = [];
-          let stopAfterPosition: string | undefined = undefined;
 
           const consumer = postgreSQLEventStoreConsumer({
             connectionString,
@@ -765,8 +730,6 @@ void describe('PostgreSQL event store started consumer', () => {
           consumer.reactor<GuestStayEvent>({
             processorId: uuid(),
             startFrom: 'END',
-            stopAfter: (event) =>
-              event.metadata.globalPosition === stopAfterPosition,
             eachMessage: (event) => {
               firstEnd.push(event);
             },
@@ -774,29 +737,25 @@ void describe('PostgreSQL event store started consumer', () => {
           consumer.reactor<GuestStayEvent>({
             processorId: uuid(),
             startFrom: 'END',
-            stopAfter: (event) =>
-              event.metadata.globalPosition === stopAfterPosition,
             eachMessage: (event) => {
               secondEnd.push(event);
             },
           });
 
+          let consumerPromise: Promise<void> | undefined;
           try {
-            const consumerPromise = consumer.start();
+            consumerPromise = consumer.start();
             await consumer.whenStarted();
 
-            const appendResult = await eventStore.appendToStream(
-              streamName,
-              newEvents,
-            );
-            stopAfterPosition = appendResult.lastEventGlobalPosition;
+            await eventStore.appendToStream(streamName, newEvents);
 
-            await consumerPromise;
+            await consumer.whenCaughtUp();
 
             assertThatArray(firstEnd).containsOnlyElementsMatching(newEvents);
             assertThatArray(secondEnd).containsOnlyElementsMatching(newEvents);
           } finally {
             await consumer.close();
+            await consumerPromise;
           }
         },
       );
@@ -823,7 +782,6 @@ void describe('PostgreSQL event store started consumer', () => {
         ];
 
         const fromEnd: GuestStayEvent[] = [];
-        let stopAfterPosition: string | undefined = undefined;
 
         const consumer = postgreSQLEventStoreConsumer({
           connectionString,
@@ -831,25 +789,20 @@ void describe('PostgreSQL event store started consumer', () => {
         consumer.reactor<GuestStayEvent>({
           processorId: uuid(),
           startFrom: 'END',
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
           eachMessage: (event) => {
             fromEnd.push(event);
           },
         });
 
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
           await consumer.whenStarted();
 
           await eventStore.appendToStream(streamName, firstAppend);
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            secondAppend,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, secondAppend);
 
-          await consumerPromise;
+          await consumer.whenCaughtUp();
 
           assertThatArray(fromEnd).containsOnlyElementsMatching([
             ...firstAppend,
@@ -857,6 +810,7 @@ void describe('PostgreSQL event store started consumer', () => {
           ]);
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -889,7 +843,6 @@ void describe('PostgreSQL event store started consumer', () => {
 
           const firstRun: GuestStayEvent[] = [];
           const secondRun: GuestStayEvent[] = [];
-          let stopAfterPosition: string | undefined = undefined;
 
           const firstConsumer = postgreSQLEventStoreConsumer({
             connectionString,
@@ -898,26 +851,20 @@ void describe('PostgreSQL event store started consumer', () => {
             processorId,
             startFrom,
             checkpoints: 'DISABLED',
-            stopAfter: (event) =>
-              event.metadata.globalPosition === stopAfterPosition,
             eachMessage: (event) => {
               firstRun.push(event);
             },
           });
+          let firstConsumerPromise: Promise<void> | undefined;
           try {
-            const consumerPromise = firstConsumer.start();
+            firstConsumerPromise = firstConsumer.start();
             await firstConsumer.whenStarted();
-            const appendResult = await eventStore.appendToStream(
-              streamName,
-              firstNewEvents,
-            );
-            stopAfterPosition = appendResult.lastEventGlobalPosition;
-            await consumerPromise;
+            await eventStore.appendToStream(streamName, firstNewEvents);
+            await firstConsumer.whenCaughtUp();
           } finally {
             await firstConsumer.close();
+            await firstConsumerPromise;
           }
-
-          stopAfterPosition = undefined;
 
           const secondConsumer = postgreSQLEventStoreConsumer({
             connectionString,
@@ -926,23 +873,19 @@ void describe('PostgreSQL event store started consumer', () => {
             processorId,
             startFrom,
             checkpoints: 'DISABLED',
-            stopAfter: (event) =>
-              event.metadata.globalPosition === stopAfterPosition,
             eachMessage: (event) => {
               secondRun.push(event);
             },
           });
+          let secondConsumerPromise: Promise<void> | undefined;
           try {
-            const consumerPromise = secondConsumer.start();
+            secondConsumerPromise = secondConsumer.start();
             await secondConsumer.whenStarted();
-            const appendResult = await eventStore.appendToStream(
-              streamName,
-              secondNewEvents,
-            );
-            stopAfterPosition = appendResult.lastEventGlobalPosition;
-            await consumerPromise;
+            await eventStore.appendToStream(streamName, secondNewEvents);
+            await secondConsumer.whenCaughtUp();
           } finally {
             await secondConsumer.close();
+            await secondConsumerPromise;
           }
 
           const expectedFirstRun =

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.inMemory.projections.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.inMemory.projections.int.spec.ts
@@ -105,14 +105,10 @@ void describe('PostgreSQL event store started consumer', () => {
       withDeadline,
       async () => {
         // Given
-        let stopAfterPosition: string | undefined = undefined;
-
         const inMemoryProcessor = inMemoryProjector<ShoppingCartSummaryEvent>({
           processorId: uuid(),
           projection: shoppingCartsSummaryProjection,
           connectionOptions: { database },
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
         });
         const consumer = postgreSQLEventStoreConsumer<ShoppingCartSummaryEvent>(
           {
@@ -137,16 +133,14 @@ void describe('PostgreSQL event store started consumer', () => {
           },
         ];
 
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await consumer.whenCaughtUp();
 
           const summary = await summaries.findOne((d) => d._id === streamName);
 
@@ -158,6 +152,7 @@ void describe('PostgreSQL event store started consumer', () => {
           });
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -185,8 +180,6 @@ void describe('PostgreSQL event store started consumer', () => {
           },
         ];
 
-        let stopAfterPosition: string | undefined = undefined;
-
         const inMemoryProcessor = inMemoryProjector<ShoppingCartSummaryEvent>({
           processorId: uuid(),
           projection: shoppingCartsSummaryProjection,
@@ -194,8 +187,6 @@ void describe('PostgreSQL event store started consumer', () => {
           startFrom: {
             lastCheckpoint: startPosition,
           },
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
         });
 
         const consumer = postgreSQLEventStoreConsumer<ShoppingCartSummaryEvent>(
@@ -206,16 +197,14 @@ void describe('PostgreSQL event store started consumer', () => {
         );
 
         // When
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await consumer.whenCaughtUp();
 
           const summary = await summaries.findOne((d) => d._id === streamName);
 
@@ -227,6 +216,7 @@ void describe('PostgreSQL event store started consumer', () => {
           });
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -254,15 +244,11 @@ void describe('PostgreSQL event store started consumer', () => {
           },
         ];
 
-        let stopAfterPosition: string | undefined = undefined;
-
         const inMemoryProcessor = inMemoryProjector<ShoppingCartSummaryEvent>({
           processorId: uuid(),
           projection: shoppingCartsSummaryProjection,
           connectionOptions: { database },
           startFrom: 'CURRENT',
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
         });
 
         const consumer = postgreSQLEventStoreConsumer<ShoppingCartSummaryEvent>(
@@ -274,16 +260,14 @@ void describe('PostgreSQL event store started consumer', () => {
 
         // When
 
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await consumer.whenCaughtUp();
 
           const summary = await summaries.findOne((d) => d._id === streamName);
 
@@ -295,6 +279,7 @@ void describe('PostgreSQL event store started consumer', () => {
           });
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -322,15 +307,12 @@ void describe('PostgreSQL event store started consumer', () => {
           },
         ];
 
-        let stopAfterPosition: string | undefined = startPosition;
-
         const inMemoryProcessor = inMemoryProjector<ShoppingCartSummaryEvent>({
           processorId: uuid(),
           projection: shoppingCartsSummaryProjection,
           connectionOptions: { database },
           startFrom: 'CURRENT',
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
+          stopAfter: (event) => event.metadata.globalPosition === startPosition,
         });
 
         const consumer = postgreSQLEventStoreConsumer<ShoppingCartSummaryEvent>(
@@ -344,18 +326,14 @@ void describe('PostgreSQL event store started consumer', () => {
         await consumer.start();
         await consumer.stop();
 
-        stopAfterPosition = undefined;
-
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await consumer.whenCaughtUp();
 
           const summary = await summaries.findOne((d) => d._id === streamName);
 
@@ -367,6 +345,7 @@ void describe('PostgreSQL event store started consumer', () => {
           });
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -394,15 +373,12 @@ void describe('PostgreSQL event store started consumer', () => {
           },
         ];
 
-        let stopAfterPosition: string | undefined = startPosition;
-
         const inMemoryProcessor = inMemoryProjector<ShoppingCartSummaryEvent>({
           processorId: uuid(),
           projection: shoppingCartsSummaryProjection,
           connectionOptions: { database },
           startFrom: 'CURRENT',
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
+          stopAfter: (event) => event.metadata.globalPosition === startPosition,
         });
 
         const consumer = postgreSQLEventStoreConsumer<ShoppingCartSummaryEvent>(
@@ -419,23 +395,19 @@ void describe('PostgreSQL event store started consumer', () => {
           await consumer.close();
         }
 
-        stopAfterPosition = undefined;
-
         const newConsumer = postgreSQLEventStoreConsumer({
           connectionString,
           processors: [inMemoryProcessor],
         });
 
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = newConsumer.start();
+          consumerPromise = newConsumer.start();
+          await newConsumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await newConsumer.whenCaughtUp();
 
           const summary = await summaries.findOne((d) => d._id === streamName);
 
@@ -447,6 +419,7 @@ void describe('PostgreSQL event store started consumer', () => {
           });
         } finally {
           await newConsumer.close();
+          await consumerPromise;
         }
       },
     );

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.int.spec.ts
@@ -41,6 +41,7 @@ void describe('PostgreSQL event store consumer', () => {
     start: () => Promise.resolve('BEGINNING'),
     close: () => Promise.resolve(),
     handle: () => Promise.resolve(),
+    whenProcessed: () => Promise.resolve(),
     isActive: false,
   };
 

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.projections.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.projections.int.spec.ts
@@ -1,4 +1,8 @@
-import { assertDeepEqual, type ReadEvent } from '@event-driven-io/emmett';
+import {
+  assertDeepEqual,
+  assertMatches,
+  type ReadEvent,
+} from '@event-driven-io/emmett';
 import { getPostgreSQLStartedContainer } from '@event-driven-io/emmett-testcontainers';
 import {
   pongoClient,
@@ -111,17 +115,12 @@ void describe('PostgreSQL event store started consumer', () => {
       withDeadline,
       async () => {
         // Given
-        let stopAfterPosition: string | undefined = undefined;
-
-        // When
         const consumer = postgreSQLEventStoreConsumer({
           connectionString,
         });
         consumer.projector({
           processorId: uuid(),
           projection: shoppingCartsSummaryProjection,
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
         });
 
         const shoppingCartId = `shoppingCart:${uuid()}`;
@@ -139,16 +138,15 @@ void describe('PostgreSQL event store started consumer', () => {
           },
         ];
 
+        // When
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await consumer.whenCaughtUp();
 
           const summary = await summaries.findOne({ _id: streamName });
 
@@ -160,6 +158,7 @@ void describe('PostgreSQL event store started consumer', () => {
           });
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -187,8 +186,6 @@ void describe('PostgreSQL event store started consumer', () => {
           },
         ];
 
-        let stopAfterPosition: string | undefined = undefined;
-
         // When
         const consumer = postgreSQLEventStoreConsumer({
           connectionString,
@@ -199,20 +196,16 @@ void describe('PostgreSQL event store started consumer', () => {
           startFrom: {
             lastCheckpoint: startPosition,
           },
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
         });
 
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await consumer.whenCaughtUp();
 
           const summary = await summaries.findOne({ _id: streamName });
 
@@ -224,6 +217,7 @@ void describe('PostgreSQL event store started consumer', () => {
           });
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -251,8 +245,6 @@ void describe('PostgreSQL event store started consumer', () => {
           },
         ];
 
-        let stopAfterPosition: string | undefined = undefined;
-
         // When
         const consumer = postgreSQLEventStoreConsumer({
           connectionString,
@@ -261,31 +253,29 @@ void describe('PostgreSQL event store started consumer', () => {
           processorId: uuid(),
           projection: shoppingCartsSummaryProjection,
           startFrom: 'CURRENT',
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
         });
 
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await consumer.whenCaughtUp();
 
           const summary = await summaries.findOne({ _id: streamName });
 
-          assertDeepEqual(summary, {
+          // _version is not asserted here because the pre-existing events and
+          // the ones appended after start may land in one or two poll batches
+          assertMatches(summary, {
             _id: streamName,
             status: 'confirmed',
-            _version: 1n, // because it captures the whole batch of events as one operation
             productItemsCount: productItem.quantity * 3,
           });
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -313,8 +303,6 @@ void describe('PostgreSQL event store started consumer', () => {
           },
         ];
 
-        let stopAfterPosition: string | undefined = startPosition;
-
         // When
         const consumer = postgreSQLEventStoreConsumer({
           connectionString,
@@ -323,25 +311,20 @@ void describe('PostgreSQL event store started consumer', () => {
           processorId: uuid(),
           projection: shoppingCartsSummaryProjection,
           startFrom: 'CURRENT',
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
+          stopAfter: (event) => event.metadata.globalPosition === startPosition,
         });
 
         await consumer.start();
         await consumer.stop();
 
-        stopAfterPosition = undefined;
-
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = consumer.start();
+          consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await consumer.whenCaughtUp();
 
           const summary = await summaries.findOne({ _id: streamName });
 
@@ -353,6 +336,7 @@ void describe('PostgreSQL event store started consumer', () => {
           });
         } finally {
           await consumer.close();
+          await consumerPromise;
         }
       },
     );
@@ -380,15 +364,13 @@ void describe('PostgreSQL event store started consumer', () => {
           },
         ];
 
-        let stopAfterPosition: string | undefined = startPosition;
-
         const processorOptions: PostgreSQLProjectorOptions<ShoppingCartSummaryEvent> =
           {
             processorId: uuid(),
             projection: shoppingCartsSummaryProjection,
             startFrom: 'CURRENT',
             stopAfter: (event) =>
-              event.metadata.globalPosition === stopAfterPosition,
+              event.metadata.globalPosition === startPosition,
           };
 
         // When
@@ -403,23 +385,19 @@ void describe('PostgreSQL event store started consumer', () => {
           await consumer.close();
         }
 
-        stopAfterPosition = undefined;
-
         const newConsumer = postgreSQLEventStoreConsumer({
           connectionString,
         });
         newConsumer.projector<ShoppingCartSummaryEvent>(processorOptions);
 
+        let consumerPromise: Promise<void> | undefined;
         try {
-          const consumerPromise = newConsumer.start();
+          consumerPromise = newConsumer.start();
+          await newConsumer.whenStarted();
 
-          const appendResult = await eventStore.appendToStream(
-            streamName,
-            events,
-          );
-          stopAfterPosition = appendResult.lastEventGlobalPosition;
+          await eventStore.appendToStream(streamName, events);
 
-          await consumerPromise;
+          await newConsumer.whenCaughtUp();
 
           const summary = await summaries.findOne({ _id: streamName });
 
@@ -431,6 +409,7 @@ void describe('PostgreSQL event store started consumer', () => {
           });
         } finally {
           await newConsumer.close();
+          await consumerPromise;
         }
       },
     );

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
@@ -214,8 +214,9 @@ export const postgreSQLEventStoreConsumer = <
       ).then(() => undefined),
     whenCaughtUp: async (options): Promise<void> => {
       const tail = await pool.withConnection(async (connection) => {
-        const { currentCheckpoint } =
-          await readLastCommittedMessageCheckpoint(connection.execute);
+        const { currentCheckpoint } = await readLastCommittedMessageCheckpoint(
+          connection.execute,
+        );
         return currentCheckpoint;
       });
 

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
@@ -24,6 +24,7 @@ import {
 import { v7 as uuid } from 'uuid';
 import {
   PostgreSQLEventStoreCheckpoint,
+  readLastCommittedMessageCheckpoint,
   readLastMessageCheckpoint,
 } from '../schema';
 import {
@@ -213,9 +214,8 @@ export const postgreSQLEventStoreConsumer = <
       ).then(() => undefined),
     whenCaughtUp: async (options): Promise<void> => {
       const tail = await pool.withConnection(async (connection) => {
-        const { currentCheckpoint } = await readLastMessageCheckpoint(
-          connection.execute,
-        );
+        const { currentCheckpoint } =
+          await readLastCommittedMessageCheckpoint(connection.execute);
         return currentCheckpoint;
       });
 

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
@@ -16,7 +16,9 @@ import {
   type MessageConsumerOptions,
   type MessageHandlerContext,
   type MessageProcessor,
+  type ProcessorCheckpoint,
   type ReadEventMetadataWithGlobalPosition,
+  type WaitOptions,
   type WorkflowProcessorContext,
 } from '@event-driven-io/emmett';
 import { v7 as uuid } from 'uuid';
@@ -66,6 +68,12 @@ export type PostgreSQLEventStoreConsumer<
   ConsumerMessageType extends AnyMessage = any,
 > = MessageConsumer<ConsumerMessageType> &
   Readonly<{
+    whenProcessed: (
+      position: ProcessorCheckpoint,
+      options?: WaitOptions,
+    ) => Promise<void>;
+    whenCaughtUp: (options?: WaitOptions) => Promise<void>;
+
     reactor: <MessageType extends AnyMessage = ConsumerMessageType>(
       options: PostgreSQLReactorOptions<MessageType>,
     ) => PostgreSQLProcessor<MessageType>;
@@ -199,6 +207,29 @@ export const postgreSQLEventStoreConsumer = <
       return isRunning;
     },
     whenStarted: (): Promise<void> => startedAwaiter.wait,
+    whenProcessed: (position, options): Promise<void> =>
+      Promise.all(
+        processors.map((p) => p.whenProcessed(position, options)),
+      ).then(() => undefined),
+    whenCaughtUp: async (options): Promise<void> => {
+      const tail = await pool.withConnection(async (connection) => {
+        const { currentCheckpoint } = await readLastMessageCheckpoint(
+          connection.execute,
+        );
+        return currentCheckpoint;
+      });
+
+      if (tail === null) return;
+
+      await Promise.all(
+        processors.map((p) =>
+          p.whenProcessed(
+            PostgreSQLEventStoreCheckpoint.toProcessorCheckpoint(tail),
+            options,
+          ),
+        ),
+      );
+    },
     processors,
     init,
     reactor: <MessageType extends AnyMessage = ConsumerMessageType>(

--- a/src/packages/emmett-postgresql/src/eventStore/schema/readLastMessageCheckpoint.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/readLastMessageCheckpoint.ts
@@ -35,3 +35,28 @@ export const readLastMessageCheckpoint = async (
         : null,
   };
 };
+
+export const readLastCommittedMessageCheckpoint = async (
+  execute: SQLExecutor,
+  options?: { partition?: string },
+): Promise<ReadLastMessageCheckpointResult> => {
+  const result = await singleOrNull(
+    execute.query<ReadLastMessageCheckpointSqlResult>(
+      SQL`SELECT transaction_id, global_position
+           FROM ${SQL.identifier(messagesTable.name)}
+           WHERE partition = ${options?.partition ?? defaultTag} AND is_archived = FALSE
+           ORDER BY transaction_id DESC, global_position DESC
+           LIMIT 1`,
+    ),
+  );
+
+  return {
+    currentCheckpoint:
+      result !== null
+        ? {
+            transactionId: BigInt(result.transaction_id),
+            globalPosition: BigInt(result.global_position),
+          }
+        : null,
+  };
+};

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.awaiters.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.awaiters.int.spec.ts
@@ -1,0 +1,198 @@
+import { JSONSerializer } from '@event-driven-io/dumbo';
+import {
+  sqlite3Connection,
+  sqlite3Pool,
+  type SQLite3Connection,
+  type SQLitePool,
+} from '@event-driven-io/dumbo/sqlite3';
+import {
+  assertThatArray,
+  assertRejects,
+  bigIntProcessorCheckpoint,
+  type Event,
+} from '@event-driven-io/emmett';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { v4 as uuid } from 'uuid';
+import { afterEach, beforeEach, describe, it } from 'vitest';
+import {
+  sqlite3EventStoreDriver,
+  type SQLite3EventStoreOptions,
+} from '../../sqlite3';
+import { createEventStoreSchema } from '../schema';
+import {
+  getSQLiteEventStore,
+  type SQLiteEventStore,
+} from '../SQLiteEventStore';
+import { sqliteEventStoreConsumer } from './sqliteEventStoreConsumer';
+
+type GuestStayEvent = Event<
+  'GuestCheckedIn' | 'GuestCheckedOut',
+  { guestId: string }
+>;
+
+const withDeadline = { timeout: 30000 };
+
+void describe('waiting for a SQLite consumer to catch up in a test', () => {
+  const testDatabasePath = path.dirname(fileURLToPath(import.meta.url));
+  const fileName = path.resolve(testDatabasePath, `awaiters.test.db`);
+
+  let pool: SQLitePool<SQLite3Connection>;
+
+  const config: SQLite3EventStoreOptions = {
+    driver: sqlite3EventStoreDriver,
+    schema: { autoMigration: 'None' },
+    fileName,
+  };
+
+  let eventStore: SQLiteEventStore;
+
+  beforeEach(() => {
+    pool = sqlite3Pool({
+      fileName,
+      transactionOptions: { allowNestedTransactions: true },
+    });
+    eventStore = getSQLiteEventStore({ ...config, pool });
+    return createEventStoreSchema(
+      sqlite3Connection({ fileName, serializer: JSONSerializer }),
+    );
+  });
+
+  afterEach(async () => {
+    await eventStore.close();
+    await pool.close();
+    if (!fs.existsSync(fileName)) return;
+    try {
+      fs.unlinkSync(fileName);
+      fs.unlinkSync(`${fileName}-shm`);
+      fs.unlinkSync(`${fileName}-wal`);
+    } catch (error) {
+      console.log(error);
+    }
+  });
+
+  void it(
+    'lets a test append after start and assert once the consumer has caught up',
+    withDeadline,
+    async () => {
+      // Given
+      const processed: GuestStayEvent[] = [];
+      const consumer = sqliteEventStoreConsumer({
+        driver: sqlite3EventStoreDriver,
+        fileName,
+      });
+      consumer.reactor<GuestStayEvent>({
+        processorId: uuid(),
+        eachMessage: (event) => {
+          processed.push(event);
+        },
+      });
+
+      const guestId = uuid();
+      const events: GuestStayEvent[] = [
+        { type: 'GuestCheckedIn', data: { guestId } },
+        { type: 'GuestCheckedOut', data: { guestId } },
+      ];
+
+      let consumerPromise: Promise<void> | undefined;
+      try {
+        // When
+        consumerPromise = consumer.start();
+        await consumer.whenStarted();
+
+        await eventStore.appendToStream(`guestStay-${guestId}`, events);
+
+        await consumer.whenCaughtUp();
+
+        // Then
+        assertThatArray(processed).containsElementsMatching(events);
+      } finally {
+        await consumer.close();
+        await consumerPromise;
+      }
+    },
+  );
+
+  void it(
+    'lets a test wait for a specific appended position',
+    withDeadline,
+    async () => {
+      // Given
+      const processed: GuestStayEvent[] = [];
+      const consumer = sqliteEventStoreConsumer({
+        driver: sqlite3EventStoreDriver,
+        fileName,
+      });
+      consumer.reactor<GuestStayEvent>({
+        processorId: uuid(),
+        eachMessage: (event) => {
+          processed.push(event);
+        },
+      });
+
+      const guestId = uuid();
+      const events: GuestStayEvent[] = [
+        { type: 'GuestCheckedIn', data: { guestId } },
+        { type: 'GuestCheckedOut', data: { guestId } },
+      ];
+
+      let consumerPromise: Promise<void> | undefined;
+      try {
+        // When
+        consumerPromise = consumer.start();
+        await consumer.whenStarted();
+
+        const appendResult = await eventStore.appendToStream(
+          `guestStay-${guestId}`,
+          events,
+        );
+
+        await consumer.whenProcessed(appendResult.lastEventGlobalPosition);
+
+        // Then
+        assertThatArray(processed).containsElementsMatching(events);
+      } finally {
+        await consumer.close();
+        await consumerPromise;
+      }
+    },
+  );
+
+  void it(
+    'fails fast with a clear error instead of hanging when the point is never reached',
+    withDeadline,
+    async () => {
+      // Given
+      const consumer = sqliteEventStoreConsumer({
+        driver: sqlite3EventStoreDriver,
+        fileName,
+      });
+      consumer.reactor<GuestStayEvent>({
+        processorId: uuid(),
+        eachMessage: () => {},
+      });
+
+      const guestId = uuid();
+      await eventStore.appendToStream(`guestStay-${guestId}`, [
+        { type: 'GuestCheckedIn', data: { guestId } },
+      ]);
+
+      let consumerPromise: Promise<void> | undefined;
+      try {
+        consumerPromise = consumer.start();
+        await consumer.whenStarted();
+
+        // When / Then - a position far past the tail is never reached
+        await assertRejects(
+          consumer.whenProcessed(bigIntProcessorCheckpoint(9_999_999_999n), {
+            timeout: 200,
+          }),
+        );
+      } finally {
+        await consumer.close();
+        await consumerPromise;
+      }
+    },
+  );
+});

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.handling.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.handling.int.spec.ts
@@ -159,7 +159,6 @@ void describe('SQLite event store started consumer', () => {
         // Given
 
         const result: GuestStayEvent[] = [];
-        const resultReachedEnd = asyncAwaiter();
 
         // When
         const consumer = sqliteEventStoreConsumer({
@@ -170,11 +169,6 @@ void describe('SQLite event store started consumer', () => {
           processorId: uuid(),
           eachMessage: (event) => {
             result.push(event);
-            if (
-              event.type === 'GuestCheckedOut' &&
-              event.data.guestId === guestId
-            )
-              resultReachedEnd.resolve();
           },
         });
 
@@ -188,10 +182,11 @@ void describe('SQLite event store started consumer', () => {
         let consumerPromise: Promise<void> | undefined;
         try {
           consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
           await eventStore.appendToStream(streamName, events);
 
-          await resultReachedEnd.wait;
+          await consumer.whenCaughtUp();
 
           assertThatArray(result).containsElementsMatching(events);
         } finally {
@@ -248,6 +243,7 @@ void describe('SQLite event store started consumer', () => {
         let consumerPromise: Promise<void> | undefined;
         try {
           consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
           await eventStore.appendToStream(streamName, events);
 
@@ -283,7 +279,6 @@ void describe('SQLite event store started consumer', () => {
         ];
 
         const result: GuestStayEvent[] = [];
-        const resultReachedEnd = asyncAwaiter();
 
         // When
         const consumer = sqliteEventStoreConsumer({
@@ -295,21 +290,17 @@ void describe('SQLite event store started consumer', () => {
           startFrom: 'CURRENT',
           eachMessage: (event) => {
             result.push(event);
-            if (
-              event.type === 'GuestCheckedOut' &&
-              event.data.guestId === otherGuestId
-            )
-              resultReachedEnd.resolve();
           },
         });
 
         let consumerPromise: Promise<void> | undefined;
         try {
           consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
           await eventStore.appendToStream(streamName, events);
 
-          await resultReachedEnd.wait;
+          await consumer.whenCaughtUp();
 
           assertThatArray(result).containsElementsMatching([
             ...initialEvents,
@@ -345,8 +336,6 @@ void describe('SQLite event store started consumer', () => {
 
           const fromBeginning: GuestStayEvent[] = [];
           const fromEnd: GuestStayEvent[] = [];
-          const beginningReachedEnd = asyncAwaiter();
-          const endReachedEnd = asyncAwaiter();
 
           // When
           const consumer = sqliteEventStoreConsumer({
@@ -358,11 +347,6 @@ void describe('SQLite event store started consumer', () => {
             startFrom: 'BEGINNING',
             eachMessage: (event) => {
               fromBeginning.push(event);
-              if (
-                event.type === 'GuestCheckedOut' &&
-                event.data.guestId === otherGuestId
-              )
-                beginningReachedEnd.resolve();
             },
           });
           consumer.reactor<GuestStayEvent>({
@@ -370,11 +354,6 @@ void describe('SQLite event store started consumer', () => {
             startFrom: 'END',
             eachMessage: (event) => {
               fromEnd.push(event);
-              if (
-                event.type === 'GuestCheckedOut' &&
-                event.data.guestId === otherGuestId
-              )
-                endReachedEnd.resolve();
             },
           });
 
@@ -385,7 +364,7 @@ void describe('SQLite event store started consumer', () => {
 
             await eventStore.appendToStream(streamName, newEvents);
 
-            await Promise.all([beginningReachedEnd.wait, endReachedEnd.wait]);
+            await consumer.whenCaughtUp();
 
             // Then the BEGINNING processor sees the whole history,
             // while the END processor sees only messages appended after start
@@ -502,8 +481,6 @@ void describe('SQLite event store started consumer', () => {
 
           const firstEnd: GuestStayEvent[] = [];
           const secondEnd: GuestStayEvent[] = [];
-          const firstReachedEnd = asyncAwaiter();
-          const secondReachedEnd = asyncAwaiter();
 
           const consumer = sqliteEventStoreConsumer({
             driver: sqlite3EventStoreDriver,
@@ -514,11 +491,6 @@ void describe('SQLite event store started consumer', () => {
             startFrom: 'END',
             eachMessage: (event) => {
               firstEnd.push(event);
-              if (
-                event.type === 'GuestCheckedOut' &&
-                event.data.guestId === otherGuestId
-              )
-                firstReachedEnd.resolve();
             },
           });
           consumer.reactor<GuestStayEvent>({
@@ -526,11 +498,6 @@ void describe('SQLite event store started consumer', () => {
             startFrom: 'END',
             eachMessage: (event) => {
               secondEnd.push(event);
-              if (
-                event.type === 'GuestCheckedOut' &&
-                event.data.guestId === otherGuestId
-              )
-                secondReachedEnd.resolve();
             },
           });
 
@@ -541,7 +508,7 @@ void describe('SQLite event store started consumer', () => {
 
             await eventStore.appendToStream(streamName, newEvents);
 
-            await Promise.all([firstReachedEnd.wait, secondReachedEnd.wait]);
+            await consumer.whenCaughtUp();
 
             assertThatArray(firstEnd).containsOnlyElementsMatching(newEvents);
             assertThatArray(secondEnd).containsOnlyElementsMatching(newEvents);
@@ -574,7 +541,6 @@ void describe('SQLite event store started consumer', () => {
         ];
 
         const fromEnd: GuestStayEvent[] = [];
-        const reachedEnd = asyncAwaiter();
 
         const consumer = sqliteEventStoreConsumer({
           driver: sqlite3EventStoreDriver,
@@ -585,11 +551,6 @@ void describe('SQLite event store started consumer', () => {
           startFrom: 'END',
           eachMessage: (event) => {
             fromEnd.push(event);
-            if (
-              event.type === 'GuestCheckedOut' &&
-              event.data.guestId === otherGuestId
-            )
-              reachedEnd.resolve();
           },
         });
 
@@ -601,7 +562,7 @@ void describe('SQLite event store started consumer', () => {
           await eventStore.appendToStream(streamName, firstAppend);
           await eventStore.appendToStream(streamName, secondAppend);
 
-          await reachedEnd.wait;
+          await consumer.whenCaughtUp();
 
           assertThatArray(fromEnd).containsOnlyElementsMatching([
             ...firstAppend,
@@ -642,8 +603,6 @@ void describe('SQLite event store started consumer', () => {
 
           const firstRun: GuestStayEvent[] = [];
           const secondRun: GuestStayEvent[] = [];
-          const firstRunReachedEnd = asyncAwaiter();
-          const secondRunReachedEnd = asyncAwaiter();
 
           const firstConsumer = sqliteEventStoreConsumer({
             driver: sqlite3EventStoreDriver,
@@ -655,11 +614,6 @@ void describe('SQLite event store started consumer', () => {
             checkpoints: 'DISABLED',
             eachMessage: (event) => {
               firstRun.push(event);
-              if (
-                event.type === 'GuestCheckedOut' &&
-                event.data.guestId === otherGuestId
-              )
-                firstRunReachedEnd.resolve();
             },
           });
           let firstConsumerPromise: Promise<void> | undefined;
@@ -667,7 +621,7 @@ void describe('SQLite event store started consumer', () => {
             firstConsumerPromise = firstConsumer.start();
             await firstConsumer.whenStarted();
             await eventStore.appendToStream(streamName, firstNewEvents);
-            await firstRunReachedEnd.wait;
+            await firstConsumer.whenCaughtUp();
           } finally {
             await firstConsumer.close();
             await firstConsumerPromise;
@@ -683,11 +637,6 @@ void describe('SQLite event store started consumer', () => {
             checkpoints: 'DISABLED',
             eachMessage: (event) => {
               secondRun.push(event);
-              if (
-                event.type === 'GuestCheckedOut' &&
-                event.data.guestId === thirdGuestId
-              )
-                secondRunReachedEnd.resolve();
             },
           });
           let secondConsumerPromise: Promise<void> | undefined;
@@ -695,7 +644,7 @@ void describe('SQLite event store started consumer', () => {
             secondConsumerPromise = secondConsumer.start();
             await secondConsumer.whenStarted();
             await eventStore.appendToStream(streamName, secondNewEvents);
-            await secondRunReachedEnd.wait;
+            await secondConsumer.whenCaughtUp();
           } finally {
             await secondConsumer.close();
             await secondConsumerPromise;
@@ -742,8 +691,6 @@ void describe('SQLite event store started consumer', () => {
         ];
 
         let result: GuestStayEvent[] = [];
-        let stopAfterPosition: string | undefined = startPosition;
-        const restartReachedEnd = asyncAwaiter();
 
         // When
         const consumer = sqliteEventStoreConsumer({
@@ -753,15 +700,9 @@ void describe('SQLite event store started consumer', () => {
         consumer.reactor<GuestStayEvent>({
           processorId: uuid(),
           startFrom: 'CURRENT',
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
+          stopAfter: (event) => event.metadata.globalPosition === startPosition,
           eachMessage: (event) => {
             result.push(event);
-            if (
-              event.type === 'GuestCheckedOut' &&
-              event.data.guestId === otherGuestId
-            )
-              restartReachedEnd.resolve();
           },
         });
 
@@ -770,15 +711,14 @@ void describe('SQLite event store started consumer', () => {
 
         result = [];
 
-        stopAfterPosition = undefined;
-
         let consumerPromise: Promise<void> | undefined;
         try {
           consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
           await eventStore.appendToStream(streamName, events);
 
-          await restartReachedEnd.wait;
+          await consumer.whenCaughtUp();
 
           assertThatArray(result).containsOnlyElementsMatching(events);
         } finally {
@@ -810,21 +750,13 @@ void describe('SQLite event store started consumer', () => {
         ];
 
         let result: GuestStayEvent[] = [];
-        let stopAfterPosition: string | undefined = startPosition;
-        const newConsumerReachedEnd = asyncAwaiter();
 
         const processorOptions: SQLiteReactorOptions<GuestStayEvent> = {
           processorId: uuid(),
           startFrom: 'CURRENT',
-          stopAfter: (event) =>
-            event.metadata.globalPosition === stopAfterPosition,
+          stopAfter: (event) => event.metadata.globalPosition === startPosition,
           eachMessage: (event) => {
             result.push(event);
-            if (
-              event.type === 'GuestCheckedOut' &&
-              event.data.guestId === otherGuestId
-            )
-              newConsumerReachedEnd.resolve();
           },
         };
 
@@ -843,8 +775,6 @@ void describe('SQLite event store started consumer', () => {
 
         result = [];
 
-        stopAfterPosition = undefined;
-
         const newConsumer = sqliteEventStoreConsumer({
           driver: sqlite3EventStoreDriver,
           fileName,
@@ -854,10 +784,11 @@ void describe('SQLite event store started consumer', () => {
         let consumerPromise: Promise<void> | undefined;
         try {
           consumerPromise = newConsumer.start();
+          await newConsumer.whenStarted();
 
           await eventStore.appendToStream(streamName, events);
 
-          await newConsumerReachedEnd.wait;
+          await newConsumer.whenCaughtUp();
 
           assertThatArray(result).containsOnlyElementsMatching(events);
         } finally {
@@ -888,7 +819,6 @@ void describe('SQLite event store started consumer', () => {
         ];
 
         const result: GuestStayEvent[] = [];
-        const reachedEnd = asyncAwaiter();
 
         // When
         const consumer = sqliteEventStoreConsumer({
@@ -900,11 +830,6 @@ void describe('SQLite event store started consumer', () => {
           startFrom: 'END',
           eachMessage: (event) => {
             result.push(event);
-            if (
-              event.type === 'GuestCheckedOut' &&
-              event.data.guestId === otherGuestId
-            )
-              reachedEnd.resolve();
           },
         });
 
@@ -915,7 +840,7 @@ void describe('SQLite event store started consumer', () => {
 
           await eventStore.appendToStream(streamName, events);
 
-          await reachedEnd.wait;
+          await consumer.whenCaughtUp();
 
           assertThatArray(result).containsOnlyElementsMatching(events);
         } catch (error) {
@@ -941,7 +866,6 @@ void describe('SQLite event store started consumer', () => {
         ];
 
         const result: GuestStayEvent[] = [];
-        const reachedEnd = asyncAwaiter();
 
         // When
         const consumer = sqliteEventStoreConsumer({
@@ -953,11 +877,6 @@ void describe('SQLite event store started consumer', () => {
           startFrom: 'END',
           eachMessage: (event) => {
             result.push(event);
-            if (
-              event.type === 'GuestCheckedOut' &&
-              event.data.guestId === guestId
-            )
-              reachedEnd.resolve();
           },
         });
 
@@ -968,7 +887,7 @@ void describe('SQLite event store started consumer', () => {
 
           await eventStore.appendToStream(streamName, events);
 
-          await reachedEnd.wait;
+          await consumer.whenCaughtUp();
 
           assertThatArray(result).containsElementsMatching(events);
         } finally {
@@ -1000,8 +919,6 @@ void describe('SQLite event store started consumer', () => {
         ];
 
         let result: GuestStayEvent[] = [];
-        const firstRunReachedEnd = asyncAwaiter();
-        const secondRunReachedEnd = asyncAwaiter();
 
         const consumer = sqliteEventStoreConsumer({
           driver: sqlite3EventStoreDriver,
@@ -1012,12 +929,6 @@ void describe('SQLite event store started consumer', () => {
           startFrom: 'END',
           eachMessage: (event) => {
             result.push(event);
-            if (event.type === 'GuestCheckedOut') {
-              if (event.data.guestId === otherGuestId)
-                firstRunReachedEnd.resolve();
-              if (event.data.guestId === thirdGuestId)
-                secondRunReachedEnd.resolve();
-            }
           },
         });
 
@@ -1026,7 +937,7 @@ void describe('SQLite event store started consumer', () => {
         await consumer.whenStarted();
 
         await eventStore.appendToStream(streamName, firstBatch);
-        await firstRunReachedEnd.wait;
+        await consumer.whenCaughtUp();
         await consumer.stop();
         await firstConsumerPromise;
 
@@ -1041,10 +952,11 @@ void describe('SQLite event store started consumer', () => {
         let secondConsumerPromise: Promise<void> | undefined;
         try {
           secondConsumerPromise = consumer.start();
+          await consumer.whenStarted();
 
           await eventStore.appendToStream(streamName, secondBatch);
 
-          await secondRunReachedEnd.wait;
+          await consumer.whenCaughtUp();
 
           assertThatArray(result).containsOnlyElementsMatching(secondBatch);
         } finally {
@@ -1063,8 +975,6 @@ void describe('SQLite event store started consumer', () => {
         const expectedCount = concurrentStreams * 2;
         const projectionResult: GuestStayEvent[] = [];
         const forwarderResult: GuestStayEvent[] = [];
-        const projectionReachedEnd = asyncAwaiter();
-        const forwarderReachedEnd = asyncAwaiter();
 
         const consumer = sqliteEventStoreConsumer({
           driver: sqlite3EventStoreDriver,
@@ -1081,8 +991,6 @@ void describe('SQLite event store started consumer', () => {
           eachMessage: (event) => {
             if (guestIds.includes(event.data.guestId)) {
               projectionResult.push(event);
-              if (projectionResult.length === expectedCount)
-                projectionReachedEnd.resolve();
             }
           },
         });
@@ -1092,8 +1000,6 @@ void describe('SQLite event store started consumer', () => {
           eachMessage: (event) => {
             if (guestIds.includes(event.data.guestId)) {
               forwarderResult.push(event);
-              if (forwarderResult.length === expectedCount)
-                forwarderReachedEnd.resolve();
             }
           },
         });
@@ -1102,6 +1008,7 @@ void describe('SQLite event store started consumer', () => {
         let consumerPromise: Promise<void> | undefined;
         try {
           consumerPromise = consumer.start();
+          await consumer.whenStarted();
 
           await Promise.all(
             guestIds.map((guestId) =>
@@ -1114,10 +1021,7 @@ void describe('SQLite event store started consumer', () => {
             ),
           );
 
-          await Promise.all([
-            projectionReachedEnd.wait,
-            forwarderReachedEnd.wait,
-          ]);
+          await consumer.whenCaughtUp();
 
           // Then
           assertThatArray(projectionResult).hasSize(expectedCount);

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.int.spec.ts
@@ -31,6 +31,7 @@ void describe('SQLite event store consumer', () => {
     close: () => Promise.resolve(),
     handle: () => Promise.resolve(),
     isActive: false,
+    whenProcessed: () => Promise.resolve(),
   };
 
   let connection: SQLite3Connection;

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.ts
@@ -18,7 +18,9 @@ import {
   type MessageConsumerOptions,
   type MessageHandlerContext,
   type MessageProcessor,
+  type ProcessorCheckpoint,
   type ReadEventMetadataWithGlobalPosition,
+  type WaitOptions,
   type WorkflowProcessorContext,
 } from '@event-driven-io/emmett';
 import { v7 as uuid } from 'uuid';
@@ -72,6 +74,12 @@ export type SQLiteEventStoreConsumer<
   ConsumerMessageType extends AnyMessage = any,
 > = MessageConsumer<ConsumerMessageType> &
   Readonly<{
+    whenProcessed: (
+      position: ProcessorCheckpoint,
+      options?: WaitOptions,
+    ) => Promise<void>;
+    whenCaughtUp: (options?: WaitOptions) => Promise<void>;
+
     reactor: <MessageType extends AnyMessage = ConsumerMessageType>(
       options: SQLiteReactorOptions<MessageType>,
     ) => SQLiteProcessor<MessageType>;
@@ -188,6 +196,26 @@ export const sqliteEventStoreConsumer = <
       return isRunning;
     },
     whenStarted: (): Promise<void> => startedAwaiter.wait,
+    whenProcessed: (position, options): Promise<void> =>
+      Promise.all(
+        processors.map((p) => p.whenProcessed(position, options)),
+      ).then(() => undefined),
+    whenCaughtUp: async (options): Promise<void> => {
+      const tail = await pool.withConnection(async (connection) => {
+        const { currentGlobalPosition } = await readLastMessageGlobalPosition(
+          connection.execute,
+        );
+        return currentGlobalPosition;
+      });
+
+      if (tail === null) return;
+
+      await Promise.all(
+        processors.map((p) =>
+          p.whenProcessed(bigIntProcessorCheckpoint(tail), options),
+        ),
+      );
+    },
     processors,
     init,
     reactor: <MessageType extends AnyMessage = ConsumerMessageType>(

--- a/src/packages/emmett-tests/src/errorHandling/sqliteReactorErrors.int.spec.ts
+++ b/src/packages/emmett-tests/src/errorHandling/sqliteReactorErrors.int.spec.ts
@@ -4,11 +4,11 @@ import {
   sqliteEventStoreConsumer,
 } from '@event-driven-io/emmett-sqlite';
 import { sqlite3EventStoreDriver } from '@event-driven-io/emmett-sqlite/sqlite3';
-import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { v4 as uuid } from 'uuid';
 import { describe } from 'vitest';
+import { deleteSQLiteDatabaseFiles } from '../testing/sqliteTestDatabase';
 import {
   testReactorRecordsFailureAsEvent,
   testReactorSkipsAndStops,
@@ -46,10 +46,7 @@ const sqliteConsumerFactory: ConsumerFactory = () => {
     teardown: async () => {
       await eventStore.close();
       await pool.close();
-      for (const suffix of ['', '-shm', '-wal']) {
-        const file = `${fileName}${suffix}`;
-        if (fs.existsSync(file)) fs.unlinkSync(file);
-      }
+      deleteSQLiteDatabaseFiles(fileName);
     },
   });
 };

--- a/src/packages/emmett-tests/src/testing/sqliteTestDatabase.ts
+++ b/src/packages/emmett-tests/src/testing/sqliteTestDatabase.ts
@@ -1,0 +1,13 @@
+import fs from 'fs';
+
+export const deleteSQLiteDatabaseFiles = (fileName: string): void => {
+  for (const file of [fileName, `${fileName}-shm`, `${fileName}-wal`]) {
+    if (!fs.existsSync(file)) continue;
+
+    try {
+      fs.unlinkSync(file);
+    } catch (error) {
+      console.log(error);
+    }
+  }
+};

--- a/src/packages/emmett/src/consumers/consumers.ts
+++ b/src/packages/emmett/src/consumers/consumers.ts
@@ -6,6 +6,26 @@ import type {
 import type { Message } from '../typing';
 import type { ConsumerObservabilityConfig } from './observability';
 
+/**
+ * Condition that makes a running consumer stop on its own. Keys are OR-ed:
+ * the consumer stops as soon as the first satisfied condition is met.
+ *
+ * - `noMessagesLeft` - stop once a poll finds nothing left to process, even
+ *   while the tail keeps moving (drains a live stream, e.g. blue-green
+ *   projection rebuilds).
+ * - `caughtUp` - stop once every processor reaches the store tail as of the
+ *   start call (a bounded snapshot).
+ */
+export type MessageConsumerUntilCondition = {
+  noMessagesLeft?: boolean;
+  caughtUp?: boolean;
+};
+
+export type MessageConsumerStartOptions = {
+  until?: MessageConsumerUntilCondition;
+  timeout?: number;
+};
+
 export type MessageConsumerOptions<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ConsumerMessageType extends Message = any,
@@ -14,6 +34,8 @@ export type MessageConsumerOptions<
   observability?: ConsumerObservabilityConfig;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   processors?: Array<MessageProcessor<ConsumerMessageType, any, any>>;
+  until?: MessageConsumerUntilCondition;
+  defaultTimeout?: number;
 };
 
 export type MessageConsumer<

--- a/src/packages/emmett/src/consumers/consumers.ts
+++ b/src/packages/emmett/src/consumers/consumers.ts
@@ -1,4 +1,8 @@
-import type { MessageProcessor } from '../processors';
+import type {
+  MessageProcessor,
+  ProcessorCheckpoint,
+  WaitOptions,
+} from '../processors';
 import type { Message } from '../typing';
 import type { ConsumerObservabilityConfig } from './observability';
 
@@ -19,6 +23,31 @@ export type MessageConsumer<
   consumerId: string;
   isRunning: boolean;
   whenStarted: () => Promise<void>;
+  /**
+   * Resolves once every processor has processed up to the given position,
+   * typically an append result's `lastEventGlobalPosition`. Resolves
+   * immediately when that point was already processed, so a test can append
+   * and then wait without racing the poller. Rejects on
+   * {@link WaitOptions.timeout}.
+   *
+   * Available on stores that expose an ordered global position (SQLite,
+   * PostgreSQL). Stores without one (e.g. MongoDB change streams) may leave it
+   * undefined.
+   */
+  whenProcessed?: (
+    position: ProcessorCheckpoint,
+    options?: WaitOptions,
+  ) => Promise<void>;
+  /**
+   * Resolves once every processor has processed up to the store's tail as of
+   * the call. The everyday test wait: start, append, `whenCaughtUp`, assert.
+   * Rejects on {@link WaitOptions.timeout}.
+   *
+   * Available on stores that expose an ordered global position (SQLite,
+   * PostgreSQL). Stores without one (e.g. MongoDB change streams) may leave it
+   * undefined.
+   */
+  whenCaughtUp?: (options?: WaitOptions) => Promise<void>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   processors: ReadonlyArray<MessageProcessor<ConsumerMessageType, any, any>>;
   start: () => Promise<void>;

--- a/src/packages/emmett/src/processors/checkpoints.ts
+++ b/src/packages/emmett/src/processors/checkpoints.ts
@@ -30,7 +30,7 @@ export const ProcessorCheckpoint = Object.assign(
     isEnd: (checkpoint: ProcessorCheckpoint | undefined): checkpoint is END =>
       checkpoint === 'END',
     compare: (a: ProcessorCheckpoint, b: ProcessorCheckpoint) =>
-      a > b ? 1 : -1,
+      a > b ? 1 : a < b ? -1 : 0,
   } as const,
 );
 

--- a/src/packages/emmett/src/processors/checkpoints.unit.spec.ts
+++ b/src/packages/emmett/src/processors/checkpoints.unit.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it } from 'vitest';
+import { assertEqual } from '../testing';
+import { ProcessorCheckpoint } from './checkpoints';
+
+void describe('ProcessorCheckpoint.compare', () => {
+  const a = ProcessorCheckpoint('1');
+  const b = ProcessorCheckpoint('2');
+
+  void it('returns a negative number when the first is lower', () => {
+    assertEqual(ProcessorCheckpoint.compare(a, b) < 0, true);
+  });
+
+  void it('returns a positive number when the first is higher', () => {
+    assertEqual(ProcessorCheckpoint.compare(b, a) > 0, true);
+  });
+
+  void it('returns 0 when the checkpoints are equal', () => {
+    assertEqual(ProcessorCheckpoint.compare(a, ProcessorCheckpoint('1')), 0);
+  });
+});

--- a/src/packages/emmett/src/processors/processorStartPositions.ts
+++ b/src/packages/emmett/src/processors/processorStartPositions.ts
@@ -5,7 +5,7 @@ import type {
   MessageHandlerContext,
   RecordedMessage,
 } from '../typing';
-import { getCheckpoint, type ProcessorCheckpoint } from './checkpoints';
+import { getCheckpoint, ProcessorCheckpoint } from './checkpoints';
 import {
   CurrentMessageProcessorPosition,
   type MessageProcessor,
@@ -77,10 +77,15 @@ export const ProcessorStartPositions = (
         return messages;
 
       const { lastCheckpoint } = position;
+      const compareCheckpoints =
+        options?.compareCheckpoints ?? ProcessorCheckpoint.compare;
 
       return messages.filter((message) => {
         const checkpoint = getCheckpoint(message);
-        return checkpoint !== null && checkpoint > lastCheckpoint;
+        return (
+          checkpoint !== null &&
+          compareCheckpoints(checkpoint, lastCheckpoint) > 0
+        );
       });
     },
   };

--- a/src/packages/emmett/src/processors/processorStartPositions.unit.spec.ts
+++ b/src/packages/emmett/src/processors/processorStartPositions.unit.spec.ts
@@ -5,7 +5,7 @@ import type {
   MessageHandlerContext,
   RecordedMessage,
 } from '../typing';
-import { bigIntProcessorCheckpoint } from './checkpoints';
+import { bigIntProcessorCheckpoint, ProcessorCheckpoint } from './checkpoints';
 import {
   ConsumerStartPositions,
   ProcessorStartPositions,
@@ -19,6 +19,19 @@ const messageAt = (checkpoint: bigint): RecordedMessage =>
   ({
     metadata: { checkpoint: bigIntProcessorCheckpoint(checkpoint) },
   }) as unknown as RecordedMessage;
+
+const rawMessageAt = (checkpoint: string): RecordedMessage =>
+  ({
+    metadata: { checkpoint: ProcessorCheckpoint(checkpoint) },
+  }) as unknown as RecordedMessage;
+
+const numericCompareCheckpoints = (
+  a: ProcessorCheckpoint,
+  b: ProcessorCheckpoint,
+): number => {
+  const [left, right] = [BigInt(a), BigInt(b)];
+  return left > right ? 1 : left < right ? -1 : 0;
+};
 
 void describe('processorStartPositions', () => {
   void describe('zip', () => {
@@ -211,6 +224,19 @@ void describe('processorStartPositions', () => {
         startPositions.afterStartPosition('a', messages),
         messages,
       );
+    });
+
+    void it('uses the provided comparator to decide what is above the checkpoint', () => {
+      const startPositions = ProcessorStartPositions({
+        compareCheckpoints: numericCompareCheckpoints,
+      });
+      startPositions.set('a', { lastCheckpoint: ProcessorCheckpoint('9') });
+
+      const messages = [rawMessageAt('9'), rawMessageAt('10')];
+
+      assertDeepEqual(startPositions.afterStartPosition('a', messages), [
+        rawMessageAt('10'),
+      ]);
     });
   });
 });

--- a/src/packages/emmett/src/processors/processors.ts
+++ b/src/packages/emmett/src/processors/processors.ts
@@ -583,17 +583,6 @@ export const reactor = <
           await hooks.onStart(context);
         }
 
-        if (startFrom !== undefined && typeof startFrom !== 'string') {
-          lastCheckpoint = startFrom.lastCheckpoint;
-          lastStoredCheckpoint = startFrom.lastCheckpoint;
-          log(
-            info(
-              `Processor ${processorId} with instance id ${instanceId} starting from: ${JSONSerializer.serialize(startFrom)}`,
-            ),
-          );
-          return startFrom;
-        }
-
         if (checkpointer) {
           const readResult = await checkpointer.read(
             {
@@ -603,6 +592,16 @@ export const reactor = <
             { ...startOptions, ...context },
           );
           lastStoredCheckpoint = readResult.lastCheckpoint;
+        }
+
+        if (startFrom !== undefined && typeof startFrom !== 'string') {
+          lastCheckpoint = startFrom.lastCheckpoint;
+          log(
+            info(
+              `Processor ${processorId} with instance id ${instanceId} starting from: ${JSONSerializer.serialize(startFrom)}`,
+            ),
+          );
+          return startFrom;
         }
 
         if (startFrom === 'BEGINNING' || startFrom === 'END') {
@@ -662,7 +661,7 @@ export const reactor = <
         messages,
         async (scope) => {
           try {
-            return await processingScope(
+            const result = await processingScope(
               async (context) => {
                 const messagesAboveCheckpoint = messages.filter(
                   (message) =>
@@ -747,7 +746,6 @@ export const reactor = <
                     // TODO: Add correct handling of the storing checkpoint
                     lastCheckpoint = storeCheckpointResult.newCheckpoint;
                     lastStoredCheckpoint = storeCheckpointResult.newCheckpoint;
-                    notifyCheckpointWaiters();
                   }
                 }
 
@@ -765,6 +763,10 @@ export const reactor = <
               },
               { ...partialContext, observabilityScope: scope },
             );
+
+            if (result?.type !== 'STOP') notifyCheckpointWaiters();
+
+            return result;
           } catch (err) {
             scope.log(
               error(

--- a/src/packages/emmett/src/processors/processors.ts
+++ b/src/packages/emmett/src/processors/processors.ts
@@ -1,7 +1,7 @@
 import { LogEvent, noopScope } from '@event-driven-io/almanac';
 import { v7 as uuid } from 'uuid';
 import type { ProcessorObservabilityConfig } from '.';
-import type { EmmettError } from '../errors';
+import { EmmettError } from '../errors';
 import { upcastRecordedMessage } from '../eventStore';
 import type { WithObservabilityScope } from '../observability';
 import { EmmettAttributes } from '../observability';
@@ -27,6 +27,7 @@ import {
   type SingleRecordedMessageHandlerWithContext,
 } from '../typing';
 import { onShutdown } from '../utils/lifecycle';
+import { asyncAwaiter } from '../utils/promises';
 import {
   getCheckpoint,
   type Checkpointer,
@@ -107,6 +108,35 @@ export const MessageProcessorType = {
   REACTOR: 'reactor' as MessageProcessorType,
 };
 
+export type WaitOptions = {
+  /**
+   * Maximum time to wait, in milliseconds. When it elapses before the
+   * awaited point is reached, the returned promise rejects with a descriptive
+   * {@link EmmettError} instead of hanging. Omit to wait indefinitely.
+   */
+  timeout?: number;
+};
+
+const raceWithTimeout = (
+  wait: Promise<void>,
+  timeout: number | undefined,
+  timeoutMessage: () => string,
+): Promise<void> => {
+  if (timeout === undefined) return wait;
+
+  let timer: ReturnType<typeof setTimeout>;
+  const timeoutPromise = new Promise<void>((_resolve, reject) => {
+    timer = setTimeout(
+      () => reject(new EmmettError(timeoutMessage())),
+      timeout,
+    );
+  });
+
+  return Promise.race([wait, timeoutPromise]).finally(() =>
+    clearTimeout(timer),
+  );
+};
+
 export type MessageProcessor<
   MessageType extends AnyMessage = AnyMessage,
   MessageMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
@@ -122,6 +152,16 @@ export type MessageProcessor<
   ) => Promise<CurrentMessageProcessorPosition | undefined>;
   close: (closeOptions?: Partial<HandlerContext>) => Promise<void>;
   isActive: boolean;
+  /**
+   * Resolves once the processor has stored a checkpoint at or past the given
+   * one. Resolves immediately when that point was already reached, so it never
+   * races an append that has already been processed. Rejects on
+   * {@link WaitOptions.timeout}.
+   */
+  whenProcessed: (
+    checkpoint: ProcessorCheckpoint,
+    options?: WaitOptions,
+  ) => Promise<void>;
   handle: BatchRecordedMessageHandlerWithContext<
     MessageType,
     MessageMetadataType,
@@ -387,6 +427,41 @@ export const reactor = <
   let lastCheckpoint: ProcessorCheckpoint | null = null;
   let closeSignal: (() => void) | null = null;
 
+  const checkpointWaiters = new Set<{
+    target: ProcessorCheckpoint;
+    resolve: () => void;
+  }>();
+
+  const hasProcessed = (target: ProcessorCheckpoint): boolean =>
+    lastCheckpoint !== null && lastCheckpoint >= target;
+
+  const notifyCheckpointWaiters = () => {
+    for (const waiter of checkpointWaiters) {
+      if (hasProcessed(waiter.target)) {
+        checkpointWaiters.delete(waiter);
+        waiter.resolve();
+      }
+    }
+  };
+
+  const whenProcessed = (
+    checkpoint: ProcessorCheckpoint,
+    options?: WaitOptions,
+  ): Promise<void> => {
+    if (hasProcessed(checkpoint)) return Promise.resolve();
+
+    const awaiter = asyncAwaiter<void>();
+    const waiter = { target: checkpoint, resolve: awaiter.resolve };
+    checkpointWaiters.add(waiter);
+
+    return raceWithTimeout(
+      awaiter.wait,
+      options?.timeout,
+      () =>
+        `Processor ${processorId} with instance id ${instanceId} did not process checkpoint ${checkpoint} within ${options!.timeout}ms (last processed checkpoint: ${lastCheckpoint ?? 'none'})`,
+    ).finally(() => checkpointWaiters.delete(waiter));
+  };
+
   const init = async (
     initOptions: WithObservabilityScope<Partial<HandlerContext>>,
   ): Promise<void> => {
@@ -555,6 +630,7 @@ export const reactor = <
     get isActive() {
       return isActive;
     },
+    whenProcessed,
     handle: async (
       messages: RecordedMessage<MessageType, MessageMetadataType>[],
       partialContext: Partial<HandlerContext>,
@@ -645,6 +721,7 @@ export const reactor = <
                   if (storeCheckpointResult.success) {
                     // TODO: Add correct handling of the storing checkpoint
                     lastCheckpoint = storeCheckpointResult.newCheckpoint;
+                    notifyCheckpointWaiters();
                   }
                 }
 

--- a/src/packages/emmett/src/processors/processors.ts
+++ b/src/packages/emmett/src/processors/processors.ts
@@ -30,8 +30,8 @@ import { onShutdown } from '../utils/lifecycle';
 import { asyncAwaiter } from '../utils/promises';
 import {
   getCheckpoint,
+  ProcessorCheckpoint,
   type Checkpointer,
-  type ProcessorCheckpoint,
   type StoreProcessorCheckpointResult,
 } from './checkpoints';
 import { inMemoryCheckpointer } from './inMemoryProcessors';
@@ -47,7 +47,7 @@ export const CurrentMessageProcessorPosition = {
     compareCheckpoints: (
       a: ProcessorCheckpoint,
       b: ProcessorCheckpoint,
-    ) => number = (chkA, chkB) => (chkA > chkB ? 1 : chkA < chkB ? -1 : 0),
+    ) => number = ProcessorCheckpoint.compare,
   ) => {
     if (a === b) return 0;
 
@@ -84,6 +84,10 @@ export const wasMessageHandled = <
 >(
   message: RecordedMessage<MessageType, MessageMetadataType>,
   checkpoint: ProcessorCheckpoint | null,
+  compareCheckpoints: (
+    a: ProcessorCheckpoint,
+    b: ProcessorCheckpoint,
+  ) => number = ProcessorCheckpoint.compare,
 ): boolean => {
   //TODO Make it smarter
   const messageCheckpoint = getCheckpoint(message);
@@ -93,7 +97,7 @@ export const wasMessageHandled = <
     messageCheckpoint !== undefined &&
     checkpoint !== null &&
     checkpoint !== undefined &&
-    messageCheckpoint <= checkpoint
+    compareCheckpoints(messageCheckpoint, checkpoint) <= 0
   );
 };
 
@@ -218,6 +222,10 @@ export type BaseMessageProcessorOptions<
   checkpoints?:
     Checkpointer<MessageType, MessageMetadataType, HandlerContext> | 'DISABLED';
   canHandle?: CanHandle<MessageType>;
+  compareCheckpoints?: (
+    a: ProcessorCheckpoint,
+    b: ProcessorCheckpoint,
+  ) => number;
   hooks?: ProcessorHooks<HandlerContext>;
 } & JSONSerializationOptions & {
     observability?: ProcessorObservabilityConfig;
@@ -343,6 +351,7 @@ export const reactor = <
     startFrom,
     canHandle,
     stopAfter,
+    compareCheckpoints = ProcessorCheckpoint.compare,
   } = options;
 
   const checkpointer =
@@ -433,7 +442,7 @@ export const reactor = <
   }>();
 
   const hasProcessed = (target: ProcessorCheckpoint): boolean =>
-    lastCheckpoint !== null && lastCheckpoint >= target;
+    lastCheckpoint !== null && compareCheckpoints(lastCheckpoint, target) >= 0;
 
   const notifyCheckpointWaiters = () => {
     for (const waiter of checkpointWaiters) {
@@ -645,7 +654,12 @@ export const reactor = <
             return await processingScope(
               async (context) => {
                 const messagesAboveCheckpoint = messages.filter(
-                  (message) => !wasMessageHandled(message, lastCheckpoint),
+                  (message) =>
+                    !wasMessageHandled(
+                      message,
+                      lastCheckpoint,
+                      compareCheckpoints,
+                    ),
                 );
 
                 const upcastedMessages = messagesAboveCheckpoint

--- a/src/packages/emmett/src/processors/processors.ts
+++ b/src/packages/emmett/src/processors/processors.ts
@@ -434,6 +434,7 @@ export const reactor = <
   let isActive = false;
 
   let lastCheckpoint: ProcessorCheckpoint | null = null;
+  let lastStoredCheckpoint: ProcessorCheckpoint | null = null;
   let closeSignal: (() => void) | null = null;
 
   const checkpointWaiters = new Set<{
@@ -582,10 +583,9 @@ export const reactor = <
           await hooks.onStart(context);
         }
 
-        if (startFrom !== undefined && startFrom !== 'CURRENT') {
-          if (typeof startFrom !== 'string') {
-            lastCheckpoint = startFrom.lastCheckpoint;
-          }
+        if (startFrom !== undefined && typeof startFrom !== 'string') {
+          lastCheckpoint = startFrom.lastCheckpoint;
+          lastStoredCheckpoint = startFrom.lastCheckpoint;
           log(
             info(
               `Processor ${processorId} with instance id ${instanceId} starting from: ${JSONSerializer.serialize(startFrom)}`,
@@ -602,8 +602,19 @@ export const reactor = <
             },
             { ...startOptions, ...context },
           );
-          lastCheckpoint = readResult.lastCheckpoint;
+          lastStoredCheckpoint = readResult.lastCheckpoint;
         }
+
+        if (startFrom === 'BEGINNING' || startFrom === 'END') {
+          log(
+            info(
+              `Processor ${processorId} with instance id ${instanceId} starting from: ${JSONSerializer.serialize(startFrom)}`,
+            ),
+          );
+          return startFrom;
+        }
+
+        lastCheckpoint = lastStoredCheckpoint;
 
         if (lastCheckpoint === null) {
           log(
@@ -726,7 +737,7 @@ export const reactor = <
                           MessageType,
                           MessageMetadataType
                         >,
-                        lastCheckpoint,
+                        lastCheckpoint: lastStoredCheckpoint,
                         partition,
                       },
                       context,
@@ -735,6 +746,7 @@ export const reactor = <
                   if (storeCheckpointResult.success) {
                     // TODO: Add correct handling of the storing checkpoint
                     lastCheckpoint = storeCheckpointResult.newCheckpoint;
+                    lastStoredCheckpoint = storeCheckpointResult.newCheckpoint;
                     notifyCheckpointWaiters();
                   }
                 }

--- a/src/packages/emmett/src/processors/processors.unit.spec.ts
+++ b/src/packages/emmett/src/processors/processors.unit.spec.ts
@@ -797,7 +797,7 @@ void describe('Processors', () => {
       };
     };
 
-    void it('resolves BEGINNING without reading the stored checkpoint', async () => {
+    void it('resolves BEGINNING even when a checkpoint is stored', async () => {
       // Given
       const { checkpoints, wasRead } = trackingCheckpointer(
         bigIntProcessorCheckpoint(9n),
@@ -814,7 +814,7 @@ void describe('Processors', () => {
 
       // Then
       assertEqual(startPosition, 'BEGINNING');
-      assertEqual(wasRead(), false);
+      assertEqual(wasRead(), true);
     });
 
     void it('resolves an explicit checkpoint without reading the stored checkpoint', async () => {
@@ -912,7 +912,7 @@ void describe('Processors', () => {
 
       // Then
       assertEqual(startPosition, 'END');
-      assertEqual(wasRead(), false);
+      assertEqual(wasRead(), true);
     });
   });
 

--- a/src/packages/emmett/src/processors/processors.unit.spec.ts
+++ b/src/packages/emmett/src/processors/processors.unit.spec.ts
@@ -689,6 +689,51 @@ void describe('Processors', () => {
         (error: EmmettError) => error instanceof EmmettError,
       );
     });
+
+    void it('resolves when the target batch is skipped', async () => {
+      // Given
+      const processor = reactor({
+        processorId: uuid(),
+        eachMessage: () => ({ type: 'SKIP' }),
+        checkpoints: positionCheckpointer(),
+      });
+      await processor.start();
+
+      let resolved = false;
+      const whenProcessed = processor
+        .whenProcessed(bigIntProcessorCheckpoint(2n))
+        .then(() => {
+          resolved = true;
+        });
+
+      // When
+      await processor.handle([recordedEvent(1n), recordedEvent(2n)], {});
+      await whenProcessed;
+
+      // Then
+      assertEqual(resolved, true);
+    });
+
+    void it('does not resolve past a stopped batch', async () => {
+      // Given
+      const processor = reactor({
+        processorId: uuid(),
+        eachMessage: () => ({ type: 'STOP' }),
+        checkpoints: positionCheckpointer(),
+      });
+      await processor.start();
+
+      // When
+      await processor.handle([recordedEvent(1n), recordedEvent(2n)], {});
+
+      // Then
+      await assertRejects(
+        processor.whenProcessed(bigIntProcessorCheckpoint(2n), {
+          timeout: 20,
+        }),
+        (error: EmmettError) => error instanceof EmmettError,
+      );
+    });
   });
 
   void describe('skipping and stopping from a reactor', () => {
@@ -817,7 +862,7 @@ void describe('Processors', () => {
       assertEqual(wasRead(), true);
     });
 
-    void it('resolves an explicit checkpoint without reading the stored checkpoint', async () => {
+    void it('resolves an explicit checkpoint after reading the stored checkpoint', async () => {
       // Given
       const provided = bigIntProcessorCheckpoint(5n);
       const { checkpoints, wasRead } = trackingCheckpointer(
@@ -835,7 +880,7 @@ void describe('Processors', () => {
 
       // Then
       assertDeepEqual(startPosition, { lastCheckpoint: provided });
-      assertEqual(wasRead(), false);
+      assertEqual(wasRead(), true);
     });
 
     void it('resolves the default to BEGINNING when no checkpoint is stored', async () => {

--- a/src/packages/emmett/src/processors/processors.unit.spec.ts
+++ b/src/packages/emmett/src/processors/processors.unit.spec.ts
@@ -6,6 +6,7 @@ import {
   assertEqual,
   assertMatches,
   assertOk,
+  assertRejects,
 } from '../testing';
 import type { Event, ReadEventMetadata, RecordedMessage } from '../typing';
 import { isString } from '../validation';
@@ -579,6 +580,101 @@ void describe('Processors', () => {
       assertEqual(handledMessages.length, 2);
       assertDeepEqual(handledMessages[0], recordedEvents[2]);
       assertDeepEqual(handledMessages[1], recordedEvents[3]);
+    });
+  });
+
+  void describe('waiting until a processor catches up to appended messages', () => {
+    const positionCheckpointer = (): Checkpointer<
+      TestEvent,
+      ReadEventMetadata & { globalPosition: bigint; streamPosition: bigint }
+    > => ({
+      read: () => Promise.resolve({ lastCheckpoint: null }),
+      store: (options) =>
+        Promise.resolve({
+          success: true,
+          newCheckpoint: bigIntProcessorCheckpoint(
+            options.message.metadata.globalPosition,
+          ),
+        }),
+    });
+
+    const recordedEvent = (
+      position: bigint,
+    ): RecordedMessage<
+      TestEvent,
+      ReadEventMetadata & { globalPosition: bigint; streamPosition: bigint }
+    > => ({
+      type: 'test',
+      kind: 'Event',
+      data: { counter: Number(position) },
+      metadata: {
+        streamName: 'test-stream',
+        messageId: uuid(),
+        checkpoint: bigIntProcessorCheckpoint(position),
+        globalPosition: position,
+        streamPosition: position,
+      },
+    });
+
+    void it('lets a test wait for its appended messages to be processed before asserting', async () => {
+      // Given
+      const processor = reactor({
+        processorId: uuid(),
+        eachMessage: () => Promise.resolve(),
+        checkpoints: positionCheckpointer(),
+      });
+      await processor.start();
+
+      let resolved = false;
+      const whenProcessed = processor
+        .whenProcessed(bigIntProcessorCheckpoint(2n))
+        .then(() => {
+          resolved = true;
+        });
+
+      // When - not yet at the target
+      await processor.handle([recordedEvent(1n)], {});
+      await Promise.resolve();
+
+      // Then
+      assertEqual(resolved, false);
+
+      // When - reaching the target
+      await processor.handle([recordedEvent(2n)], {});
+      await whenProcessed;
+
+      // Then
+      assertEqual(resolved, true);
+    });
+
+    void it('does not hang when the messages were already processed before the wait', async () => {
+      // Given
+      const processor = reactor({
+        processorId: uuid(),
+        eachMessage: () => Promise.resolve(),
+        checkpoints: positionCheckpointer(),
+      });
+      await processor.start();
+      await processor.handle([recordedEvent(5n)], {});
+
+      // When / Then - resolves without any further handling
+      await processor.whenProcessed(bigIntProcessorCheckpoint(3n));
+    });
+
+    void it('fails fast with a clear error instead of hanging when the processor never catches up', async () => {
+      // Given
+      const processor = reactor({
+        processorId: uuid(),
+        eachMessage: () => Promise.resolve(),
+        checkpoints: positionCheckpointer(),
+      });
+      await processor.start();
+
+      // When / Then
+      await assertRejects(
+        processor.whenProcessed(bigIntProcessorCheckpoint(2n), { timeout: 20 }),
+        (error: EmmettError) => error instanceof EmmettError,
+      );
     });
   });
 

--- a/src/packages/emmett/src/processors/processors.unit.spec.ts
+++ b/src/packages/emmett/src/processors/processors.unit.spec.ts
@@ -12,10 +12,23 @@ import type { Event, ReadEventMetadata, RecordedMessage } from '../typing';
 import { isString } from '../validation';
 import {
   bigIntProcessorCheckpoint,
+  ProcessorCheckpoint,
   type Checkpointer,
-  type ProcessorCheckpoint,
 } from './checkpoints';
-import { MessageProcessor, projector, reactor } from './processors';
+import {
+  MessageProcessor,
+  projector,
+  reactor,
+  wasMessageHandled,
+} from './processors';
+
+const numericCompareCheckpoints = (
+  a: ProcessorCheckpoint,
+  b: ProcessorCheckpoint,
+): number => {
+  const [left, right] = [BigInt(a), BigInt(b)];
+  return left > right ? 1 : left < right ? -1 : 0;
+};
 
 type TestEvent = Event<'test', { counter: number }>;
 
@@ -1152,5 +1165,68 @@ void describe('Processors', () => {
       // Then
       assertEqual(processor.instanceId, customInstanceId);
     });
+  });
+});
+
+void describe('comparing checkpoints', () => {
+  const rawRecordedEvent = (
+    checkpoint: string,
+  ): RecordedMessage<
+    TestEvent,
+    ReadEventMetadata & { globalPosition: bigint; streamPosition: bigint }
+  > => ({
+    type: 'test',
+    kind: 'Event',
+    data: { counter: 0 },
+    metadata: {
+      streamName: 'test-stream',
+      messageId: uuid(),
+      checkpoint: ProcessorCheckpoint(checkpoint),
+      globalPosition: BigInt(checkpoint),
+      streamPosition: BigInt(checkpoint),
+    },
+  });
+
+  void describe('wasMessageHandled', () => {
+    void it('uses the provided comparator to decide whether a message was handled', () => {
+      // '10' <= '9' lexicographically (native), but 10 <= 9 is false numerically
+      const message = rawRecordedEvent('10');
+
+      assertEqual(
+        wasMessageHandled(
+          message,
+          ProcessorCheckpoint('9'),
+          numericCompareCheckpoints,
+        ),
+        false,
+      );
+    });
+  });
+
+  void it('uses the provided comparator when deciding whether a checkpoint was processed', async () => {
+    // Given
+    const checkpoint = ProcessorCheckpoint('10');
+    const message = rawRecordedEvent('10');
+    const processor = reactor({
+      processorId: uuid(),
+      compareCheckpoints: numericCompareCheckpoints,
+      eachMessage: () => Promise.resolve(),
+      checkpoints: {
+        read: () => Promise.resolve({ lastCheckpoint: null }),
+        store: () =>
+          Promise.resolve({
+            success: true,
+            newCheckpoint: checkpoint,
+          }),
+      },
+    });
+    await processor.start();
+
+    // When - processed up to checkpoint '10'
+    await processor.handle([message], {});
+
+    // Then - '10' is past '9' numerically, so the wait resolves rather than
+    // timing out as it would under lexicographic string comparison
+    await processor.whenProcessed(ProcessorCheckpoint('9'), { timeout: 100 });
   });
 });


### PR DESCRIPTION
Also ensured that processors returning `END` are correctly handled in ESDB and MongoDB consumers.

Fixes https://github.com/event-driven-io/emmett/issues/273