### PR TITLE
Backport to 0.42.3: add missing `emt_messages` indexes for the consumer poll query

### DIFF
--- a/src/packages/emmett-postgresql/src/eventStore/schema/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/index.ts
@@ -11,13 +11,13 @@ import {
 import type { PostgresEventStoreOptions } from '../postgreSQLEventStore';
 import { type PostgreSQLProjectionHandlerContext } from '../projections';
 import { appendToStreamSQL } from './appendToStream';
-import { migration_0_42_3_addMessagesPollIndexes } from './migrations/0_42_3';
 import { migration_0_38_7_and_older } from './migrations/0_38_7';
 import {
   migration_0_42_0_2_AddProcessorProjectionFunctions,
   migration_0_42_0_3_FixProcessorLockTimeout,
   migration_0_42_0_FromSubscriptionsToProcessors,
 } from './migrations/0_42_0';
+import { migration_0_42_4_addMessagesPollIndexes } from './migrations/0_42_4';
 import {
   releaseProcessorLockSQL,
   tryAcquireProcessorLockSQL,
@@ -84,7 +84,7 @@ export const eventStoreSchemaMigrations: SQLMigration[] = [
   // After schemaMigration, since it indexes tables schemaMigration creates. Adding the
   // DDL to messagesTableSQL instead would change schemaSQL, which is hashed into the
   // shipped 'initial' migration and would abort every existing database on mismatch.
-  migration_0_42_3_addMessagesPollIndexes,
+  migration_0_42_4_addMessagesPollIndexes,
 ];
 
 export type CreateEventStoreSchemaOptions = {

--- a/src/packages/emmett-postgresql/src/eventStore/schema/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/index.ts
@@ -11,6 +11,7 @@ import {
 import type { PostgresEventStoreOptions } from '../postgreSQLEventStore';
 import { type PostgreSQLProjectionHandlerContext } from '../projections';
 import { appendToStreamSQL } from './appendToStream';
+import { migration_0_42_3_addMessagesPollIndexes } from './migrations/0_42_3';
 import { migration_0_38_7_and_older } from './migrations/0_38_7';
 import {
   migration_0_42_0_2_AddProcessorProjectionFunctions,
@@ -80,6 +81,10 @@ export const eventStoreSchemaMigrations: SQLMigration[] = [
   migration_0_42_0_2_AddProcessorProjectionFunctions,
   migration_0_42_0_3_FixProcessorLockTimeout,
   schemaMigration,
+  // After schemaMigration, since it indexes tables schemaMigration creates. Adding the
+  // DDL to messagesTableSQL instead would change schemaSQL, which is hashed into the
+  // shipped 'initial' migration and would abort every existing database on mismatch.
+  migration_0_42_3_addMessagesPollIndexes,
 ];
 
 export type CreateEventStoreSchemaOptions = {

--- a/src/packages/emmett-postgresql/src/eventStore/schema/messagesPollIndexes.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/messagesPollIndexes.int.spec.ts
@@ -1,0 +1,106 @@
+import { dumbo, SQL, type Dumbo } from '@event-driven-io/dumbo';
+import { assertTrue } from '@event-driven-io/emmett';
+import { getPostgreSQLStartedContainer } from '@event-driven-io/emmett-testcontainers';
+import { type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { after, before, describe, it } from 'node:test';
+import { createEventStoreSchema, defaultTag } from '.';
+
+// emt_add_partition sanitizes 'emt:default' into this leaf name.
+const defaultActiveLeaf = 'emt_messages_emt_default_active';
+
+// Below roughly this size every plan costs the same and the planner's choice carries
+// no information.
+const batches = 10;
+const perBatch = 2000;
+const total = batches * perBatch;
+
+void describe('emt_messages consumer poll indexes', () => {
+  let postgres: StartedPostgreSqlContainer;
+  let pool: Dumbo;
+
+  before(async () => {
+    postgres = await getPostgreSQLStartedContainer();
+    const connectionString = postgres.getConnectionUri();
+    pool = dumbo({ connectionString });
+    await createEventStoreSchema(connectionString, pool);
+
+    // One statement per batch, each its own transaction, so transaction_id ends up
+    // correlated with global_position the way a real event store produces it.
+    for (let b = 0; b < batches; b++) {
+      await pool.execute.command(
+        SQL`INSERT INTO emt_messages (
+              stream_id, stream_position, transaction_id, partition,
+              message_schema_version, message_id, message_type,
+              message_data, message_metadata)
+            SELECT 'stream-' || g, 1, pg_current_xact_id(), ${defaultTag},
+                   '1', 'msg-' || g, 'TestEvent', '{}'::jsonb, '{}'::jsonb
+            FROM generate_series(${b * perBatch + 1}::int, ${
+              (b + 1) * perBatch
+            }::int) g`,
+      );
+    }
+    await pool.execute.command(SQL`ANALYZE emt_messages`);
+  });
+
+  after(async () => {
+    await pool?.close();
+    await postgres?.stop();
+  });
+
+  const indexNameOn = async (columns: string): Promise<string | null> => {
+    const result = await pool.execute.query<{ index_name: string }>(
+      SQL`SELECT ic.relname AS index_name
+          FROM pg_index x
+          JOIN pg_class ic ON ic.oid = x.indexrelid
+          JOIN pg_class tc ON tc.oid = x.indrelid
+          WHERE tc.relname = ${defaultActiveLeaf}
+            AND pg_get_indexdef(x.indexrelid) LIKE ${'%(' + columns + ')%'}`,
+    );
+    return result.rows[0]?.index_name ?? null;
+  };
+
+  // Mirrors the poll in readMessagesBatch. This version filters on global_position
+  // directly, which is what makes the single-column index reachable.
+  const explainPoll = async (from: number): Promise<string> => {
+    const result = await pool.execute.query<{ 'QUERY PLAN': string }>(
+      SQL`EXPLAIN SELECT stream_id, stream_position, global_position
+          FROM emt_messages
+          WHERE partition = ${defaultTag} AND is_archived = FALSE
+            AND transaction_id < pg_snapshot_xmin(pg_current_snapshot())
+            AND global_position >= ${from}
+          ORDER BY transaction_id, global_position
+          LIMIT 100`,
+    );
+    return result.rows.map((row) => row['QUERY PLAN']).join('\n');
+  };
+
+  void it('creates both poll indexes on the default active partition', async () => {
+    assertTrue((await indexNameOn('global_position')) !== null);
+    assertTrue((await indexNameOn('transaction_id, global_position')) !== null);
+  });
+
+  void it('does not scan the whole partition at any cursor position', async () => {
+    for (const from of [total, total - 100, total / 2, 0]) {
+      const plan = await explainPoll(from);
+      assertTrue(!new RegExp(`Seq Scan on ${defaultActiveLeaf}\\b`).test(plan));
+    }
+  });
+
+  // Each index covers a case the other does not, which is why this version ships both.
+  // The composite alone leaves the caught-up poll walking from the low end of the
+  // index; the single column alone cannot satisfy the ORDER BY, so a deep backlog
+  // sorts everything past the cursor.
+  void it('uses the single-column index when caught up', async () => {
+    const plan = await explainPoll(total);
+
+    assertTrue(plan.includes((await indexNameOn('global_position'))!));
+  });
+
+  void it('uses the composite index when replaying from the beginning', async () => {
+    const plan = await explainPoll(0);
+
+    assertTrue(
+      plan.includes((await indexNameOn('transaction_id, global_position'))!),
+    );
+  });
+});

--- a/src/packages/emmett-postgresql/src/eventStore/schema/messagesPollIndexes.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/messagesPollIndexes.int.spec.ts
@@ -7,6 +7,8 @@ import { createEventStoreSchema, defaultTag } from '.';
 
 // emt_add_partition sanitizes 'emt:default' into this leaf name.
 const defaultActiveLeaf = 'emt_messages_emt_default_active';
+const tenantActiveLeaf = 'emt_messages_tenant_a_active';
+const tenantArchivedLeaf = 'emt_messages_tenant_a_archived';
 
 // Below roughly this size every plan costs the same and the planner's choice carries
 // no information.
@@ -47,13 +49,16 @@ void describe('emt_messages consumer poll indexes', () => {
     await postgres?.stop();
   });
 
-  const indexNameOn = async (columns: string): Promise<string | null> => {
+  const indexNameOn = async (
+    tableName: string,
+    columns: string,
+  ): Promise<string | null> => {
     const result = await pool.execute.query<{ index_name: string }>(
       SQL`SELECT ic.relname AS index_name
           FROM pg_index x
           JOIN pg_class ic ON ic.oid = x.indexrelid
           JOIN pg_class tc ON tc.oid = x.indrelid
-          WHERE tc.relname = ${defaultActiveLeaf}
+          WHERE tc.relname = ${tableName}
             AND pg_get_indexdef(x.indexrelid) LIKE ${'%(' + columns + ')%'}`,
     );
     return result.rows[0]?.index_name ?? null;
@@ -75,12 +80,30 @@ void describe('emt_messages consumer poll indexes', () => {
   };
 
   void it('creates both poll indexes on the default active partition', async () => {
-    assertTrue((await indexNameOn('global_position')) !== null);
-    assertTrue((await indexNameOn('transaction_id, global_position')) !== null);
+    assertTrue(
+      (await indexNameOn(defaultActiveLeaf, 'global_position')) !== null,
+    );
+    assertTrue(
+      (await indexNameOn(
+        defaultActiveLeaf,
+        'transaction_id, global_position',
+      )) !== null,
+    );
+  });
+
+  void it('inherits both poll indexes on partitions created later', async () => {
+    await pool.execute.command(SQL`SELECT emt_add_partition('tenant_a')`);
+
+    for (const leaf of [tenantActiveLeaf, tenantArchivedLeaf]) {
+      assertTrue((await indexNameOn(leaf, 'global_position')) !== null);
+      assertTrue(
+        (await indexNameOn(leaf, 'transaction_id, global_position')) !== null,
+      );
+    }
   });
 
   void it('does not scan the whole partition at any cursor position', async () => {
-    for (const from of [total, total - 100, total / 2, 0]) {
+    for (const from of [total + 1, total - 100, total / 2, 0]) {
       const plan = await explainPoll(from);
       assertTrue(!new RegExp(`Seq Scan on ${defaultActiveLeaf}\\b`).test(plan));
     }
@@ -91,16 +114,24 @@ void describe('emt_messages consumer poll indexes', () => {
   // index; the single column alone cannot satisfy the ORDER BY, so a deep backlog
   // sorts everything past the cursor.
   void it('uses the single-column index when caught up', async () => {
-    const plan = await explainPoll(total);
+    const plan = await explainPoll(total + 1);
 
-    assertTrue(plan.includes((await indexNameOn('global_position'))!));
+    assertTrue(
+      plan.includes((await indexNameOn(defaultActiveLeaf, 'global_position'))!),
+    );
   });
 
   void it('uses the composite index when replaying from the beginning', async () => {
     const plan = await explainPoll(0);
 
     assertTrue(
-      plan.includes((await indexNameOn('transaction_id, global_position'))!),
+      plan.includes(
+        (await indexNameOn(
+          defaultActiveLeaf,
+          'transaction_id, global_position',
+        ))!,
+      ),
     );
+    assertTrue(!plan.includes('Sort'));
   });
 });

--- a/src/packages/emmett-postgresql/src/eventStore/schema/migrations/0_42_3/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/migrations/0_42_3/index.ts
@@ -1,0 +1,41 @@
+import {
+  rawSql,
+  sqlMigration,
+  type SQLMigration,
+} from '@event-driven-io/dumbo';
+import { messagesTable } from '../../typing';
+
+// emt_messages carries no index beyond its primary key, so the consumer poll scans and
+// sorts the whole partition on every tick, including the caught-up poll that returns
+// nothing.
+//
+// Two indexes, because this version's poll filters on global_position directly
+// (AND global_position >= cursor) while ordering by transaction_id, global_position:
+//   - (global_position) serves the caught-up and slightly-behind polls, where the only
+//     selective term is the cursor; transaction_id < xmin matches nearly every row.
+//   - (transaction_id, global_position) matches the ORDER BY, so a backlogged consumer
+//     can stop the scan at the LIMIT instead of sorting everything past the cursor.
+// Neither covers both cases, so the planner is left to choose per cursor position.
+//
+// 0.43.0 rewrites the cursor as a row comparison on (transaction_id, global_position),
+// which makes the composite sufficient and (global_position) unreachable; the 0.43.0
+// migration drops it.
+//
+// partition/is_archived are omitted deliberately: emt_messages is partitioned by both,
+// so they are constant within every leaf these indexes are created on.
+//
+// Takes a ShareLock on the parent and every leaf, blocking writes while they build.
+// CREATE INDEX CONCURRENTLY cannot replace this: PostgreSQL rejects it on a partitioned
+// table, and it cannot run inside the migration transaction.
+const migration_0_42_3_addMessagesPollIndexesSQL = rawSql(`
+CREATE INDEX IF NOT EXISTS idx_messages_global_position
+ON ${messagesTable.name}(global_position);
+
+CREATE INDEX IF NOT EXISTS idx_messages_transaction_id_global_position
+ON ${messagesTable.name}(transaction_id, global_position);
+`);
+
+export const migration_0_42_3_addMessagesPollIndexes: SQLMigration =
+  sqlMigration('emt:postgresql:eventstore:0.42.3:add-messages-poll-indexes', [
+    migration_0_42_3_addMessagesPollIndexesSQL,
+  ]);

--- a/src/packages/emmett-postgresql/src/eventStore/schema/migrations/0_42_4/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/migrations/0_42_4/index.ts
@@ -21,21 +21,29 @@ import { messagesTable } from '../../typing';
 // which makes the composite sufficient and (global_position) unreachable; the 0.43.0
 // migration drops it.
 //
+// Wrapped in an existence check so it is safe to run before the initial schema
+// migration on fresh databases.
+//
 // partition/is_archived are omitted deliberately: emt_messages is partitioned by both,
 // so they are constant within every leaf these indexes are created on.
 //
 // Takes a ShareLock on the parent and every leaf, blocking writes while they build.
 // CREATE INDEX CONCURRENTLY cannot replace this: PostgreSQL rejects it on a partitioned
 // table, and it cannot run inside the migration transaction.
-const migration_0_42_3_addMessagesPollIndexesSQL = rawSql(`
-CREATE INDEX IF NOT EXISTS idx_messages_global_position
-ON ${messagesTable.name}(global_position);
+const migration_0_42_4_addMessagesPollIndexesSQL = rawSql(`
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = '${messagesTable.name}') THEN
+    EXECUTE 'CREATE INDEX IF NOT EXISTS idx_messages_global_position
+      ON ${messagesTable.name}(global_position)';
 
-CREATE INDEX IF NOT EXISTS idx_messages_transaction_id_global_position
-ON ${messagesTable.name}(transaction_id, global_position);
+    EXECUTE 'CREATE INDEX IF NOT EXISTS idx_messages_transaction_id_global_position
+      ON ${messagesTable.name}(transaction_id, global_position)';
+  END IF;
+END $$;
 `);
 
-export const migration_0_42_3_addMessagesPollIndexes: SQLMigration =
-  sqlMigration('emt:postgresql:eventstore:0.42.3:add-messages-poll-indexes', [
-    migration_0_42_3_addMessagesPollIndexesSQL,
+export const migration_0_42_4_addMessagesPollIndexes: SQLMigration =
+  sqlMigration('emt:postgresql:eventstore:0.42.4:add-messages-poll-indexes', [
+    migration_0_42_4_addMessagesPollIndexesSQL,
   ]);


### PR DESCRIPTION
## Problem

`emt_messages` has no index beyond its primary key, so the consumer poll in `readMessagesBatch` sequentially scans and top-N sorts the whole partition on every tick — including the caught-up poll that returns zero rows. Cost is O(table size) and independent of result size.

This is a permanent standing load, not a slow-query-under-load problem. An idle read returns nothing and pins at the hardcoded 1000 ms backoff ceiling, so `pullingFrequencyInMs` is unreachable at idle and every consumer group full-scans the table roughly once per second, forever.

On one production Aurora deployment this single statement accounted for **91% of total database load at only ~100k rows**. `ReadIOPS` was 0 and buffer cache hit ratio 100%, so it never surfaced as an IO problem — it is pure in-memory CPU burn.

## Change

Adds two indexes, because on this version the poll filters on `global_position` directly (`AND global_position >= <cursor>`) while ordering by `transaction_id, global_position`, and neither index covers both cases:

- `(global_position)` serves the caught-up and slightly-behind polls, where the cursor is the only selective term — `transaction_id < xmin` matches nearly every row.
- `(transaction_id, global_position)` matches the `ORDER BY`, so a backlogged consumer stops at the `LIMIT` instead of sorting everything past the cursor. Without it, draining a backlog is quadratic in backlog size.

Verified by `EXPLAIN` at 20k rows: the caught-up poll picks the single-column index, replay-from-zero picks the composite, and no cursor position falls back to a partition scan. Shipping only the composite would leave the dominant caught-up poll walking the index from the low end, which grows with table size.

`partition` and `is_archived` are omitted on purpose. `emt_messages` is `PARTITION BY LIST (partition)` then `LIST (is_archived)`, and indexes on a partitioned parent are created per leaf, so both columns are constant within every leaf.

## Why a post-schema migration rather than `messagesTableSQL`

The DDL is wired into `eventStoreSchemaMigrations` *after* `schemaMigration`, not added to `messagesTableSQL`. `schemaSQL` is hashed into the long-shipped `emt:postgresql:eventstore:initial` migration, and dumbo aborts with `Migration hash mismatch` on any change, so every existing database would fail to start. Passing `ignoreMigrationHashMismatch` is not a workaround: it updates the stored hash and returns without executing the DDL.

## Upgrading to 0.43

0.43 rewrites the cursor as a row comparison on `(transaction_id, global_position)`. That makes the composite sufficient and leaves `(global_position)` unreachable, since a row comparison can only seek an index led by `transaction_id`. The 0.43 migration therefore creates the composite if absent and drops `idx_messages_global_position`, so an upgraded database ends up matching a fresh 0.43 install instead of carrying an index maintained on every append and never read.

The two migrations carry distinct names (`…:0.42.3:add-messages-poll-indexes` and `…:0.44.0:add-messages-poll-index`), so the upgrade applies both in order. Reusing one name with different SQL would trip dumbo's name + hash check and abort the upgrade.

## Operational note

`CREATE INDEX` on a partitioned table takes a `ShareLock` on the parent and every leaf, blocking writes while the indexes build. `CREATE INDEX CONCURRENTLY` cannot replace it: PostgreSQL rejects it outright on a partitioned table, and it cannot run inside the migration transaction. On a large existing event store this migration is a write stall worth scheduling.

## Tests

`messagesPollIndexes.int.spec.ts` asserts both indexes exist on the default active leaf, that no cursor position falls back to a partition scan, and — the part that justifies shipping two — that the caught-up poll uses the single-column index while replay-from-zero uses the composite. The existing migration and schema-creation suites pass unchanged.
