### PR TITLE
Upgrade Express package to Express v5

### DIFF
--- a/src/docs/frameworks/expressjs.md
+++ b/src/docs/frameworks/expressjs.md
@@ -5,443 +5,197 @@ outline: deep
 
 # Express.js Integration
 
-::: warning
-We created this page with the help of the GenAI tool.
-
-We're currently double-checking it to ensure the information is 100% correct and free of hallucinations.
-:::
-
-Emmett's Express.js integration provides a streamlined way to build event-sourced web APIs with built-in error handling, ETag support, and testing utilities.
-
-## Overview
-
-The `@event-driven-io/emmett-expressjs` package provides:
-
-- **Application setup helpers** - Sensible defaults for Express.js configuration
-- **Request handlers** - Clean pattern for command handling in routes
-- **Problem Details** - RFC 9457 compliant error responses
-- **ETag support** - Optimistic concurrency via HTTP headers
-- **Testing utilities** - BDD-style API testing
+The `@event-driven-io/emmett-expressjs` package integrates Emmett with Express 5. It provides route handlers that return typed HTTP responses, application registration helpers, ETag utilities, and Problem Details error handling.
 
 ## Installation
 
 ```bash
-npm install @event-driven-io/emmett-expressjs
+npm install @event-driven-io/emmett @event-driven-io/emmett-expressjs express http-problem-details
+npm install --save-dev @types/express
 ```
 
-### Peer Dependencies
+## Define an API
 
-```bash
-npm install @event-driven-io/emmett express
-npm install -D @types/express
-```
-
-## Quick Start
-
-### Application Setup
+An API setup function receives an Express router. Wrap route handlers with `on` and return one of the response helpers exported by the package.
 
 ```typescript
-import { getApplication, startAPI } from '@event-driven-io/emmett-expressjs';
-import { getInMemoryEventStore } from '@event-driven-io/emmett';
+import {
+  NotFound,
+  OK,
+  on,
+  type WebApiSetup,
+} from '@event-driven-io/emmett-expressjs';
+import type { Request } from 'express';
 
-const eventStore = getInMemoryEventStore();
+type ShoppingCart = {
+  id: string;
+  productItems: Array<{ productId: string; quantity: number }>;
+};
 
-const app = getApplication({
-  apis: [shoppingCartApi(eventStore)],
-});
-
-startAPI(app, 3000);
-```
-
-### Defining Routes
-
-```typescript
-import { on, ok, created, notFound } from '@event-driven-io/emmett-expressjs';
-import { Router } from 'express';
-
-export const shoppingCartApi = (eventStore: EventStore) => (router: Router) => {
-  const handle = CommandHandler(eventStore, shoppingCartDecider);
-
-  // GET - Read shopping cart
+export const shoppingCartApi = (): WebApiSetup => (router) => {
   router.get(
     '/carts/:cartId',
-    on(async (request) => {
-      const cartId = request.params.cartId;
-
-      const { state, currentStreamVersion } = await eventStore.aggregateStream(
-        `shopping_cart-${cartId}`,
-        { evolve, initialState },
+    on(async (request: Request<{ cartId: string }>) => {
+      const cart: ShoppingCart | undefined = await loadCart(
+        request.params.cartId,
       );
 
-      if (currentStreamVersion === 0n) {
-        return notFound({ detail: `Cart ${cartId} not found` });
-      }
-
-      return ok(state, { eTag: currentStreamVersion });
-    }),
-  );
-
-  // POST - Add product item
-  router.post(
-    '/carts/:cartId/items',
-    on(async (request) => {
-      const cartId = request.params.cartId;
-      const { productId, quantity } = request.body;
-
-      const result = await handle(cartId, {
-        type: 'AddProductItem',
-        data: { productId, quantity, price: await getPrice(productId) },
-      });
-
-      return ok({ success: true }, { eTag: result.nextExpectedStreamVersion });
-    }),
-  );
-
-  // POST - Confirm cart
-  router.post(
-    '/carts/:cartId/confirm',
-    on(async (request) => {
-      const cartId = request.params.cartId;
-
-      await handle(cartId, {
-        type: 'ConfirmShoppingCart',
-        data: { confirmedAt: new Date() },
-      });
-
-      return ok({ status: 'Confirmed' });
+      return cart !== undefined
+        ? OK({ body: cart })
+        : NotFound({ detail: 'Shopping cart was not found' });
     }),
   );
 };
 ```
 
-## Response Helpers
+Other response helpers include `Created`, `NoContent`, `BadRequest`, `Forbidden`, `Conflict`, `PreconditionFailed`, and `HttpProblem`.
 
-### Success Responses
+## Start with the default application
 
-```typescript
-import { ok, created, noContent } from '@event-driven-io/emmett-expressjs';
-
-// 200 OK with body
-return ok({ items: cart.items });
-
-// 200 OK with ETag
-return ok(cart, { eTag: version });
-
-// 201 Created with location header
-return created({ id: cartId }, { location: `/carts/${cartId}` });
-
-// 204 No Content
-return noContent();
-```
-
-### Error Responses
+`getApplication` creates an Express application and configures Emmett's default middleware and API routes. `startAPI` starts the HTTP server.
 
 ```typescript
-import {
-  badRequest,
-  notFound,
-  forbidden,
-  conflict,
-  preconditionFailed,
-} from '@event-driven-io/emmett-expressjs';
-
-// 400 Bad Request
-return badRequest({ detail: 'Quantity must be positive' });
-
-// 404 Not Found
-return notFound({ detail: 'Cart not found' });
-
-// 403 Forbidden
-return forbidden({ detail: 'Cart is already confirmed' });
-
-// 409 Conflict
-return conflict({ detail: 'Operation conflicts with current state' });
-
-// 412 Precondition Failed (version mismatch)
-return preconditionFailed({ detail: 'Cart was modified' });
-```
-
-## Problem Details (RFC 9457)
-
-Errors are automatically formatted as Problem Details:
-
-```json
-{
-  "type": "about:blank",
-  "title": "Not Found",
-  "status": 404,
-  "detail": "Cart cart-123 not found"
-}
-```
-
-### Default Error Mapping
-
-| Emmett Error        | HTTP Status |
-| ------------------- | ----------- |
-| `ValidationError`   | 400         |
-| `IllegalStateError` | 403         |
-| `NotFoundError`     | 404         |
-| `ConcurrencyError`  | 412         |
-
-### Custom Error Mapping
-
-```typescript
-const app = getApplication({
-  apis: [shoppingCartApi],
-  problemDetails: {
-    mapError: (error) => {
-      if (error instanceof InsufficientFundsError) {
-        return {
-          status: 402,
-          title: 'Payment Required',
-          detail: error.message,
-        };
-      }
-      return undefined; // Use default mapping
-    },
-  },
-});
-```
-
-## Optimistic Concurrency with ETags
-
-### Reading Version
-
-```typescript
-router.get(
-  '/carts/:cartId',
-  on(async (request) => {
-    const { state, currentStreamVersion } =
-      await eventStore.aggregateStream(/*...*/);
-
-    // Sets ETag header: ETag: "5"
-    return ok(state, { eTag: currentStreamVersion });
-  }),
-);
-```
-
-### Checking Version on Write
-
-```typescript
-import { getExpectedVersionFromRequest } from '@event-driven-io/emmett-expressjs';
-
-router.post(
-  '/carts/:cartId/items',
-  on(async (request) => {
-    // Reads If-Match header: If-Match: "5"
-    const expectedVersion = getExpectedVersionFromRequest(request);
-
-    await eventStore.appendToStream(streamName, events, {
-      expectedStreamVersion: expectedVersion,
-    });
-
-    return ok({ success: true });
-  }),
-);
-```
-
-## Testing
-
-### Integration Tests (In-Memory)
-
-```typescript
-import {
-  ApiSpecification,
-  existingStream,
-  expectResponse,
-  expectEvents,
-} from '@event-driven-io/emmett-expressjs';
-import { getInMemoryEventStore } from '@event-driven-io/emmett';
-
-describe('Shopping Cart API', () => {
-  let given: ApiSpecification;
-
-  beforeAll(() => {
-    const eventStore = getInMemoryEventStore();
-
-    given = ApiSpecification.for(() =>
-      getApplication({
-        apis: [shoppingCartApi(eventStore)],
-      }),
-    );
-  });
-
-  it('adds product to cart', () =>
-    given(
-      existingStream('shopping_cart-123', [
-        {
-          type: 'ProductItemAdded',
-          data: { productId: 'p1', quantity: 1, price: 10 },
-        },
-      ]),
-    )
-      .when((request) =>
-        request.post('/carts/123/items').send({ productId: 'p2', quantity: 2 }),
-      )
-      .then([
-        expectResponse(200),
-        expectEvents('shopping_cart-123', [
-          {
-            type: 'ProductItemAdded',
-            data: { productId: 'p2', quantity: 2, price: expect.any(Number) },
-          },
-        ]),
-      ]));
-
-  it('returns 404 for missing cart', () =>
-    given()
-      .when((request) => request.get('/carts/nonexistent'))
-      .then([expectResponse(404)]));
-});
-```
-
-### E2E Tests (Real Database)
-
-```typescript
-import { ApiE2ESpecification } from '@event-driven-io/emmett-expressjs';
-import { getPostgreSQLEventStore } from '@event-driven-io/emmett-postgresql';
-import { PostgreSqlContainer } from '@testcontainers/postgresql';
-
-describe('Shopping Cart API (E2E)', () => {
-  let postgres: StartedPostgreSqlContainer;
-  let given: ApiE2ESpecification;
-
-  beforeAll(async () => {
-    postgres = await new PostgreSqlContainer().start();
-    const eventStore = getPostgreSQLEventStore(postgres.getConnectionUri());
-
-    given = ApiE2ESpecification.for(() =>
-      getApplication({
-        apis: [shoppingCartApi(eventStore)],
-      }),
-    );
-  });
-
-  afterAll(async () => {
-    await postgres.stop();
-  });
-
-  it('completes shopping flow', async () => {
-    // Add item
-    await given()
-      .when((request) =>
-        request
-          .post('/carts/123/items')
-          .send({ productId: 'shoes', quantity: 1 }),
-      )
-      .then([expectResponse(200)]);
-
-    // Confirm
-    await given()
-      .when((request) => request.post('/carts/123/confirm'))
-      .then([expectResponse(200)]);
-  });
-});
-```
-
-## Application Configuration
-
-### Default Setup
-
-`getApplication` provides sensible defaults:
-
-```typescript
-const app = getApplication({
-  apis: [myApi],
-});
-
-// Includes:
-// - JSON body parsing
-// - URL encoding
-// - Problem Details error handling
-// - ETag support
-```
-
-### Custom Configuration
-
-```typescript
-import express from 'express';
-
-const app = getApplication({
-  apis: [myApi],
-
-  // Add custom middleware
-  beforeRoutes: (app) => {
-    app.use(cors());
-    app.use(helmet());
-  },
-
-  // Add after routes
-  afterRoutes: (app) => {
-    app.use(customErrorHandler);
-  },
-
-  // Customize problem details
-  problemDetails: {
-    mapError: customErrorMapper,
-  },
-});
-```
-
-### Using with Existing Express App
-
-```typescript
-import express from 'express';
-import { setupRoutes } from '@event-driven-io/emmett-expressjs';
-
-const app = express();
-
-// Your existing middleware
-app.use(cors());
-app.use(express.json());
-
-// Add Emmett routes
-setupRoutes(app, [shoppingCartApi(eventStore)]);
-
-app.listen(3000);
-```
-
-## WebAPI Setup Pattern
-
-The recommended pattern for organizing routes:
-
-```typescript
-// api/shoppingCartApi.ts
-import { WebApiSetup } from '@event-driven-io/emmett-expressjs';
-
-export const shoppingCartApi =
-  (
-    eventStore: EventStore,
-    getPrice: (productId: string) => Promise<number>,
-  ): WebApiSetup =>
-  (router) => {
-    // All routes defined here
-    router.get('/carts/:id' /* ... */);
-    router.post('/carts/:id/items' /* ... */);
-    router.post('/carts/:id/confirm' /* ... */);
-  };
-
-// main.ts
 import { getApplication, startAPI } from '@event-driven-io/emmett-expressjs';
 
-const app = getApplication({
-  apis: [
-    shoppingCartApi(eventStore, priceService.getPrice),
-    orderApi(eventStore),
-    userApi(userService),
-  ],
+const application = getApplication({
+  apis: [shoppingCartApi()],
 });
 
-startAPI(app);
+startAPI(application, { port: 3000 });
 ```
 
-## Full Package Documentation
+The default registration order is:
 
-For complete API reference and advanced usage, see the [package README](https://github.com/event-driven-io/emmett/tree/main/src/packages/emmett-expressjs).
+1. ETag configuration.
+2. Express JSON parser.
+3. Express URL-encoded parser with `extended: true`.
+4. Trace response header middleware when observability is configured.
+5. API routes.
+6. Problem Details error middleware.
 
-## See Also
+## Register Emmett on an existing application
 
-- [Getting Started](/getting-started) - Full tutorial with Express.js
-- [Error Handling](/guides/error-handling) - Comprehensive error patterns
-- [Testing Patterns](/guides/testing) - Testing strategies
-- [Fastify Integration](/frameworks/fastify) - Alternative framework
+Use `configureApplication` to apply the same conventional setup to an existing Express application. It returns the supplied application and accepts the same options as `getApplication`:
+
+```typescript
+import {
+  configureApplication,
+  startAPI,
+} from '@event-driven-io/emmett-expressjs';
+import express from 'express';
+
+const application = express();
+
+application.get('/health', (_request, response) => {
+  response.status(200).json({ status: 'ok' });
+});
+application.use(authMiddleware);
+
+configureApplication(application, {
+  apis: [shoppingCartApi()],
+});
+
+startAPI(application, { port: 3000 });
+```
+
+This applies Emmett's ETag setting, enabled request middleware, API routes, and enabled error middleware in the documented default order. Routes and middleware already present on the application keep their existing position.
+
+Use `registerWebApi` instead when every middleware position must be controlled explicitly. It only registers the supplied API routes and returns the application supplied by the caller. It does not configure ETags or install middleware.
+
+```typescript
+import {
+  problemDetailsMiddleware,
+  registerWebApi,
+  startAPI,
+} from '@event-driven-io/emmett-expressjs';
+import express from 'express';
+
+const application = express();
+
+// Infrastructure endpoints registered here are not protected by the auth
+// middleware below.
+application.get('/health', (_request, response) => {
+  response.status(200).json({ status: 'ok' });
+});
+
+application.use(express.json());
+application.use(express.urlencoded({ extended: true }));
+application.use(authMiddleware);
+
+registerWebApi(application, [shoppingCartApi()]);
+application.use(problemDetailsMiddleware());
+
+startAPI(application, { port: 3000 });
+```
+
+Express executes middleware in registration order. Put middleware before `registerWebApi` to run it before Emmett routes, or after it for routes registered later.
+
+The caller owns all middleware configuration. For example, it can replace Express's default JSON parser without any disable flag:
+
+```typescript
+const application = express();
+
+application.use(express.json({ limit: '2mb' }));
+application.use(authMiddleware);
+
+registerWebApi(application, [shoppingCartApi()]);
+```
+
+## Customize error handling
+
+Applications configured by `getApplication` or `configureApplication` serialize errors as `application/problem+json` by default. Pass `mapError` to customize how errors become Problem Details documents:
+
+```typescript
+import { getApplication } from '@event-driven-io/emmett-expressjs';
+import { ProblemDocument } from 'http-problem-details';
+
+const application = getApplication({
+  apis: [shoppingCartApi()],
+  mapError: (error) =>
+    error instanceof ShoppingCartNotFound
+      ? new ProblemDocument({
+          status: 404,
+          title: 'Shopping cart not found',
+          detail: error.message,
+        })
+      : undefined,
+});
+```
+
+With a caller-owned application, register the exported `problemDetailsMiddleware` explicitly after the API routes:
+
+```typescript
+import {
+  problemDetailsMiddleware,
+  registerWebApi,
+} from '@event-driven-io/emmett-expressjs';
+
+registerWebApi(application, [shoppingCartApi()]);
+
+application.use(customErrorMiddleware);
+application.use(problemDetailsMiddleware());
+```
+
+Error middleware must be registered after the routes whose errors it handles.
+
+## Application options
+
+`getApplication` and `configureApplication` accept these options:
+
+| Option                            | Description                                                     |
+| --------------------------------- | --------------------------------------------------------------- |
+| `apis`                            | API setup functions applied to the Emmett router.               |
+| `disableJsonMiddleware`           | Do not install Express's JSON parser.                           |
+| `disableUrlEncodingMiddleware`    | Do not install Express's URL-encoded parser.                    |
+| `disableProblemDetailsMiddleware` | Do not install the default Problem Details middleware.          |
+| `enableDefaultExpressEtag`        | Enable Express's generated ETag responses. Disabled by default. |
+| `mapError`                        | Map application errors to Problem Details documents.            |
+| `observability`                   | Add tracing support and the trace response header.              |
+
+`configureApplication(application, options)` configures and returns an existing application. `registerWebApi(application, apis)` accepts only the target Express application and a list of API setup functions. For fully caller-composed applications, `problemDetailsMiddleware` and `traceIdMiddleware` are available as independently composable middleware exports.
+
+## Express 5 behavior
+
+The package targets Express 5, so asynchronous Express handlers forward rejected promises to error middleware without `express-async-errors`. Express 5 also uses the current `path-to-regexp` route syntax; for example, a named wildcard is written as `/files/{*path}`.
+
+See the [Express 5 migration guide](https://expressjs.com/en/guide/migrating-5/) for the complete set of framework-level changes.

--- a/src/docs/frameworks/expressjs.md
+++ b/src/docs/frameworks/expressjs.md
@@ -5,197 +5,325 @@ outline: deep
 
 # Express.js Integration
 
-The `@event-driven-io/emmett-expressjs` package integrates Emmett with Express 5. It provides route handlers that return typed HTTP responses, application registration helpers, ETag utilities, and Problem Details error handling.
+`@event-driven-io/emmett-expressjs` provides the Express adapters for exposing commands and read models through a Web API. Use it when you already have an Express API, prefer Express for new development, or are unsure which Node.js web framework to choose and want a long-established, mature option.
+
+Routes remain ordinary Express routes. A command route reads and validates the request, obtains any external data the decision needs, calls the command handler, and chooses a response. A query route reads its parameters, queries the read store, and returns the matching model. The integration supplies the repeated HTTP boundary work around both kinds of route.
+
+Nothing in the application setup or response handling requires event sourcing. Use the command-result, ETag, and event-backed testing helpers only where those concerns are part of the API.
+
+## What the Integration Adds
+
+| Concern                | What the integration provides                                                                   | What remains in the route or application                   |
+| ---------------------- | ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Express setup          | Request parsing, feature-route registration, optional trace IDs, and Problem Details responses. | Authentication and any application-specific middleware.    |
+| HTTP responses         | A common return type with helpers for status, body, `Location`, ETag, and error responses.      | Choosing the response that represents each outcome.        |
+| Command results        | Mapping returned events to success or failure responses.                                        | Deciding whether business failures are returned or thrown. |
+| Optimistic concurrency | Reading `If-Match` and returning a stream version as an ETag.                                   | Choosing which writes require a client-supplied version.   |
+| API tests              | Given/when/then specifications built on SuperTest.                                              | The initial events or requests and the outcomes to assert. |
+
+The integration does not dispatch commands, build projections, or choose a database. Those choices stay explicit in the feature that defines each route.
 
 ## Installation
 
 ```bash
-npm install @event-driven-io/emmett @event-driven-io/emmett-expressjs express http-problem-details
-npm install --save-dev @types/express
+npm install @event-driven-io/emmett-expressjs
 ```
 
-## Define an API
+## Set Up Express
 
-An API setup function receives an Express router. Wrap route handlers with `on` and return one of the response helpers exported by the package.
+An Express bootstrap for this kind of API usually repeats the same setup: create the application, install body parsers, mount the feature routes, and put shared error handling after those routes. Traced APIs also need middleware that exposes the active trace ID. `getApplication` collects those application-level concerns in one call. It reduces bootstrap code, but it does not hide the routes, commands, queries, or dependencies that make up the API.
 
-```typescript
-import {
-  NotFound,
-  OK,
-  on,
-  type WebApiSetup,
-} from '@event-driven-io/emmett-expressjs';
-import type { Request } from 'express';
+The shared error handling is useful once more than one route can fail. Without it, command and query routes each need to catch errors, choose an HTTP status, and maintain their own error-body shape. The default Problem Details middleware does that translation in one place and gives clients the same standard response format across the API.
 
-type ShoppingCart = {
-  id: string;
-  productItems: Array<{ productId: string; quantity: number }>;
-};
+None of that setup is required. Each default body parser and the Problem Details middleware can be disabled independently. An existing application can receive the same defaults through `configureApplication`, or retain complete control by composing the smaller exports itself.
 
-export const shoppingCartApi = (): WebApiSetup => (router) => {
-  router.get(
-    '/carts/:cartId',
-    on(async (request: Request<{ cartId: string }>) => {
-      const cart: ShoppingCart | undefined = await loadCart(
-        request.params.cartId,
-      );
+Choose the level that matches the application:
 
-      return cart !== undefined
-        ? OK({ body: cart })
-        : NotFound({ detail: 'Shopping cart was not found' });
-    }),
-  );
-};
+| Starting point                              | Use                                          | Result                                                                                        |
+| ------------------------------------------- | -------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| A new Web API                               | `getApplication(options)`                    | Creates Express and applies the default HTTP setup.                                           |
+| An existing Express application             | `configureApplication(application, options)` | Adds the default HTTP setup after the application's existing routes and middleware.           |
+| An application with its own middleware plan | `registerWebApi(application, apiSetups)`     | Adds only the feature routes, leaving parsers, tracing, authentication, and errors untouched. |
+
+### Start a New Express API
+
+`getApplication(options)` is the shortest path when the API does not already have an Express bootstrap:
+
+<<< @./../packages/emmett-expressjs/src/application.int.spec.ts#default-application
+
+It replaces the repeated `express()`, parser, router, and error-middleware registration with the following defaults, in order:
+
+1. Keeps ETags explicit by turning off Express's automatic response-body ETags. This avoids presenting a cache validator where an API may use an ETag as a stream version; enable `enableDefaultExpressEtag` when automatic ETags are also wanted for HTTP caching.
+2. Parses JSON and URL-encoded requests, unless either parser is disabled.
+3. Adds the active trace ID to responses when `observability` is provided.
+4. Registers the supplied feature APIs.
+5. Serialises errors from those APIs in the standard Problem Details format, unless disabled.
+
+These defaults provide a working HTTP boundary, not an application architecture. Authentication, request validation, command mapping, read-store queries, and other application-specific work remain in caller-owned middleware and routes.
+
+### Add the Defaults to an Existing Express API
+
+`configureApplication(application, options)` applies the same setup without creating the application. Existing infrastructure routes and middleware stay before the Emmett routes. Here `/health` remains available outside the configured API stack:
+
+<<< @./../packages/emmett-expressjs/src/e2e/configureExistingApplication.e2e.spec.ts#configure-existing-application
+
+Each default can be replaced independently. This application installs its own JSON body parser, then disables the default parser so Express does not process the body twice:
+
+<<< @./../packages/emmett-expressjs/src/application.int.spec.ts#configure-custom-json-middleware
+
+`configureApplication` intentionally replaces the existing application's ETag setting with Emmett's default. Express normally generates weak ETags for response bodies, but Emmett disables them so every ETag exposed by default was assigned explicitly and can safely represent a stream version. Set `enableDefaultExpressEtag: true` when the application also needs Express-generated ETags for HTTP caching. Use `registerWebApi` instead when the integration should mount routes without changing this or any other application setting.
+
+### Compose Only What the Application Needs {#registering-api-routes}
+
+Use `registerWebApi(application, apiSetups)` when the application already has a deliberate Express stack. It creates and mounts the router for the supplied APIs without changing application settings or adding middleware:
+
+<<< @./../packages/emmett-expressjs/src/application.int.spec.ts#route-only-registration
+
+The example keeps `/health` outside authentication, then places parsing, tracing, and authentication before the API router. Problem Details middleware follows the routes whose errors it handles.
+
+The application can opt into the remaining pieces independently:
+
+| Export                     | What it adds                                                                        |
+| -------------------------- | ----------------------------------------------------------------------------------- |
+| `registerWebApi`           | One router containing the supplied feature APIs.                                    |
+| `problemDetailsMiddleware` | One standard error-response contract for errors from routes registered before it.   |
+| `traceIdMiddleware`        | The active OpenTelemetry trace ID in the `x-trace-id` response header.              |
+| `on` and response helpers  | Route handlers that return an explicit HTTP response instead of mutating it inline. |
+| ETag helpers               | Explicit `If-Match` parsing and response ETags for optimistic concurrency.          |
+
+Express's own `express.json()` and `express.urlencoded()` remain available when the application needs different parser options. This granular path is also useful when existing authentication, observability, or error middleware already defines the required conventions.
+
+### Start the HTTP Server
+
+`startAPI(application, options?)` creates a Node HTTP server and starts listening. Omitting the options uses port 3000. The returned `http.Server` can be used for shutdown or other server-level integration.
+
+### Application Options
+
+`getApplication` and `configureApplication` accept `ApplicationOptions`. Omitted boolean options are treated as `false`. For the `disable...` options, that means the default middleware is installed unless the option is set to `true`.
+
+| Option                            | Behaviour                                                                                                                                 |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `apis`                            | Required. Each setup registers routes on one shared router, which is then mounted on the application.                                     |
+| `mapError`                        | Optional error mapper tried before the default Problem Details mapping.                                                                   |
+| `enableDefaultExpressEtag`        | Default `false`. Keeps Express-generated ETags off; set to `true` when the API also wants Express cache validators for implicit ETags.    |
+| `disableJsonMiddleware`           | Default `false`. Installs `express.json()`; set to `true` when the application configures JSON parsing itself.                            |
+| `disableUrlEncodingMiddleware`    | Default `false`. Installs `express.urlencoded({ extended: true })`; set to `true` when the application configures URL-encoded parsing.    |
+| `disableProblemDetailsMiddleware` | Default `false`. Installs Problem Details error middleware; set to `true` when the application owns error serialisation.                  |
+| `observability`                   | Optional. When provided, adds the active trace ID to the `x-trace-id` response header. Omitted means no trace ID middleware is installed. |
+
+## Define the Web API
+
+### Keep Routes with Their Feature
+
+A `WebApiSetup` is a function that receives an Express router. A feature can export one setup containing its related command and query endpoints, while closing over the event store, read store, and other dependencies it needs. The application bootstrap composes those setups through `apis` without taking ownership of the endpoints themselves.
+
+The command and query examples below are both ordinary Express routes registered inside a setup. `on` adapts an async route function that returns an `HttpResponse`. `NoContent`, `OK`, and `NotFound` apply the status, body, and headers to the Express response. The route remains responsible for reading the request, calling the application dependency it needs, and choosing the outcome.
+
+All setups receive the same router in array order. The integration mounts that router once.
+
+### Handle a Command
+
+Command routes keep the complete application flow visible. This endpoint validates request data, obtains the current product price, builds a command, invokes the command handler, and returns 204 No Content:
+
+<<< @/snippets/gettingStarted/webApi/simpleApi.ts#add-product-item-endpoint
+
+The integration does not infer the command or decision from the route. For handler setup, decisions, retries, and idempotence, see [Command Handling](/guides/command-handling).
+
+### Query a Read Model
+
+Query routes use the same Express and response abstractions without a command handler. This API queries an injected Pongo read store, returns 404 when a model is absent, and returns the model with 200 when found:
+
+<<< @/guides/projections/queryingReadModels.snippet.ts#api-routes
+
+The read store is an application choice rather than an Express integration requirement. See [Query Read Models](/guides/projections#query) for the query and projection setup.
+
+### Return HTTP Responses {#response-helpers}
+
+The examples above return an `HttpResponse` from every expected outcome: `OK` or `NotFound` for a query, and `NoContent` after the command completes. Each helper captures the status, body, and headers to send. `on` applies that choice to the Express response; the route remains responsible for choosing it.
+
+The built-in response helpers are:
+
+| Helper               | Status | Typical use                                                                  |
+| -------------------- | ------ | ---------------------------------------------------------------------------- |
+| `OK`                 | 200    | Return a representation, with optional `Location` and ETag headers.          |
+| `Created`            | 201    | Return a newly created resource or ID and set its `Location`.                |
+| `Accepted`           | 202    | Accept work that continues elsewhere and identify its status resource.       |
+| `NoContent`          | 204    | Complete a command without returning a body, optionally with an ETag.        |
+| `HttpResponse`       | Custom | Use another successful or application-specific status.                       |
+| `BadRequest`         | 400    | Return Problem Details for a request the API cannot accept.                  |
+| `Forbidden`          | 403    | Return Problem Details when the requested operation is not allowed.          |
+| `NotFound`           | 404    | Return Problem Details when the requested resource is absent.                |
+| `Conflict`           | 409    | Return Problem Details when the request conflicts with the current state.    |
+| `PreconditionFailed` | 412    | Return Problem Details when a condition such as `If-Match` is not satisfied. |
+| `HttpProblem`        | Custom | Return Problem Details with another error status.                            |
+
+`Created({ createdId })` appends `createdId` to the request URL for the `Location` header and sends `{ id: createdId, ...body }`. Its `url` form supplies `Location` directly. `Accepted` requires `location`; the other success helpers accept it optionally.
+
+Problem responses accept either `problem: ProblemDocument` or `problemDetails: string`. The latter creates a `ProblemDocument` with the helper's status code and the supplied string as `detail`.
+
+## Return Consistent Errors
+
+Successful routes choose their response explicitly. Thrown errors need a separate path: validation can fail, a decision can reject an invalid transition, a queried dependency can be unavailable, or a read model can be missing unexpectedly. Handling each case inside every route repeats `try`/`catch`, status selection, and response-body construction, and makes it easy for endpoints to drift into different error formats.
+
+`getApplication` and `configureApplication` therefore install `problemDetailsMiddleware` after the API routes by default. Express passes thrown errors and rejected async handlers to it, and the middleware returns `application/problem+json` using the [Problem Details standard (RFC 9457)](https://www.rfc-editor.org/rfc/rfc9457.html). Clients can handle the same fields, including `status`, `title`, and `detail`, instead of learning a different error shape for each endpoint. For example, an `IllegalStateError` becomes:
+
+```json
+{
+  "type": "about:blank",
+  "title": "Forbidden",
+  "status": 403,
+  "detail": "Cannot confirm an empty shopping cart"
+}
 ```
 
-Other response helpers include `Created`, `NoContent`, `BadRequest`, `Forbidden`, `Conflict`, `PreconditionFailed`, and `HttpProblem`.
+The middleware handles exceptions. A business failure returned as an event is still a normal command result, so the route maps it explicitly with `ResponseFromEvents` or its own response selection.
 
-## Start with the default application
+The default mapping is:
 
-`getApplication` creates an Express application and configures Emmett's default middleware and API routes. `startAPI` starts the HTTP server.
+| Error value                                                      | Status      | Detail                  |
+| ---------------------------------------------------------------- | ----------- | ----------------------- |
+| `Error` with `errorCode` from 100 through 599                    | `errorCode` | `error.message`         |
+| `Error` without a valid `errorCode`                              | 500         | `error.message`         |
+| `string`                                                         | 500         | The string value        |
+| Object other than `Error`, with `errorCode` from 100 through 599 | `errorCode` | `Internal Server Error` |
+| Any other value                                                  | 500         | `Internal Server Error` |
 
-```typescript
-import { getApplication, startAPI } from '@event-driven-io/emmett-expressjs';
+Emmett's built-in validation, illegal-state, not-found, and concurrency errors carry status codes 400, 403, 404, and 412 respectively.
 
-const application = getApplication({
-  apis: [shoppingCartApi()],
-});
+Pass `mapError(error, request)` to translate an application-specific error into a `ProblemDocument`. This keeps library errors and application-specific error classes behind the same public HTTP contract. Returning `undefined` delegates to the default mapping:
 
-startAPI(application, { port: 3000 });
-```
+<<< @./../packages/emmett-expressjs/src/mapError.int.spec.ts#custom-error-mapping
 
-The default registration order is:
+When the application already has an error contract, set `disableProblemDetailsMiddleware: true` and register the replacement after the API routes:
 
-1. ETag configuration.
-2. Express JSON parser.
-3. Express URL-encoded parser with `extended: true`.
-4. Trace response header middleware when observability is configured.
-5. API routes.
-6. Problem Details error middleware.
+<<< @./../packages/emmett-expressjs/src/application.int.spec.ts#configure-custom-error-middleware
 
-## Register Emmett on an existing application
+For a manually composed stack, call `problemDetailsMiddleware(mapError?)` directly after `registerWebApi`. Omitting it leaves error serialisation entirely to the application.
 
-Use `configureApplication` to apply the same conventional setup to an existing Express application. It returns the supplied application and accepts the same options as `getApplication`:
+For deciding whether business logic should throw or return a failure event, see [Error Handling](/guides/error-handling).
 
-```typescript
-import {
-  configureApplication,
-  startAPI,
-} from '@event-driven-io/emmett-expressjs';
-import express from 'express';
+### Map Returned Events to HTTP Responses {#mapping-events-to-responses}
 
-const application = express();
+A command handler can return a business failure event without appending it, for example through `rejectOn` or `stopOn`. Because nothing was thrown, Express error middleware does not see that outcome. `ResponseFromEvents(options)` maps it explicitly to the same `HttpResponse` returned by other `on` handlers:
 
-application.get('/health', (_request, response) => {
-  response.status(200).json({ status: 'ok' });
-});
-application.use(authMiddleware);
+<<< @./../packages/emmett-expressjs/src/responses.int.spec.ts#express-response-from-events-route
 
-configureApplication(application, {
-  apis: [shoppingCartApi()],
-});
+| Option    | Type                                                     | Behaviour                                                                                   |
+| --------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `events`  | `Event[] \| { events: Event[] }`                         | Supplies the events or complete command-handler result.                                     |
+| `success` | `number \| (source => number \| HttpResponse)`           | Selects the success response. Defaults to 204.                                              |
+| `failure` | `(event, source) => number \| HttpResponse \| undefined` | Checks events from newest to oldest. The first defined result selects the failure response. |
 
-startAPI(application, { port: 3000 });
-```
+`sendResponseFromEvents(response, options)` performs the same selection and applies the response immediately.
 
-This applies Emmett's ETag setting, enabled request middleware, API routes, and enabled error middleware in the documented default order. Routes and middleware already present on the application keep their existing position.
+## Carry Stream Versions over HTTP {#etags}
 
-Use `registerWebApi` instead when every middleware position must be controlled explicitly. It only registers the supplied API routes and returns the application supplied by the caller. It does not configure ETags or install middleware.
+An update based on stale state must not silently overwrite a newer stream version. The ETag helpers carry the optimistic concurrency check through HTTP:
 
-```typescript
-import {
-  problemDetailsMiddleware,
-  registerWebApi,
-  startAPI,
-} from '@event-driven-io/emmett-expressjs';
-import express from 'express';
+1. A successful response returns the current stream version as an ETag.
+2. The client sends that ETag in `If-Match` with its next update.
+3. The route passes the value to the command handler as `expectedStreamVersion`.
+4. If another request changed the stream first, the default error mapping returns 412 Precondition Failed.
 
-const application = express();
+This endpoint reads the version the client last saw and returns the version produced by the successful command:
 
-// Infrastructure endpoints registered here are not protected by the auth
-// middleware below.
-application.get('/health', (_request, response) => {
-  response.status(200).json({ status: 'ok' });
-});
+<<< @./../packages/emmett-expressjs/src/e2e/commandHandler/api.ts#etag-command-handler
 
-application.use(express.json());
-application.use(express.urlencoded({ extended: true }));
-application.use(authMiddleware);
+`getETagValueFromIfMatch` reports a missing `If-Match` header as a 412 error. `getWeakETagValue` does the same for a value that does not match `WeakETagRegex`. A version conflict raised by the event store follows the same Problem Details path.
 
-registerWebApi(application, [shoppingCartApi()]);
-application.use(problemDetailsMiddleware());
+`getApplication` and `configureApplication` disable Express-generated ETags by default so stream-version ETags remain explicit. Setting `enableDefaultExpressEtag` to `true` restores Express-generated ETags. `registerWebApi` does not change that Express setting.
 
-startAPI(application, { port: 3000 });
-```
+Express generates an ETag only when the response has not already set one, so an explicit stream-version ETag from an Emmett response helper takes precedence. Generated ETags are still content hashes rather than stream versions. Enable them for ordinary HTTP caching only when clients can distinguish those values from the ETags used as `If-Match` versions on command endpoints.
 
-Express executes middleware in registration order. Put middleware before `registerWebApi` to run it before Emmett routes, or after it for routes registered later.
+The `eTag` option on success and Problem Details responses sets an explicit ETag independently of the application setting.
 
-The caller owns all middleware configuration. For example, it can replace Express's default JSON parser without any disable flag:
+### ETag Functions and Types
 
-```typescript
-const application = express();
+| Export                             | Type or result              | Behaviour                                                                             |
+| ---------------------------------- | --------------------------- | ------------------------------------------------------------------------------------- |
+| `HeaderNames`                      | Header-name constants       | Contains `if-match`, `if-not-match`, and `etag`.                                      |
+| `ETag`                             | Branded `string`            | Represents an ETag value.                                                             |
+| `WeakETag`                         | Branded `` `W/${string}` `` | Represents a weak ETag value.                                                         |
+| `WeakETagRegex`                    | `RegExp`                    | Matches the weak ETag format accepted by `getWeakETagValue`.                          |
+| `ETagErrors`                       | String enum                 | Contains invalid-format and missing-header error identifiers.                         |
+| `toWeakETag(value)`                | `WeakETag`                  | Formats a number, bigint, or string as a weak ETag.                                   |
+| `isWeakETag(etag)`                 | Type guard                  | Tests an ETag with `WeakETagRegex`.                                                   |
+| `getWeakETagValue(etag)`           | `string`                    | Returns the value inside a weak ETag or throws a concurrency `EmmettError`.           |
+| `getETagFromIfMatch(request)`      | `ETag`                      | Reads `If-Match` or throws a concurrency `EmmettError` when the header is absent.     |
+| `getETagFromIfNotMatch(request)`   | `ETag`                      | Reads `if-not-match` or throws a concurrency `EmmettError` when the header is absent. |
+| `getETagValueFromIfMatch(request)` | `string`                    | Unwraps a weak `If-Match` value and returns any other ETag value unchanged.           |
+| `setETag(response, etag)`          | `void`                      | Sets the response `ETag` header.                                                      |
 
-application.use(express.json({ limit: '2mb' }));
-application.use(authMiddleware);
+## Include Trace IDs in Responses
 
-registerWebApi(application, [shoppingCartApi()]);
-```
+When OpenTelemetry has an active span, `traceIdMiddleware` copies its trace ID to the `x-trace-id` response header. This gives API clients an identifier they can include when reporting a failed request. With no active span, the middleware adds no header.
 
-## Customize error handling
+Providing `observability` to `getApplication` or `configureApplication` installs this middleware before the API routes. An application using `registerWebApi` can place the exported middleware directly in its own stack.
 
-Applications configured by `getApplication` or `configureApplication` serialize errors as `application/problem+json` by default. Pass `mapError` to customize how errors become Problem Details documents:
+## Test the Web API
 
-```typescript
-import { getApplication } from '@event-driven-io/emmett-expressjs';
-import { ProblemDocument } from 'http-problem-details';
+Unit tests cover a decision or query function on its own. An HTTP-level test covers the boundary around it: request mapping, middleware, error serialisation, response headers, and access to the configured stores.
 
-const application = getApplication({
-  apis: [shoppingCartApi()],
-  mapError: (error) =>
-    error instanceof ShoppingCartNotFound
-      ? new ProblemDocument({
-          status: 404,
-          title: 'Shopping cart not found',
-          detail: error.message,
-        })
-      : undefined,
-});
-```
+The package provides two SuperTest-based specifications:
 
-With a caller-owned application, register the exported `problemDetailsMiddleware` explicitly after the API routes:
+| Specification         | Starting state                                  | Assertions                                   | Use it for                                                                     |
+| --------------------- | ----------------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------ |
+| `ApiSpecification`    | Events written directly to one or more streams. | The HTTP response and newly appended events. | An event-backed integration test of a command endpoint.                        |
+| `ApiE2ESpecification` | Requests sent in order through the application. | The final HTTP response.                     | A black-box flow where setup passes through the same public API as the action. |
 
-```typescript
-import {
-  problemDetailsMiddleware,
-  registerWebApi,
-} from '@event-driven-io/emmett-expressjs';
+### Start from Recorded Events
 
-registerWebApi(application, [shoppingCartApi()]);
+`ApiSpecification.for({ getEventStore, getApplication })` creates a fresh event store and application for each specification invocation:
 
-application.use(customErrorMiddleware);
-application.use(problemDetailsMiddleware());
-```
+<<< @./../packages/emmett-expressjs/src/testing/apiSpecification.int.spec.ts#api-specification-setup
 
-Error middleware must be registered after the routes whose errors it handles.
+Streams passed to the given phase are written before the request. The specification wraps the event store so the assertion can check both the response observed by the caller and the events appended by that request:
 
-## Application options
+<<< @./../packages/emmett-expressjs/src/testing/apiSpecification.int.spec.ts#api-specification-example
 
-`getApplication` and `configureApplication` accept these options:
+### Start from Previous Requests
 
-| Option                            | Description                                                     |
-| --------------------------------- | --------------------------------------------------------------- |
-| `apis`                            | API setup functions applied to the Emmett router.               |
-| `disableJsonMiddleware`           | Do not install Express's JSON parser.                           |
-| `disableUrlEncodingMiddleware`    | Do not install Express's URL-encoded parser.                    |
-| `disableProblemDetailsMiddleware` | Do not install the default Problem Details middleware.          |
-| `enableDefaultExpressEtag`        | Enable Express's generated ETag responses. Disabled by default. |
-| `mapError`                        | Map application errors to Problem Details documents.            |
-| `observability`                   | Add tracing support and the trace response header.              |
+`ApiE2ESpecification.for({ getEventStore?, getApplication })` prepares state through requests instead of writing directly to the event store. It sends the given requests in order, sends the request under test, and checks the final response. `getEventStore` defaults to `getInMemoryEventStore`.
 
-`configureApplication(application, options)` configures and returns an existing application. `registerWebApi(application, apis)` accepts only the target Express application and a list of API setup functions. For fully caller-composed applications, `problemDetailsMiddleware` and `traceIdMiddleware` are available as independently composable middleware exports.
+<<< @./../packages/emmett-expressjs/src/testing/apiE2ESpecification.int.spec.ts#api-e2e-specification-setup
 
-## Express 5 behavior
+This example opens a cart, adds a product, and then confirms it through the public API:
 
-The package targets Express 5, so asynchronous Express handlers forward rejected promises to error middleware without `express-async-errors`. Express 5 also uses the current `path-to-regexp` route syntax; for example, a named wildcard is written as `/files/{*path}`.
+<<< @./../packages/emmett-expressjs/src/testing/apiE2ESpecification.int.spec.ts#api-e2e-specification-example
 
-See the [Express 5 migration guide](https://expressjs.com/en/guide/migrating-5/) for the complete set of framework-level changes.
+### Assertion Helpers
+
+| Export            | Behaviour                                                                                                            |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `existingStream`  | Creates a `[streamId, events]` tuple that `ApiSpecification` writes before the request.                              |
+| `expect`          | Creates a `[streamId, events]` tuple to match against events appended during the request.                            |
+| `expectNewEvents` | An equivalent, more explicit name for `expect`.                                                                      |
+| `expectResponse`  | Checks the exact status code and, when supplied, matches the specified body and header fields.                       |
+| `expectError`     | Calls `expectResponse` with an error status and optional Problem Details fields.                                     |
+| `TestRequest`     | A function receiving a SuperTest agent and returning its configured request. It is used for given and when requests. |
+
+`ApiSpecification.then` accepts a response assertion, expected event streams, or a response assertion followed by expected event streams. `ApiE2ESpecification.then` accepts one response assertion in a one-element array.
+
+For choosing between decision, API, and infrastructure-backed tests, see [Testing](/guides/testing).
+
+## Compatibility
+
+The package peer dependency is Express `^5.2.1`. Rejected promises from asynchronous handlers reach Express error middleware without `express-async-errors`. Express 5 route syntax requires named wildcards such as `/files/{*path}`. Applications migrating from Express 4 can consult the [Express 5 migration guide](https://expressjs.com/en/guide/migrating-5/).
+
+## Type Sources
+
+- [Application configuration](https://github.com/event-driven-io/emmett/blob/main/src/packages/emmett-expressjs/src/application.ts)
+- [Handlers and response helpers](https://github.com/event-driven-io/emmett/blob/main/src/packages/emmett-expressjs/src/handler.ts)
+- [ETag utilities](https://github.com/event-driven-io/emmett/blob/main/src/packages/emmett-expressjs/src/etag.ts)
+- [Response types and sending](https://github.com/event-driven-io/emmett/blob/main/src/packages/emmett-expressjs/src/responses.ts)
+- [Middleware](https://github.com/event-driven-io/emmett/tree/main/src/packages/emmett-expressjs/src/middlewares)
+- [Testing utilities](https://github.com/event-driven-io/emmett/tree/main/src/packages/emmett-expressjs/src/testing)
+
+## See Also
+
+- [Getting Started: Application Setup](/getting-started#application-setup)
+- [Command Handling](/guides/command-handling)
+- [Read Models](/guides/projections)
+- [Error Handling](/guides/error-handling)
+- [Testing](/guides/testing)
+- [How to use ETag header for optimistic concurrency](https://event-driven.io/pl/how_to_use_etag_header_for_optimistic_concurrency/)

--- a/src/docs/guides/projections/queryingReadModels.snippet.ts
+++ b/src/docs/guides/projections/queryingReadModels.snippet.ts
@@ -56,9 +56,15 @@ const shoppingCartApi =
 
         const result = await getDetailsById(readStore, shoppingCartId);
 
-        if (result === null) return NotFound();
+        if (result === null)
+          return NotFound({
+            problemDetails: 'No open shopping cart was found',
+          });
 
-        if (result.status !== 'Opened') return NotFound();
+        if (result.status !== 'Opened')
+          return NotFound({
+            problemDetails: 'No open shopping cart was found',
+          });
 
         return OK({ body: result });
       }),
@@ -71,7 +77,10 @@ const shoppingCartApi =
 
         const result = await getShortInfoById(readStore, shoppingCartId);
 
-        if (result === null) return NotFound();
+        if (result === null)
+          return NotFound({
+            problemDetails: 'Shopping cart summary was not found',
+          });
 
         return OK({ body: result });
       }),

--- a/src/docs/guides/projections/queryingReadModels.snippet.ts
+++ b/src/docs/guides/projections/queryingReadModels.snippet.ts
@@ -52,7 +52,7 @@ const shoppingCartApi =
     router.get(
       '/clients/:clientId/shopping-carts/current',
       on(async (request: Request) => {
-        const shoppingCartId = `shopping_cart:${request.params.clientId}:current`;
+        const shoppingCartId = `shopping_cart:${String(request.params.clientId)}:current`;
 
         const result = await getDetailsById(readStore, shoppingCartId);
 
@@ -67,7 +67,7 @@ const shoppingCartApi =
     router.get(
       '/clients/:clientId/shopping-carts/current/short-info',
       on(async (request: Request) => {
-        const shoppingCartId = `shopping_cart:${request.params.clientId}:current`;
+        const shoppingCartId = `shopping_cart:${String(request.params.clientId)}:current`;
 
         const result = await getShortInfoById(readStore, shoppingCartId);
 

--- a/src/docs/resources/faq.md
+++ b/src/docs/resources/faq.md
@@ -100,7 +100,7 @@ npm install @event-driven-io/emmett-expressjs express@5
 npm install --save-dev @types/express@5
 ```
 
-Express 5 forwards rejected promises from async handlers to error middleware, so `express-async-errors` is not required. See the [Express integration guide](../frameworks/expressjs.md#express-5-behavior) for route syntax and composition details.
+Express 5 forwards rejected promises from async handlers to error middleware, so `express-async-errors` is not required. See the [Express integration reference](../frameworks/expressjs.md#compatibility) for route syntax and composition details.
 
 ### TestContainers fails with "Could not find a working container runtime strategy"
 

--- a/src/docs/resources/faq.md
+++ b/src/docs/resources/faq.md
@@ -93,27 +93,14 @@ _Related: [GitHub Issue #240](https://github.com/event-driven-io/emmett/issues/2
 
 ### How do I use Emmett with Express.js v5?
 
-Express.js v5 support is in progress. Currently, Emmett uses Express v4. You can:
+`@event-driven-io/emmett-expressjs` targets Express 5. Install Express and its current type definitions alongside Emmett:
 
-1. Use Express v4 (recommended for now)
-2. Use the event store directly without `emmett-expressjs`
-3. Watch [GitHub Issue #267](https://github.com/event-driven-io/emmett/issues/267) for v5 support
-
-```typescript
-// Using event store directly with Express v5
-import express from 'express';
-import { getPostgreSQLEventStore } from '@event-driven-io/emmett-postgresql';
-
-const app = express();
-const eventStore = getPostgreSQLEventStore(connectionString);
-
-app.post('/orders', async (req, res) => {
-  const result = await eventStore.appendToStream(`order-${req.body.orderId}`, [
-    { type: 'OrderCreated', data: req.body },
-  ]);
-  res.json({ streamPosition: result.nextExpectedStreamVersion });
-});
+```bash
+npm install @event-driven-io/emmett-expressjs express@5
+npm install --save-dev @types/express@5
 ```
+
+Express 5 forwards rejected promises from async handlers to error middleware, so `express-async-errors` is not required. See the [Express integration guide](../frameworks/expressjs.md#express-5-behavior) for route syntax and composition details.
 
 ### TestContainers fails with "Could not find a working container runtime strategy"
 
@@ -376,31 +363,34 @@ _Related: [GitHub Issue #232](https://github.com/event-driven-io/emmett/issues/2
 
 ### How do I customize Express.js middleware order?
 
-If you need fine-grained control over middleware, use the event store directly instead of `emmett-expressjs`:
+Create an Express application and pass it to `registerWebApi`. Middleware and routes registered first run before Emmett's API router:
 
 ```typescript
 import express from 'express';
-import { getPostgreSQLEventStore } from '@event-driven-io/emmett-postgresql';
-import { CommandHandler } from '@event-driven-io/emmett';
+import {
+  problemDetailsMiddleware,
+  registerWebApi,
+} from '@event-driven-io/emmett-expressjs';
 
 const app = express();
 
-// Your middleware in your order
-app.use(cors());
-app.use(helmet());
+// Health is intentionally outside authentication.
+app.get('/health', (_request, response) => {
+  response.status(200).json({ status: 'ok' });
+});
+
 app.use(express.json());
 app.use(authMiddleware);
 
-const eventStore = getPostgreSQLEventStore(connectionString);
-const handle = CommandHandler({ evolve, initialState });
+registerWebApi(app, [shoppingCartApi]);
+app.use(problemDetailsMiddleware());
 
-app.post('/carts/:id/add', async (req, res) => {
-  const result = await handle(eventStore, req.params.id, (state) =>
-    addProduct(req.body, state),
-  );
-  res.json(result);
-});
+app.listen(3000);
 ```
+
+`registerWebApi` only registers routes. The caller owns ETag configuration and installs parsers, authentication, tracing, and error middleware explicitly. Register error middleware after the API routes whose errors it should handle.
+
+If you own the Express instance but want Emmett's conventional middleware stack, use `configureApplication(app, options)` instead. It accepts the same options and middleware-disable flags as `getApplication`.
 
 _Related: [GitHub Issue #267 comments](https://github.com/event-driven-io/emmett/issues/267)_
 

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -25,6 +25,7 @@
         "@testcontainers/postgresql": "^11.14.0",
         "commander": "^14.0.3",
         "dotenv": "^17.4.2",
+        "express": "^5.2.1",
         "mitata": "^1.0.34"
       },
       "devDependencies": {
@@ -64,7 +65,7 @@
       },
       "peerDependencies": {
         "@event-driven-io/pongo": "0.17.0-beta.47",
-        "@types/express": "4.17.21",
+        "@types/express": "^5.0.6",
         "@types/node": "^25.6.0",
         "@types/supertest": "^7.2.0",
         "supertest": "7.2.2"
@@ -4052,22 +4053,21 @@
       "license": "MIT"
     },
     "node_modules/@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.9",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
-      "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.3.tgz",
+      "integrity": "sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5106,17 +5106,41 @@
       "peer": true
     },
     "node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/acorn": {
@@ -5312,13 +5336,6 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/asap": {
       "version": "2.0.6",
@@ -5674,46 +5691,41 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.6",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
-      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "bytes": "~3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "~1.2.0",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "on-finished": "~2.4.1",
-        "qs": "~6.15.1",
-        "raw-body": "~2.5.3",
-        "type-is": "~1.6.18",
-        "unpipe": "~1.0.0"
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/body-parser/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/body-parser/node_modules/ms": {
+    "node_modules/body-parser/node_modules/content-type": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
       "license": "MIT",
-      "peer": true
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "5.0.9",
@@ -5800,7 +5812,6 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5820,7 +5831,6 @@
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -5834,7 +5844,6 @@
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -6054,16 +6063,16 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -6071,7 +6080,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6101,7 +6109,6 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.6.0"
       }
@@ -6274,7 +6281,6 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -6286,17 +6292,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/detect-libc": {
@@ -6515,7 +6510,6 @@
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -6581,8 +6575,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -6612,7 +6605,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -6664,7 +6656,6 @@
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6674,7 +6665,6 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6691,7 +6681,6 @@
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -6770,8 +6759,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -7039,7 +7027,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -7099,60 +7086,46 @@
       "optional": true
     },
     "node_modules/express": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
-      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "~1.20.5",
-        "content-disposition": "~0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "~0.7.1",
-        "cookie-signature": "~1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.3.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "~0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "~6.15.1",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "~0.19.0",
-        "serve-static": "~1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "~2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
       },
       "engines": {
-        "node": ">= 0.10.0"
+        "node": ">= 18"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express-async-errors": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.1.1.tgz",
-      "integrity": "sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==",
-      "license": "ISC",
-      "peer": true,
-      "peerDependencies": {
-        "express": "^4.16.2"
       }
     },
     "node_modules/express/node_modules/cookie": {
@@ -7160,34 +7133,34 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
     },
-    "node_modules/express/node_modules/cookie-signature": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
-      "peer": true
-    },
-    "node_modules/express/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ms": "2.0.0"
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "node_modules/express/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
-      "peer": true
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
@@ -7446,40 +7419,25 @@
       "license": "MIT"
     },
     "node_modules/finalhandler": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
-      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "~2.0.2",
-        "unpipe": "~1.0.0"
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/finalhandler/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/finalhandler/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/find-my-way": {
       "version": "9.7.0",
@@ -7600,19 +7558,17 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs-constants": {
@@ -7641,7 +7597,6 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7660,7 +7615,6 @@
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -7697,7 +7651,6 @@
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -7814,7 +7767,6 @@
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -7833,7 +7785,6 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -7862,7 +7813,6 @@
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -7941,7 +7891,6 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "depd": "~2.0.0",
         "inherits": "~2.0.4",
@@ -7965,16 +7914,19 @@
       "peer": true
     },
     "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -8099,6 +8051,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -8416,7 +8374,6 @@
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -8444,13 +8401,16 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/memory-pager": {
@@ -8469,11 +8429,13 @@
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
-      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -8886,11 +8848,10 @@
       "license": "MIT"
     },
     "node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -9072,7 +9033,6 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -9108,7 +9068,6 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -9198,7 +9157,6 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -9245,11 +9203,14 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
-      "peer": true
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -9812,7 +9773,6 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -9826,7 +9786,6 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -9895,7 +9854,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
       "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.1",
         "side-channel": "^1.1.1"
@@ -9931,29 +9889,31 @@
       "license": "MIT"
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
+        "iconv-lite": "~0.7.0",
         "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/rc": {
@@ -10278,6 +10238,22 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -10374,74 +10350,73 @@
       }
     },
     "node_modules/send": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
-      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.1",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "~2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "~2.0.2"
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/send/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
-      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/send/node_modules/debug/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/send/node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "mime": "cli.js"
+        "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/serve-static": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
-      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "~0.19.1"
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-cookie-parser": {
@@ -10455,8 +10430,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.35.2",
@@ -10559,7 +10533,6 @@
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.4",
@@ -10579,7 +10552,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.4"
@@ -10596,7 +10568,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -10615,7 +10586,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -10852,7 +10822,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -11289,7 +11258,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -11550,17 +11518,59 @@
       }
     },
     "node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
       },
       "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -11684,7 +11694,6 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -11732,16 +11741,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/uuid": {
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
@@ -11767,7 +11766,6 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -13502,10 +13500,9 @@
       "devDependencies": {},
       "peerDependencies": {
         "@event-driven-io/emmett": "0.43.0-beta.38",
-        "@types/express": "^4.17.21",
+        "@types/express": "^5.0.6",
         "@types/supertest": "^7.2.0",
-        "express": "^4.22.1",
-        "express-async-errors": "^3.1.1",
+        "express": "^5.2.1",
         "http-problem-details": "^0.1.7",
         "supertest": "^7.2.2"
       }

--- a/src/package.json
+++ b/src/package.json
@@ -120,7 +120,7 @@
   },
   "peerDependencies": {
     "@event-driven-io/pongo": "0.17.0-beta.47",
-    "@types/express": "4.17.21",
+    "@types/express": "^5.0.6",
     "@types/node": "^25.6.0",
     "@types/supertest": "^7.2.0",
     "supertest": "7.2.2"
@@ -143,6 +143,7 @@
     "@testcontainers/postgresql": "^11.14.0",
     "commander": "^14.0.3",
     "dotenv": "^17.4.2",
+    "express": "^5.2.1",
     "mitata": "^1.0.34"
   }
 }

--- a/src/packages/emmett-expressjs/README.md
+++ b/src/packages/emmett-expressjs/README.md
@@ -1,49 +1,26 @@
 # @event-driven-io/emmett-expressjs
 
-Express.js integration for the Emmett event sourcing library, providing HTTP request handling, response helpers, ETag support for optimistic concurrency, RFC 7807 Problem Details middleware, and BDD-style API testing utilities.
+Express.js integration for Emmett Web APIs.
+
+Use this package when you want to expose your application through HTTP and you already have an Express API, prefer Express for new services, or want a mature Node.js web framework with a small integration layer. The package helps with route composition, response helpers, Problem Details errors, explicit ETags for optimistic concurrency, trace IDs, and API tests.
+
+Routes remain ordinary Express routes. A command route reads and validates the request, obtains any external data the decision needs, calls the command handler, and chooses a response. A query route reads its parameters, queries the read store, and returns the matching model. The integration supplies the repeated HTTP boundary work around both kinds of route.
+
+The application setup and response helpers can also be used without event sourcing. The command-result, ETag, and event-backed testing helpers are useful when those concerns are part of the API.
 
 ## Purpose
 
-This package bridges Emmett's event sourcing capabilities with Express.js web applications. It provides:
+This package provides the Express-specific pieces around an HTTP API:
 
-- A functional handler pattern with deferred response execution
-- Built-in ETag utilities for optimistic concurrency control
-- RFC 7807 Problem Details error handling middleware
-- BDD-style API specification testing utilities
-- Response helpers for common HTTP status codes
+| Concern                | What the package provides                                                                   | What remains in the route or application                  |
+| ---------------------- | ------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| Express setup          | Request parsing, feature-route registration, optional trace IDs, and Problem Details errors | Authentication and any application-specific middleware    |
+| HTTP responses         | Helpers for status codes, bodies, `Location`, ETag, and Problem Details responses           | Choosing the response that represents each route outcome  |
+| Command results        | Mapping returned events to success or failure responses                                     | Deciding whether business failures are returned or thrown |
+| Optimistic concurrency | Reading `If-Match` and returning stream versions as ETags                                   | Choosing which writes require a client-supplied version   |
+| API tests              | Given/when/then tests built on SuperTest                                                    | The requests, initial events, and outcomes to assert      |
 
-## Key Concepts
-
-### Handler Pattern
-
-The package uses an `on()` wrapper function that enables handlers to return `HttpResponse` functions rather than directly manipulating the response object. This creates a clean separation between business logic and HTTP response handling:
-
-```typescript
-export type HttpResponse = (response: Response) => void;
-
-export type HttpHandler<RequestType extends Request> = (
-  request: RequestType,
-) => Promise<HttpResponse> | HttpResponse;
-
-export const on =
-  <RequestType extends Request>(handle: HttpHandler<RequestType>) =>
-  async (
-    request: RequestType,
-    response: Response,
-    next: NextFunction,
-  ): Promise<void> => {
-    const setResponse = await Promise.resolve(handle(request));
-    return setResponse(response);
-  };
-```
-
-### ETag-Based Optimistic Concurrency
-
-Express's default ETag behavior is disabled to enable explicit optimistic concurrency control via `if-match` and `if-not-match` headers. The package provides branded `ETag` and `WeakETag` types for type-safe ETag handling.
-
-### Problem Details
-
-Errors are automatically converted to RFC 7807 Problem Details format. Errors with an `errorCode` property (100-599) map to the corresponding HTTP status code.
+It does not dispatch commands by itself, build projections, choose a database, or replace Express middleware. Those choices stay in the application.
 
 ## Installation
 
@@ -51,66 +28,96 @@ Errors are automatically converted to RFC 7807 Problem Details format. Errors wi
 npm install @event-driven-io/emmett-expressjs
 ```
 
-All dependencies are peer dependencies, so you also need to install:
-
-```bash
-npm install @event-driven-io/emmett express http-problem-details supertest
-npm install -D @types/express @types/supertest
-```
+The package declares peer dependencies for Emmett, Express, Problem Details, SuperTest, and their TypeScript types. npm 7 and newer install missing peers automatically. With package managers that do not install peer dependencies automatically, follow the peer dependency warnings they print.
 
 ## Quick Start
 
-### Creating an Express Application
+Start with a feature route setup. The route remains an ordinary Express route: it reads and validates the request, obtains external data the decision needs, calls the command handler, and chooses the HTTP response. This excerpt is copied from the tested Getting Started Web API snippet; the surrounding feature setup supplies the router, event store, command handler, and domain functions.
+
+```typescript
+router.post(
+  '/clients/:clientId/shopping-carts/current/product-items',
+  on(async (request: AddProductItemRequest) => {
+    const shoppingCartId = getShoppingCartId(
+      assertNotEmptyString(request.params.clientId),
+    );
+    const productId = assertNotEmptyString(request.body.productId);
+
+    const command: AddProductItemToShoppingCart = {
+      type: 'AddProductItemToShoppingCart',
+      data: {
+        shoppingCartId,
+        productItem: {
+          productId,
+          quantity: assertPositiveNumber(request.body.quantity),
+          unitPrice: await getUnitPrice(productId),
+        },
+      },
+      metadata: { now: getCurrentTime() },
+    };
+
+    await handle(eventStore, shoppingCartId, (state) =>
+      addProductItem(command, state),
+    );
+
+    return NoContent();
+  }),
+);
+```
+
+`getApplication` then creates Express, installs the default HTTP middleware, registers the feature routes, and adds shared Problem Details error handling:
 
 ```typescript
 import { getInMemoryEventStore } from '@event-driven-io/emmett';
 import { getApplication, startAPI } from '@event-driven-io/emmett-expressjs';
 import type { Application } from 'express';
+import type { Server } from 'http';
 
 const eventStore = getInMemoryEventStore();
 
+const shoppingCarts = shoppingCartApi(
+  eventStore,
+  getUnitPrice,
+  () => new Date(),
+);
+
 const application: Application = getApplication({
-  apis: [shoppingCartApi(eventStore)],
+  apis: [shoppingCarts],
 });
 
-startAPI(application, { port: 3000 });
+const server: Server = startAPI(application);
 ```
 
-### Using an Existing Express Application
+That replaces the usual bootstrap code for creating Express, installing body parsers, mounting feature routes, and registering shared error handling. It does not hide the routes, commands, queries, or dependencies that make up the API.
 
-Use `configureApplication` to keep ownership of the Express application while applying Emmett's conventional setup:
+By default, `getApplication` and `configureApplication`:
 
-```typescript
-import express from 'express';
-import {
-  configureApplication,
-  startAPI,
-} from '@event-driven-io/emmett-expressjs';
+1. Disable Express-generated ETags, so ETags returned by the API are explicit by default.
+2. Install `express.json()` and `express.urlencoded({ extended: true })`.
+3. Add the active trace ID to the `x-trace-id` response header when `observability` is provided.
+4. Register the supplied API route setups.
+5. Install Problem Details error middleware after those routes.
 
-const application = express();
+Each default parser and the Problem Details middleware can be disabled. Use `registerWebApi` when the application already owns the full middleware stack and only wants route registration.
 
-application.get('/health', (_request, response) => {
-  response.status(200).json({ status: 'ok' });
-});
-application.use(authMiddleware);
+## Application Setup
 
-configureApplication(application, {
-  apis: [shoppingCartApi(eventStore)],
-});
+Choose the setup function based on how much of the Express stack the package should configure:
 
-startAPI(application, { port: 3000 });
-```
+| Starting point                              | Use                                          | Result                                                                                    |
+| ------------------------------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| A new Web API                               | `getApplication(options)`                    | Creates Express and applies the default HTTP setup                                        |
+| An existing Express application             | `configureApplication(application, options)` | Adds the same default HTTP setup to the provided Express application                      |
+| An application with its own middleware plan | `registerWebApi(application, apiSetups)`     | Registers only the supplied route setups, without changing application settings or errors |
 
-It applies the same ETag setting, middleware, routes, and error handling as `getApplication`, including the middleware disable options.
-
-Use `registerWebApi` when infrastructure routes and middleware must be positioned completely explicitly. It registers only the supplied API routes; it does not configure the application or install middleware:
+For an existing application that already has middleware, `registerWebApi` lets the caller keep ordering explicit:
 
 ```typescript
 import express from 'express';
 import {
   problemDetailsMiddleware,
   registerWebApi,
-  startAPI,
+  traceIdMiddleware,
 } from '@event-driven-io/emmett-expressjs';
 
 const application = express();
@@ -118,329 +125,442 @@ const application = express();
 application.get('/health', (_request, response) => {
   response.status(200).json({ status: 'ok' });
 });
+application.use(express.json({ limit: '2mb' }));
+application.use(express.urlencoded({ extended: true }));
+application.use(traceIdMiddleware);
+application.use(authenticateRequest);
 
-application.use(express.json());
-application.use(authMiddleware);
+registerWebApi(application, [echoBodyApi, asyncErrorApi]);
 
-registerWebApi(application, [shoppingCartApi(eventStore)]);
 application.use(problemDetailsMiddleware());
-
-startAPI(application, { port: 3000 });
 ```
 
-Express runs middleware in registration order, so `/health` is outside the authentication middleware in this example. The caller also retains Express's own ETag configuration.
+In that example `/health` stays outside authentication. The API routes use the caller's parsers, tracing, and authentication. Problem Details middleware is registered after the routes whose errors it handles.
 
-### Defining API Routes
+### Application Options
+
+`getApplication` and `configureApplication` accept `ApplicationOptions`. Omitted boolean options are treated as `false`. For the `disable...` options, that means the default middleware is installed unless the option is set to `true`.
+
+| Option                            | Behaviour                                                                                                                             |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `apis`                            | Required. Each setup registers routes on one shared router, which is then mounted on the application                                  |
+| `mapError`                        | Optional error mapper tried before the default Problem Details mapping                                                                |
+| `enableDefaultExpressEtag`        | Default `false`. Keeps Express-generated ETags off. Set to `true` when responses should also receive Express cache validators         |
+| `disableJsonMiddleware`           | Default `false`. Installs `express.json()`. Set to `true` when the application configures JSON parsing itself                         |
+| `disableUrlEncodingMiddleware`    | Default `false`. Installs `express.urlencoded({ extended: true })`. Set to `true` when the application configures URL-encoded parsing |
+| `disableProblemDetailsMiddleware` | Default `false`. Installs Problem Details error middleware. Set to `true` when the application owns error serialisation               |
+| `observability`                   | Optional. When provided, adds the active trace ID to the `x-trace-id` response header                                                 |
+
+`configureApplication` also applies the ETag setting. It sets Express's `etag` option to `false` unless `enableDefaultExpressEtag` is `true`. Use `registerWebApi` instead when route registration must not change existing application settings.
+
+## Defining Routes
+
+A `WebApiSetup` is a function that receives an Express router. A feature can export one setup containing its related command and query endpoints while closing over the event store, read store, and other dependencies it needs.
+
+Command routes are where Emmett does most of its work: they call a command handler that loads state, runs the decision, and appends the resulting events. Query routes use the same Express and response helpers, but read from a read model instead of calling a command handler.
+
+This query route is copied from the existing Query Read Models snippet. It uses an injected Pongo read store, returns 404 when the read model is absent or no longer open, and returns the model with 200 when found:
 
 ```typescript
 import {
-  NoContent,
   NotFound,
   OK,
   on,
   type WebApiSetup,
 } from '@event-driven-io/emmett-expressjs';
-import { CommandHandler, type EventStore } from '@event-driven-io/emmett';
+import type { PongoDb } from '@event-driven-io/pongo';
 import type { Request, Router } from 'express';
 
-export const shoppingCartApi =
-  (eventStore: EventStore): WebApiSetup =>
+type ShoppingCartShortInfo = {
+  productItemsCount: number;
+  totalAmount: number;
+};
+
+type ShoppingCartDetails = {
+  clientId: string;
+  productItemsCount: number;
+  totalAmount: number;
+  status: 'Opened' | 'Confirmed' | 'Cancelled';
+  openedAt: Date;
+  confirmedAt?: Date | undefined;
+  cancelledAt?: Date | undefined;
+};
+
+const shoppingCartShortInfoCollectionName = 'shoppingCartShortInfo';
+const shoppingCartDetailsCollectionName = 'shoppingCartDetails';
+
+const getShortInfoById = (
+  db: PongoDb,
+  shoppingCartId: string,
+): Promise<ShoppingCartShortInfo | null> =>
+  db
+    .collection<ShoppingCartShortInfo>(shoppingCartShortInfoCollectionName)
+    .findOne({ _id: shoppingCartId });
+
+const getDetailsById = (
+  db: PongoDb,
+  shoppingCartId: string,
+): Promise<ShoppingCartDetails | null> =>
+  db
+    .collection<ShoppingCartDetails>(shoppingCartDetailsCollectionName)
+    .findOne({ _id: shoppingCartId });
+
+const shoppingCartApi =
+  (readStore: PongoDb): WebApiSetup =>
   (router: Router) => {
-    // POST endpoint with command handling
-    router.post(
-      '/clients/:clientId/shopping-carts/current/product-items',
-      on(async (request: Request) => {
-        const shoppingCartId = `shopping_cart:${request.params.clientId}:current`;
-
-        await handle(eventStore, shoppingCartId, (state) =>
-          addProductItem(
-            {
-              type: 'AddProductItemToShoppingCart',
-              data: {
-                shoppingCartId,
-                productItem: request.body,
-              },
-            },
-            state,
-          ),
-        );
-
-        return NoContent();
-      }),
-    );
-
-    // GET endpoint with state aggregation
     router.get(
       '/clients/:clientId/shopping-carts/current',
       on(async (request: Request) => {
-        const shoppingCartId = `shopping_cart:${request.params.clientId}:current`;
+        const shoppingCartId = `shopping_cart:${String(request.params.clientId)}:current`;
 
-        const result = await eventStore.aggregateStream(shoppingCartId, {
-          evolve,
-          initialState,
-        });
+        const result = await getDetailsById(readStore, shoppingCartId);
 
-        if (result === null) return NotFound();
+        if (result === null)
+          return NotFound({
+            problemDetails: 'No open shopping cart was found',
+          });
 
-        return OK({ body: result.state });
+        if (result.status !== 'Opened')
+          return NotFound({
+            problemDetails: 'No open shopping cart was found',
+          });
+
+        return OK({ body: result });
+      }),
+    );
+
+    router.get(
+      '/clients/:clientId/shopping-carts/current/short-info',
+      on(async (request: Request) => {
+        const shoppingCartId = `shopping_cart:${String(request.params.clientId)}:current`;
+
+        const result = await getShortInfoById(readStore, shoppingCartId);
+
+        if (result === null)
+          return NotFound({
+            problemDetails: 'Shopping cart summary was not found',
+          });
+
+        return OK({ body: result });
       }),
     );
   };
 ```
 
-## How-to Guides
+`on` adapts an async route function that returns an `HttpResponse`. The response helper applies the status, body, and headers to the Express response. The route still chooses the outcome. See the Getting Started and Query Read Models docs for the surrounding command handler, projection, and read-store setup.
 
-### Working with ETags
+## Response Helpers
 
-Use ETags for optimistic concurrency control in update operations:
+The response helpers give routes one return shape for expected outcomes:
+
+| Helper               | Status | Typical use                                                                 |
+| -------------------- | ------ | --------------------------------------------------------------------------- |
+| `OK`                 | 200    | Return a representation, with optional `Location` and ETag headers          |
+| `Created`            | 201    | Return a newly created resource or ID and set its `Location`                |
+| `Accepted`           | 202    | Accept work that continues elsewhere and identify its status resource       |
+| `NoContent`          | 204    | Complete a command without returning a body, optionally with an ETag        |
+| `HttpResponse`       | Custom | Use another successful or application-specific status                       |
+| `BadRequest`         | 400    | Return Problem Details for a request the API cannot accept                  |
+| `Forbidden`          | 403    | Return Problem Details when the requested operation is not allowed          |
+| `NotFound`           | 404    | Return Problem Details when the requested resource is absent                |
+| `Conflict`           | 409    | Return Problem Details when the request conflicts with the current state    |
+| `PreconditionFailed` | 412    | Return Problem Details when a condition such as `If-Match` is not satisfied |
+| `HttpProblem`        | Custom | Return Problem Details with another error status                            |
+
+`Created({ createdId })` appends `createdId` to the request URL for the `Location` header and sends `{ id: createdId, ...body }`. `Created({ url })` sets `Location` directly. `Accepted` requires `location`; the other success helpers accept it optionally.
+
+Problem responses accept either `problem: ProblemDocument` or `problemDetails: string`.
+
+## Problem Details Errors
+
+`getApplication` and `configureApplication` install `problemDetailsMiddleware` after the API routes by default. Express passes thrown errors and rejected async handlers to it, and the middleware returns `application/problem+json` using the Problem Details format.
+
+That is useful when more than one route can fail. Without shared error middleware, every command and query route needs to catch errors, choose an HTTP status, and maintain its own error-body shape. Problem Details keeps the public error contract consistent across routes.
+
+The default mapping uses a numeric `errorCode` from 100 through 599 as the HTTP status. Plain `Error` objects without a valid `errorCode` become 500 responses with the error message as `detail`. Strings become 500 responses with the string as `detail`. Other values become 500 responses with `Internal Server Error`.
+
+Use `mapError` for errors from libraries or application code that should be translated into a public Problem Details document:
+
+```typescript
+import { getApplication, on } from '@event-driven-io/emmett-expressjs';
+import type { Router } from 'express';
+import { ProblemDocument } from 'http-problem-details';
+
+// an error from a library you do not control
+class CardDeclinedError extends Error {
+  constructor(public readonly code: string) {
+    super(`Card declined: ${code}`);
+  }
+}
+
+const checkoutApi = (router: Router) =>
+  router.post(
+    '/charges',
+    on(() => {
+      throw new CardDeclinedError('insufficient_funds');
+    }),
+  );
+
+const checkoutApplication = getApplication({
+  apis: [checkoutApi],
+  // translate a foreign error into Problem Details;
+  // return undefined to fall back to the default mapping
+  mapError: (error) =>
+    error instanceof CardDeclinedError
+      ? new ProblemDocument({
+          type: 'https://errors.example.com/card-declined',
+          status: 402,
+          title: 'Card Declined',
+          detail: error.message,
+        })
+      : undefined,
+});
+```
+
+Set `disableProblemDetailsMiddleware: true` when the application already has an error contract.
+
+## Command Results from Returned Events
+
+A command handler can return a business failure event without appending it, for example through `rejectOn` or `stopOn`. Because nothing was thrown, Express error middleware does not see that outcome. `ResponseFromEvents` maps the returned events explicitly to the same `HttpResponse` shape used by other `on` handlers.
+
+The tested route excerpt below shows the integration point. The command handler and event store are supplied by the surrounding application setup:
 
 ```typescript
 import {
-  getETagFromIfMatch,
-  getWeakETagValue,
-  toWeakETag,
-  NoContent,
-  PreconditionFailed,
+  Conflict,
+  ResponseFromEvents,
+  on,
 } from '@event-driven-io/emmett-expressjs';
 
-router.put(
-  '/carts/:id',
-  on(async (request: Request) => {
-    const expectedVersion = getWeakETagValue(getETagFromIfMatch(request));
+const addProductItemApi = (router: Router) => {
+  router.post(
+    '/shopping-carts/:shoppingCartId/product-items',
+    on(async (request: AddProductItemRequest) => {
+      const result = await handleAddProductItem(
+        eventStore,
+        request.params.shoppingCartId,
+        {
+          type: 'AddProductItem',
+          data: {
+            productId: String(request.body.productId),
+            quantity: Number(request.body.quantity),
+            availableQuantity: 2,
+          },
+        },
+      );
+
+      return ResponseFromEvents({
+        events: result,
+        success: 204,
+        failure: (event) => {
+          switch (event.type) {
+            case 'ProductItemOutOfStock':
+              return Conflict({
+                problemDetails: `Only ${event.data.availableQuantity} items are available`,
+              });
+          }
+          return undefined;
+        },
+      });
+    }),
+  );
+};
+```
+
+`sendResponseFromEvents(response, options)` performs the same selection and applies the response immediately.
+
+## ETags for Optimistic Concurrency
+
+The ETag helpers carry stream versions through HTTP:
+
+1. A successful command response returns the current stream version as an ETag.
+2. The client sends that value in `If-Match` with its next update.
+3. The route passes the value to the command handler as `expectedStreamVersion`.
+4. If another request changed the stream first, the default error mapping returns 412 Precondition Failed.
+
+```typescript
+import {
+  NoContent,
+  getETagValueFromIfMatch,
+  on,
+  toWeakETag,
+} from '@event-driven-io/emmett-expressjs';
+
+// Add a product item, guarded by the version carried in the If-Match header
+router.post(
+  '/clients/:clientId/shopping-carts/:shoppingCartId/product-items',
+  on(async (request: AddProductItemRequest) => {
+    const shoppingCartId = assertNotEmptyString(request.params.shoppingCartId);
+    const productItem: ProductItem = {
+      productId: assertNotEmptyString(request.body.productId),
+      quantity: assertPositiveNumber(request.body.quantity),
+    };
+    const unitPrice = dummyPriceProvider(productItem.productId);
+
+    const command: AddProductItemToShoppingCart = {
+      type: 'AddProductItemToShoppingCart',
+      data: { shoppingCartId, productItem: { ...productItem, unitPrice } },
+    };
 
     const result = await handle(
       eventStore,
-      request.params.id,
-      (state) => updateCart(request.body, state),
-      { expectedStreamVersion: BigInt(expectedVersion) },
+      shoppingCartId,
+      (state) => decide(command, state),
+      {
+        expectedStreamVersion: assertUnsignedBigInt(
+          getETagValueFromIfMatch(request),
+        ),
+      },
     );
 
-    return NoContent({ eTag: toWeakETag(result.nextExpectedStreamVersion) });
+    return NoContent({
+      eTag: toWeakETag(result.nextExpectedStreamVersion),
+    });
   }),
 );
 ```
 
-### Custom Error Mapping
+`getApplication` and `configureApplication` disable Express-generated ETags by default. This keeps stream-version ETags explicit. Express-generated ETags are content validators, not stream versions. Set `enableDefaultExpressEtag: true` only when the API also wants Express cache validators for responses that do not set an ETag explicitly.
 
-Map domain errors to specific Problem Details responses:
+`registerWebApi` does not change the Express ETag setting.
 
-```typescript
-import { getApplication } from '@event-driven-io/emmett-expressjs';
-import { ProblemDocument } from 'http-problem-details';
+## API Testing
 
-const application = getApplication({
-  apis: [myApi],
-  mapError: (error, request) => {
-    if (error instanceof CartNotFoundError) {
-      return new ProblemDocument({
-        type: 'https://example.com/problems/cart-not-found',
-        title: 'Cart Not Found',
-        detail: error.message,
-        status: 404,
-      });
-    }
-    return undefined; // Fall back to default mapping
-  },
-});
-```
-
-### BDD-Style API Testing
-
-Write declarative API tests using the given-when-then pattern:
+`ApiSpecification` builds SuperTest-based tests around a fresh event store and Express application. It can seed existing streams, execute one HTTP request, assert the response, and assert the events appended by the request:
 
 ```typescript
 import {
   ApiSpecification,
+  HeaderNames,
   existingStream,
   expectNewEvents,
   expectResponse,
-  expectError,
   getApplication,
+  toWeakETag,
 } from '@event-driven-io/emmett-expressjs';
-import {
-  getInMemoryEventStore,
-  type EventStore,
-} from '@event-driven-io/emmett';
-import { describe, it } from 'node:test';
+import { getInMemoryEventStore } from '@event-driven-io/emmett';
+import { it } from 'vitest';
 
-describe('ShoppingCart API', () => {
-  const given = ApiSpecification.for<ShoppingCartEvent>(
-    (): EventStore => getInMemoryEventStore(),
-    (eventStore: EventStore) =>
-      getApplication({
-        apis: [shoppingCartApi(eventStore)],
-      }),
-  );
-
-  it('should add product to empty cart', () => {
-    return given()
-      .when((request) =>
-        request
-          .post('/clients/123/shopping-carts/current/product-items')
-          .send({ productId: 'shoes', quantity: 1 }),
-      )
-      .then([
-        expectResponse(204),
-        expectNewEvents('shopping_cart:123:current', [
-          {
-            type: 'ProductItemAddedToShoppingCart',
-            data: { productId: 'shoes', quantity: 1 },
-          },
-        ]),
-      ]);
-  });
-
-  it('should not add to confirmed cart', () => {
-    return given(
-      existingStream('shopping_cart:123:current', [
-        { type: 'ShoppingCartConfirmed', data: { confirmedAt: new Date() } },
-      ]),
-    )
-      .when((request) =>
-        request
-          .post('/clients/123/shopping-carts/current/product-items')
-          .send({ productId: 'shoes', quantity: 1 }),
-      )
-      .then(
-        expectError(403, {
-          detail: 'Shopping Cart already closed',
-          status: 403,
-        }),
-      );
-  });
+const apiSpecification = ApiSpecification.for({
+  getEventStore: () => getInMemoryEventStore(),
+  getApplication: (eventStore) =>
+    getApplication({
+      apis: [shoppingCartApi(eventStore)],
+    }),
 });
-```
 
-### E2E API Testing
+void it('checks an HTTP response and newly appended events', () => {
+  const clientId = 'client-123';
+  const shoppingCartId = `shopping_cart:${clientId}:current`;
+  const productItem = { productId: 'product-123', quantity: 2 };
 
-For end-to-end tests that execute multiple requests in sequence:
-
-```typescript
-import { ApiE2ESpecification } from '@event-driven-io/emmett-expressjs';
-
-const given = ApiE2ESpecification.for(
-  () => getEventStoreDBEventStore(client),
-  (eventStore) => getApplication({ apis: [shoppingCartApi(eventStore)] }),
-);
-
-it('should confirm cart after adding products', () => {
-  return given((request) =>
-    request
-      .post('/clients/123/shopping-carts/current/product-items')
-      .send({ productId: 'shoes', quantity: 1 }),
+  return apiSpecification(
+    existingStream<ShoppingCartEvent>(shoppingCartId, [
+      {
+        type: 'ShoppingCartOpened',
+        data: {
+          shoppingCartId,
+          clientId,
+          openedAt: new Date('2024-01-01T00:00:00Z'),
+        },
+      },
+    ]),
   )
     .when((request) =>
-      request.post('/clients/123/shopping-carts/current/confirm'),
+      request
+        .post(
+          `/clients/${clientId}/shopping-carts/${shoppingCartId}/product-items`,
+        )
+        .set(HeaderNames.IF_MATCH, toWeakETag(1))
+        .send(productItem),
     )
-    .then([expectResponse(204)]);
+    .then([
+      expectResponse(204, { headers: { etag: toWeakETag(2) } }),
+      expectNewEvents(shoppingCartId, [
+        {
+          type: 'ProductItemAddedToShoppingCart',
+          data: {
+            shoppingCartId,
+            productItem: { ...productItem, unitPrice: 100 },
+          },
+        },
+      ]),
+    ]);
 });
 ```
+
+Use `ApiE2ESpecification` when a test needs to execute setup requests before the request being asserted.
 
 ## API Reference
 
 ### Application
 
-| Export                 | Type                       | Description                                                             |
-| ---------------------- | -------------------------- | ----------------------------------------------------------------------- |
-| `WebApiSetup`          | `(router: Router) => void` | Function type for registering API routes                                |
-| `ApplicationOptions`   | Object                     | Configuration for Express app (apis, error mapping, middleware toggles) |
-| `configureApplication` | Function                   | Applies the conventional Emmett setup to an existing application        |
-| `getApplication`       | Function                   | Creates configured Express application                                  |
-| `registerWebApi`       | Function                   | Registers only Emmett API routes on an existing Express application     |
-| `StartApiOptions`      | Object                     | Server startup configuration                                            |
-| `startAPI`             | Function                   | Starts HTTP server on specified port                                    |
+| Export                 | Description                                                                     |
+| ---------------------- | ------------------------------------------------------------------------------- |
+| `WebApiSetup`          | Function type for registering routes on an Express router                       |
+| `ApplicationOptions`   | Options for route setup, middleware defaults, ETags, error mapping, and tracing |
+| `getApplication`       | Creates a configured Express application                                        |
+| `configureApplication` | Applies the default setup to an existing Express application                    |
+| `registerWebApi`       | Registers only the supplied route setups on an existing Express application     |
+| `StartApiOptions`      | Server startup options                                                          |
+| `startAPI`             | Creates an HTTP server and starts listening                                     |
 
-### Handler & Responses
+### Handlers and Responses
 
-| Export                     | Type                           | Description                               |
-| -------------------------- | ------------------------------ | ----------------------------------------- |
-| `HttpResponse`             | `(response: Response) => void` | Deferred response function                |
-| `HttpHandler<RequestType>` | Function                       | Async handler returning HttpResponse      |
-| `on`                       | Function                       | Wrapper for HttpHandler functions         |
-| `OK`                       | Function                       | Returns 200 response                      |
-| `Created`                  | Function                       | Returns 201 response with Location header |
-| `Accepted`                 | Function                       | Returns 202 response                      |
-| `NoContent`                | Function                       | Returns 204 response                      |
-| `BadRequest`               | Function                       | Returns 400 Problem Details               |
-| `Forbidden`                | Function                       | Returns 403 Problem Details               |
-| `NotFound`                 | Function                       | Returns 404 Problem Details               |
-| `Conflict`                 | Function                       | Returns 409 Problem Details               |
-| `PreconditionFailed`       | Function                       | Returns 412 Problem Details               |
-| `HttpProblem`              | Function                       | Returns custom status Problem Details     |
+| Export                    | Description                                                                   |
+| ------------------------- | ----------------------------------------------------------------------------- |
+| `HttpResponse`            | Response function type and custom status response helper                      |
+| `HttpHandler`             | Route function type that returns an `HttpResponse` or `Promise<HttpResponse>` |
+| `on`                      | Express handler adapter for `HttpHandler` functions                           |
+| `OK`, `Created`           | 200 and 201 success response helpers                                          |
+| `Accepted`, `NoContent`   | 202 and 204 success response helpers                                          |
+| `BadRequest`, `Forbidden` | 400 and 403 Problem Details helpers                                           |
+| `NotFound`, `Conflict`    | 404 and 409 Problem Details helpers                                           |
+| `PreconditionFailed`      | 412 Problem Details helper                                                    |
+| `HttpProblem`             | Custom status Problem Details helper                                          |
+| `ResponseFromEvents`      | Maps returned events to a success or failure response                         |
+| `sendResponseFromEvents`  | Applies `ResponseFromEvents` directly to an Express response                  |
 
-### ETag Utilities
+### ETags
 
-| Export                    | Type           | Description                             |
-| ------------------------- | -------------- | --------------------------------------- |
-| `ETag`                    | Branded string | Strong ETag type                        |
-| `WeakETag`                | Branded string | Weak ETag type (W/"...")                |
-| `toWeakETag`              | Function       | Creates WeakETag from version number    |
-| `getETagFromIfMatch`      | Function       | Extracts ETag from if-match header      |
-| `getETagFromIfNotMatch`   | Function       | Extracts ETag from if-not-match header  |
-| `getWeakETagValue`        | Function       | Extracts version value from WeakETag    |
-| `getETagValueFromIfMatch` | Function       | Gets version value from if-match header |
-| `setETag`                 | Function       | Sets ETag response header               |
-| `isWeakETag`              | Function       | Type guard for WeakETag                 |
-
-### Testing
-
-| Export                | Type     | Description                                 |
-| --------------------- | -------- | ------------------------------------------- |
-| `ApiSpecification`    | Object   | BDD test builder for unit testing           |
-| `ApiE2ESpecification` | Object   | BDD test builder for E2E testing            |
-| `existingStream`      | Function | Defines pre-existing event stream for tests |
-| `expectNewEvents`     | Function | Asserts expected new events in stream       |
-| `expectResponse`      | Function | Asserts response status and body            |
-| `expectError`         | Function | Asserts error response with Problem Details |
-| `TestRequest`         | Type     | Function type for supertest requests        |
+| Export                    | Description                                                                  |
+| ------------------------- | ---------------------------------------------------------------------------- |
+| `HeaderNames`             | Header-name constants for `if-match`, `if-not-match`, and `etag`             |
+| `ETag`, `WeakETag`        | Branded ETag string types                                                    |
+| `WeakETagRegex`           | Regular expression used by the weak ETag parser                              |
+| `ETagErrors`              | Error identifiers for missing and invalid ETag headers                       |
+| `toWeakETag`              | Formats a number, bigint, or string as a weak ETag                           |
+| `isWeakETag`              | Type guard for weak ETags                                                    |
+| `getWeakETagValue`        | Returns the value inside a weak ETag or throws a concurrency error           |
+| `getETagFromIfMatch`      | Reads `If-Match` or throws a concurrency error when the header is absent     |
+| `getETagFromIfNotMatch`   | Reads `If-Not-Match` or throws a concurrency error when the header is absent |
+| `getETagValueFromIfMatch` | Unwraps a weak `If-Match` value and returns any other ETag value unchanged   |
+| `setETag`                 | Sets the response `ETag` header                                              |
 
 ### Middleware
 
-| Export                                | Type     | Description                              |
-| ------------------------------------- | -------- | ---------------------------------------- |
-| `problemDetailsMiddleware`            | Function | Express error middleware for RFC 7807    |
-| `defaultErrorToProblemDetailsMapping` | Function | Default error to ProblemDocument mapping |
-| `traceIdMiddleware`                   | Function | Adds the active trace ID response header |
-| `ErrorToProblemDetailsMapping`        | Type     | Custom error mapping function type       |
+| Export                                | Description                                                        |
+| ------------------------------------- | ------------------------------------------------------------------ |
+| `problemDetailsMiddleware`            | Express error middleware that serialises errors as Problem Details |
+| `defaultErrorToProblemDetailsMapping` | Default error-to-Problem Details mapper                            |
+| `traceIdMiddleware`                   | Adds the active trace ID to the `x-trace-id` response header       |
+| `ErrorToProblemDetailsMapping`        | Type for a custom error mapper                                     |
 
-## Architecture
+### Testing
 
-```
-src/
-├── index.ts                              # Package entry point
-├── application.ts                        # Express app factory and server startup
-├── handler.ts                            # HttpResponse, on() wrapper, response helpers
-├── etag.ts                               # ETag utilities for optimistic concurrency
-├── responses.ts                          # Low-level HTTP response sending
-├── middlewares/
-│   └── problemDetailsMiddleware.ts       # RFC 7807 error handling
-└── testing/
-    ├── index.ts                          # Testing module entry point
-    ├── apiSpecification.ts               # BDD unit test specification
-    └── apiE2ESpecification.ts            # BDD E2E test specification
-```
+| Export                | Description                                                           |
+| --------------------- | --------------------------------------------------------------------- |
+| `ApiSpecification`    | Given/when/then API test builder with event-store seeding and asserts |
+| `ApiE2ESpecification` | Given/when/then API test builder for multi-request flows              |
+| `existingStream`      | Defines a stream and events to seed before a request                  |
+| `expectNewEvents`     | Asserts events appended by the request                                |
+| `expectResponse`      | Asserts response status, body, and headers                            |
+| `expectError`         | Asserts a Problem Details error response                              |
+| `TestRequest`         | Type for a SuperTest request setup function                           |
 
-### Request Flow
+## Documentation
 
-1. Request arrives at Express router
-2. `on()` wrapper invokes the `HttpHandler`
-3. Handler processes request and returns an `HttpResponse` function
-4. `on()` wrapper calls the `HttpResponse` function with the Express response
-5. On error, `problemDetailsMiddleware` converts to RFC 7807 format
-
-### Testing Architecture
-
-The `ApiSpecification` wraps the event store to track appended events, enabling assertions on both HTTP responses and event store state changes. Test streams can be pre-populated using `existingStream()`.
-
-## Dependencies
-
-### Peer Dependencies (must be installed separately)
-
-| Package                   | Version        | Purpose                     |
-| ------------------------- | -------------- | --------------------------- |
-| `@event-driven-io/emmett` | 0.43.0-beta.38 | Core event sourcing library |
-| `express`                 | ^5.2.1         | Web framework               |
-| `http-problem-details`    | ^0.1.7         | RFC 7807 Problem Details    |
-| `supertest`               | ^7.2.2         | HTTP testing library        |
-| `@types/express`          | ^5.0.6         | Express type definitions    |
-| `@types/supertest`        | ^7.2.0         | Supertest type definitions  |
+- [Express.js Integration](https://event-driven-io.github.io/emmett/frameworks/expressjs.html)
+- [Getting Started](https://event-driven-io.github.io/emmett/getting-started.html)
+- [Command Handling](https://event-driven-io.github.io/emmett/guides/command-handling.html)
+- [Query Read Models](https://event-driven-io.github.io/emmett/guides/projections.html#query)

--- a/src/packages/emmett-expressjs/README.md
+++ b/src/packages/emmett-expressjs/README.md
@@ -54,7 +54,7 @@ npm install @event-driven-io/emmett-expressjs
 All dependencies are peer dependencies, so you also need to install:
 
 ```bash
-npm install @event-driven-io/emmett express express-async-errors http-problem-details supertest
+npm install @event-driven-io/emmett express http-problem-details supertest
 npm install -D @types/express @types/supertest
 ```
 
@@ -75,6 +75,60 @@ const application: Application = getApplication({
 
 startAPI(application, { port: 3000 });
 ```
+
+### Using an Existing Express Application
+
+Use `configureApplication` to keep ownership of the Express application while applying Emmett's conventional setup:
+
+```typescript
+import express from 'express';
+import {
+  configureApplication,
+  startAPI,
+} from '@event-driven-io/emmett-expressjs';
+
+const application = express();
+
+application.get('/health', (_request, response) => {
+  response.status(200).json({ status: 'ok' });
+});
+application.use(authMiddleware);
+
+configureApplication(application, {
+  apis: [shoppingCartApi(eventStore)],
+});
+
+startAPI(application, { port: 3000 });
+```
+
+It applies the same ETag setting, middleware, routes, and error handling as `getApplication`, including the middleware disable options.
+
+Use `registerWebApi` when infrastructure routes and middleware must be positioned completely explicitly. It registers only the supplied API routes; it does not configure the application or install middleware:
+
+```typescript
+import express from 'express';
+import {
+  problemDetailsMiddleware,
+  registerWebApi,
+  startAPI,
+} from '@event-driven-io/emmett-expressjs';
+
+const application = express();
+
+application.get('/health', (_request, response) => {
+  response.status(200).json({ status: 'ok' });
+});
+
+application.use(express.json());
+application.use(authMiddleware);
+
+registerWebApi(application, [shoppingCartApi(eventStore)]);
+application.use(problemDetailsMiddleware());
+
+startAPI(application, { port: 3000 });
+```
+
+Express runs middleware in registration order, so `/health` is outside the authentication middleware in this example. The caller also retains Express's own ETag configuration.
 
 ### Defining API Routes
 
@@ -177,7 +231,7 @@ import { ProblemDocument } from 'http-problem-details';
 const application = getApplication({
   apis: [myApi],
   mapError: (error, request) => {
-    if (error.name === 'CartNotFoundError') {
+    if (error instanceof CartNotFoundError) {
       return new ProblemDocument({
         type: 'https://example.com/problems/cart-not-found',
         title: 'Cart Not Found',
@@ -286,13 +340,15 @@ it('should confirm cart after adding products', () => {
 
 ### Application
 
-| Export               | Type                       | Description                                                             |
-| -------------------- | -------------------------- | ----------------------------------------------------------------------- |
-| `WebApiSetup`        | `(router: Router) => void` | Function type for registering API routes                                |
-| `ApplicationOptions` | Object                     | Configuration for Express app (apis, error mapping, middleware toggles) |
-| `getApplication`     | Function                   | Creates configured Express application                                  |
-| `StartApiOptions`    | Object                     | Server startup configuration                                            |
-| `startAPI`           | Function                   | Starts HTTP server on specified port                                    |
+| Export                 | Type                       | Description                                                             |
+| ---------------------- | -------------------------- | ----------------------------------------------------------------------- |
+| `WebApiSetup`          | `(router: Router) => void` | Function type for registering API routes                                |
+| `ApplicationOptions`   | Object                     | Configuration for Express app (apis, error mapping, middleware toggles) |
+| `configureApplication` | Function                   | Applies the conventional Emmett setup to an existing application        |
+| `getApplication`       | Function                   | Creates configured Express application                                  |
+| `registerWebApi`       | Function                   | Registers only Emmett API routes on an existing Express application     |
+| `StartApiOptions`      | Object                     | Server startup configuration                                            |
+| `startAPI`             | Function                   | Starts HTTP server on specified port                                    |
 
 ### Handler & Responses
 
@@ -344,6 +400,7 @@ it('should confirm cart after adding products', () => {
 | ------------------------------------- | -------- | ---------------------------------------- |
 | `problemDetailsMiddleware`            | Function | Express error middleware for RFC 7807    |
 | `defaultErrorToProblemDetailsMapping` | Function | Default error to ProblemDocument mapping |
+| `traceIdMiddleware`                   | Function | Adds the active trace ID response header |
 | `ErrorToProblemDetailsMapping`        | Type     | Custom error mapping function type       |
 
 ## Architecture
@@ -379,12 +436,11 @@ The `ApiSpecification` wraps the event store to track appended events, enabling 
 
 ### Peer Dependencies (must be installed separately)
 
-| Package                   | Version  | Purpose                     |
-| ------------------------- | -------- | --------------------------- |
-| `@event-driven-io/emmett` | 0.38.3   | Core event sourcing library |
-| `express`                 | ^4.19.2  | Web framework               |
-| `express-async-errors`    | ^3.1.1   | Async error handling        |
-| `http-problem-details`    | ^0.1.5   | RFC 7807 Problem Details    |
-| `supertest`               | ^7.0.0   | HTTP testing library        |
-| `@types/express`          | ^4.17.21 | Express type definitions    |
-| `@types/supertest`        | ^6.0.2   | Supertest type definitions  |
+| Package                   | Version        | Purpose                     |
+| ------------------------- | -------------- | --------------------------- |
+| `@event-driven-io/emmett` | 0.43.0-beta.38 | Core event sourcing library |
+| `express`                 | ^5.2.1         | Web framework               |
+| `http-problem-details`    | ^0.1.7         | RFC 7807 Problem Details    |
+| `supertest`               | ^7.2.2         | HTTP testing library        |
+| `@types/express`          | ^5.0.6         | Express type definitions    |
+| `@types/supertest`        | ^7.2.0         | Supertest type definitions  |

--- a/src/packages/emmett-expressjs/package.json
+++ b/src/packages/emmett-expressjs/package.json
@@ -49,10 +49,9 @@
   "devDependencies": {},
   "peerDependencies": {
     "@event-driven-io/emmett": "0.43.0-beta.38",
-    "@types/express": "^4.17.21",
+    "@types/express": "^5.0.6",
     "@types/supertest": "^7.2.0",
-    "express": "^4.22.1",
-    "express-async-errors": "^3.1.1",
+    "express": "^5.2.1",
     "http-problem-details": "^0.1.7",
     "supertest": "^7.2.2"
   }

--- a/src/packages/emmett-expressjs/src/application.int.spec.ts
+++ b/src/packages/emmett-expressjs/src/application.int.spec.ts
@@ -1,0 +1,323 @@
+import {
+  assertDeepEqual,
+  assertEqual,
+  assertFalse,
+  assertOk,
+  assertTrue,
+} from '@event-driven-io/emmett';
+import express, {
+  type ErrorRequestHandler,
+  type Request,
+  type Router,
+} from 'express';
+import type { ProblemDocument } from 'http-problem-details';
+import request from 'supertest';
+import { describe, it } from 'vitest';
+import {
+  configureApplication,
+  getApplication,
+  on,
+  problemDetailsMiddleware,
+  registerWebApi,
+  type HttpResponse,
+  type WebApiSetup,
+} from '.';
+
+const echoBodyApi: WebApiSetup = (router) => {
+  router.post('/echo', (req, res) => {
+    const body: unknown = req.body;
+    res.status(200).json({ body: body ?? null });
+  });
+};
+
+void describe('registerWebApi', () => {
+  void it('registers API routes on and returns the provided application', async () => {
+    const application = express();
+    application.set('trust proxy', 1);
+
+    const registered = registerWebApi(application, [
+      (router) => router.get('/orders', (_req, res) => res.sendStatus(204)),
+    ]);
+
+    assertOk(registered === application);
+    assertEqual(registered.get('trust proxy'), 1);
+
+    const response = await request(application).get('/orders').send();
+    assertEqual(response.statusCode, 204);
+  });
+
+  void it('supports named wildcard route parameters', async () => {
+    const application = express();
+
+    registerWebApi(application, [
+      (router) => {
+        router.get('/files/{*path}', (req, res) => {
+          res.status(200).json({ path: req.params.path });
+        });
+      },
+    ]);
+
+    const response = await request(application).get('/files/a/b').send();
+
+    assertEqual(response.statusCode, 200);
+    assertDeepEqual(response.body, { path: ['a', 'b'] });
+  });
+
+  void it('respects middleware and infrastructure route ordering owned by the caller', async () => {
+    const calls: string[] = [];
+    const application = express();
+
+    application.get('/health', (_req, res) => {
+      calls.push('health');
+      res.status(200).json({ status: 'ok' });
+    });
+    application.use((_req, _res, next) => {
+      calls.push('authentication');
+      next();
+    });
+
+    registerWebApi(application, [
+      (router) => {
+        router.get('/orders', (_req, res) => {
+          calls.push('orders');
+          res.sendStatus(204);
+        });
+      },
+    ]);
+
+    const healthResponse = await request(application).get('/health').send();
+    assertEqual(healthResponse.statusCode, 200);
+    assertDeepEqual(calls, ['health']);
+
+    calls.length = 0;
+    const ordersResponse = await request(application).get('/orders').send();
+    assertEqual(ordersResponse.statusCode, 204);
+    assertDeepEqual(calls, ['authentication', 'orders']);
+  });
+
+  void it('uses body parsing explicitly installed by the caller', async () => {
+    const application = express();
+    application.use(express.text({ type: 'application/json' }));
+    registerWebApi(application, [echoBodyApi]);
+
+    const response = await request(application)
+      .post('/echo')
+      .set('Content-Type', 'application/json')
+      .send('{"productId":"shoes"}');
+
+    assertEqual(
+      (response.body as { body: unknown }).body,
+      '{"productId":"shoes"}',
+    );
+  });
+
+  void it('uses error middleware explicitly installed by the caller', async () => {
+    const application = express();
+    registerWebApi(application, [asyncErrorApi]);
+    application.use(((error, _req, res, next) => {
+      res.setHeader('x-error-observed', 'true');
+      next(error);
+    }) satisfies ErrorRequestHandler);
+    application.use(problemDetailsMiddleware());
+
+    const response = await request(application).get('/async-error').send();
+
+    assertEqual(response.statusCode, 500);
+    assertEqual(response.headers['x-error-observed'], 'true');
+    assertEqual(
+      (response.body as ProblemDocument).detail,
+      'Application failed',
+    );
+  });
+});
+
+void describe('configureApplication', () => {
+  void it('applies the default Emmett setup to and returns an existing application', async () => {
+    const application = express();
+    application.set('trust proxy', 1);
+
+    const configured = configureApplication(application, {
+      apis: [echoBodyApi, asyncErrorApi],
+    });
+
+    assertOk(configured === application);
+    assertEqual(configured.get('trust proxy'), 1);
+
+    const bodyResponse = await request(application)
+      .post('/echo')
+      .send({ productId: 'shoes' });
+    assertDeepEqual((bodyResponse.body as { body: unknown }).body, {
+      productId: 'shoes',
+    });
+    assertFalse('etag' in bodyResponse.headers);
+
+    const errorResponse = await request(application).get('/async-error').send();
+    assertEqual(errorResponse.statusCode, 500);
+    assertEqual(
+      (errorResponse.body as ProblemDocument).detail,
+      'Application failed',
+    );
+  });
+
+  void it('supports replacing disabled defaults on an existing application', async () => {
+    const application = express();
+    application.use(express.text({ type: 'application/json' }));
+
+    configureApplication(application, {
+      apis: [echoBodyApi, asyncErrorApi],
+      disableJsonMiddleware: true,
+      disableProblemDetailsMiddleware: true,
+    });
+    application.use(((error, _req, res, _next) => {
+      res.status(422).json({ detail: (error as Error).message });
+    }) satisfies ErrorRequestHandler);
+
+    const bodyResponse = await request(application)
+      .post('/echo')
+      .set('Content-Type', 'application/json')
+      .send('{"productId":"shoes"}');
+    assertEqual(
+      (bodyResponse.body as { body: unknown }).body,
+      '{"productId":"shoes"}',
+    );
+
+    const errorResponse = await request(application).get('/async-error').send();
+    assertEqual(errorResponse.statusCode, 422);
+    assertDeepEqual(errorResponse.body, { detail: 'Application failed' });
+  });
+});
+
+void describe('getApplication', () => {
+  void it('parses JSON bodies by default', async () => {
+    const application = getApplication({ apis: [echoBodyApi] });
+
+    const response = await request(application)
+      .post('/echo')
+      .send({ productId: 'shoes' });
+
+    assertDeepEqual((response.body as { body: unknown }).body, {
+      productId: 'shoes',
+    });
+  });
+
+  void it('can disable the default JSON middleware', async () => {
+    const application = getApplication({
+      apis: [echoBodyApi],
+      disableJsonMiddleware: true,
+    });
+
+    const response = await request(application)
+      .post('/echo')
+      .set('Content-Type', 'application/json')
+      .send('{"productId":"shoes"}');
+
+    assertEqual((response.body as { body: unknown }).body, null);
+  });
+
+  void it('parses extended URL-encoded bodies by default', async () => {
+    const application = getApplication({ apis: [echoBodyApi] });
+
+    const response = await request(application)
+      .post('/echo')
+      .type('form')
+      .send({ 'cart[item]': 'shoes' });
+
+    assertDeepEqual((response.body as { body: unknown }).body, {
+      cart: { item: 'shoes' },
+    });
+  });
+
+  void it('can disable the default URL-encoded middleware', async () => {
+    const application = getApplication({
+      apis: [echoBodyApi],
+      disableUrlEncodingMiddleware: true,
+    });
+
+    const response = await request(application)
+      .post('/echo')
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send('cart%5Bitem%5D=shoes');
+
+    assertEqual((response.body as { body: unknown }).body, null);
+  });
+
+  void it('preserves disabled generated ETags as the Emmett default', async () => {
+    const application = getApplication({
+      apis: [
+        (router) =>
+          router.get('/body', (_req, res) => res.status(200).send('body')),
+      ],
+    });
+
+    const response = await request(application).get('/body').send();
+
+    assertFalse('etag' in response.headers);
+  });
+
+  void it('can enable generated Express ETags', async () => {
+    const application = getApplication({
+      apis: [
+        (router) =>
+          router.get('/body', (_req, res) => res.status(200).send('body')),
+      ],
+      enableDefaultExpressEtag: true,
+    });
+
+    const response = await request(application).get('/body').send();
+
+    assertTrue(typeof response.headers.etag === 'string');
+  });
+
+  void it('installs Problem Details middleware by default', async () => {
+    const application = getApplication({ apis: [asyncErrorApi] });
+
+    const response = await request(application).get('/async-error').send();
+
+    assertEqual(response.statusCode, 500);
+    assertEqual(
+      (response.body as ProblemDocument).detail,
+      'Application failed',
+    );
+  });
+
+  void it('forwards errors rejected by on handlers', async () => {
+    const application = getApplication({ apis: [onErrorApi] });
+
+    const response = await request(application).get('/on-error').send();
+
+    assertEqual(response.statusCode, 500);
+    assertEqual((response.body as ProblemDocument).detail, 'On handler failed');
+  });
+
+  void it('can disable the default Problem Details middleware', async () => {
+    const application = getApplication({
+      apis: [asyncErrorApi],
+      disableProblemDetailsMiddleware: true,
+    });
+    application.use(((error, _req, res, _next) => {
+      res.status(418).json({ detail: (error as Error).message });
+    }) satisfies ErrorRequestHandler);
+
+    const response = await request(application).get('/async-error').send();
+
+    assertEqual(response.statusCode, 418);
+    assertDeepEqual(response.body, { detail: 'Application failed' });
+  });
+});
+
+const asyncErrorApi = (router: Router) => {
+  router.get('/async-error', async (_request: Request) => {
+    await Promise.resolve();
+    throw new Error('Application failed');
+  });
+};
+
+const onErrorApi = (router: Router) => {
+  router.get(
+    '/on-error',
+    on(async (_request: Request): Promise<HttpResponse> => {
+      await Promise.resolve();
+      throw new Error('On handler failed');
+    }),
+  );
+};

--- a/src/packages/emmett-expressjs/src/application.int.spec.ts
+++ b/src/packages/emmett-expressjs/src/application.int.spec.ts
@@ -5,20 +5,25 @@ import {
   assertOk,
   assertTrue,
 } from '@event-driven-io/emmett';
+import { trace, type Span } from '@opentelemetry/api';
 import express, {
   type ErrorRequestHandler,
   type Request,
+  type RequestHandler,
   type Router,
 } from 'express';
 import type { ProblemDocument } from 'http-problem-details';
 import request from 'supertest';
-import { describe, it } from 'vitest';
+import { describe, it, vi } from 'vitest';
 import {
   configureApplication,
   getApplication,
+  NotFound,
+  OK,
   on,
   problemDetailsMiddleware,
   registerWebApi,
+  traceIdMiddleware,
   type HttpResponse,
   type WebApiSetup,
 } from '.';
@@ -30,20 +35,65 @@ const echoBodyApi: WebApiSetup = (router) => {
   });
 };
 
+const productApi: WebApiSetup = (router) => {
+  router.get(
+    '/products/:productId',
+    on((request: Request<{ productId: string }>) => {
+      const productId = request.params.productId;
+
+      return productId === 'missing'
+        ? NotFound({ problemDetails: `Product ${productId} was not found` })
+        : OK({ body: { productId, available: true } });
+    }),
+  );
+};
+
+const authenticateRequest: RequestHandler = (request, response, next) => {
+  if (request.get('authorization') !== 'Bearer valid-token') {
+    response.sendStatus(401);
+    return;
+  }
+  next();
+};
+
 void describe('registerWebApi', () => {
   void it('registers API routes on and returns the provided application', async () => {
     const application = express();
-    application.set('trust proxy', 1);
 
     const registered = registerWebApi(application, [
       (router) => router.get('/orders', (_req, res) => res.sendStatus(204)),
     ]);
 
     assertOk(registered === application);
-    assertEqual(registered.get('trust proxy'), 1);
 
     const response = await request(application).get('/orders').send();
     assertEqual(response.statusCode, 204);
+  });
+
+  void it('runs an API setup using on and response helpers', async () => {
+    const application = express();
+
+    registerWebApi(application, [productApi]);
+
+    const response = await request(application)
+      .get('/products/product-1')
+      .send();
+
+    assertEqual(response.statusCode, 200);
+    assertDeepEqual(response.body, {
+      productId: 'product-1',
+      available: true,
+    });
+
+    const missingResponse = await request(application)
+      .get('/products/missing')
+      .send();
+
+    assertEqual(missingResponse.statusCode, 404);
+    assertEqual(
+      (missingResponse.body as ProblemDocument).detail,
+      'Product missing was not found',
+    );
   });
 
   void it('supports named wildcard route parameters', async () => {
@@ -63,36 +113,48 @@ void describe('registerWebApi', () => {
     assertDeepEqual(response.body, { path: ['a', 'b'] });
   });
 
-  void it('respects middleware and infrastructure route ordering owned by the caller', async () => {
-    const calls: string[] = [];
+  void it('composes caller-owned infrastructure and middleware around API routes', async () => {
+    // #region route-only-registration
     const application = express();
 
-    application.get('/health', (_req, res) => {
-      calls.push('health');
-      res.status(200).json({ status: 'ok' });
+    application.get('/health', (_request, response) => {
+      response.status(200).json({ status: 'ok' });
     });
-    application.use((_req, _res, next) => {
-      calls.push('authentication');
-      next();
-    });
+    application.use(express.json({ limit: '2mb' }));
+    application.use(express.urlencoded({ extended: true }));
+    application.use(traceIdMiddleware);
+    application.use(authenticateRequest);
 
-    registerWebApi(application, [
-      (router) => {
-        router.get('/orders', (_req, res) => {
-          calls.push('orders');
-          res.sendStatus(204);
-        });
-      },
-    ]);
+    registerWebApi(application, [echoBodyApi, asyncErrorApi]);
+
+    application.use(problemDetailsMiddleware());
+    // #endregion route-only-registration
 
     const healthResponse = await request(application).get('/health').send();
     assertEqual(healthResponse.statusCode, 200);
-    assertDeepEqual(calls, ['health']);
 
-    calls.length = 0;
-    const ordersResponse = await request(application).get('/orders').send();
-    assertEqual(ordersResponse.statusCode, 204);
-    assertDeepEqual(calls, ['authentication', 'orders']);
+    const unauthorizedResponse = await request(application)
+      .post('/echo')
+      .send({ productId: 'shoes' });
+    assertEqual(unauthorizedResponse.statusCode, 401);
+
+    const bodyResponse = await request(application)
+      .post('/echo')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ productId: 'shoes' });
+    assertDeepEqual((bodyResponse.body as { body: unknown }).body, {
+      productId: 'shoes',
+    });
+
+    const errorResponse = await request(application)
+      .get('/async-error')
+      .set('Authorization', 'Bearer valid-token')
+      .send();
+    assertEqual(errorResponse.statusCode, 500);
+    assertEqual(
+      (errorResponse.body as ProblemDocument).detail,
+      'Application failed',
+    );
   });
 
   void it('uses body parsing explicitly installed by the caller', async () => {
@@ -134,43 +196,36 @@ void describe('registerWebApi', () => {
 void describe('configureApplication', () => {
   void it('applies the default Emmett setup to and returns an existing application', async () => {
     const application = express();
-    application.set('trust proxy', 1);
+
+    application.get('/health', (_request, response) => {
+      response.status(200).json({ status: 'ok' });
+    });
 
     const configured = configureApplication(application, {
-      apis: [echoBodyApi, asyncErrorApi],
+      apis: [echoBodyApi],
     });
 
     assertOk(configured === application);
-    assertEqual(configured.get('trust proxy'), 1);
-
-    const bodyResponse = await request(application)
+    assertEqual((await request(application).get('/health')).statusCode, 200);
+    const response = await request(application)
       .post('/echo')
       .send({ productId: 'shoes' });
-    assertDeepEqual((bodyResponse.body as { body: unknown }).body, {
+
+    assertDeepEqual((response.body as { body: unknown }).body, {
       productId: 'shoes',
     });
-    assertFalse('etag' in bodyResponse.headers);
-
-    const errorResponse = await request(application).get('/async-error').send();
-    assertEqual(errorResponse.statusCode, 500);
-    assertEqual(
-      (errorResponse.body as ProblemDocument).detail,
-      'Application failed',
-    );
   });
 
-  void it('supports replacing disabled defaults on an existing application', async () => {
+  void it('uses a caller-provided JSON parser when the default is disabled', async () => {
+    // #region configure-custom-json-middleware
     const application = express();
     application.use(express.text({ type: 'application/json' }));
 
     configureApplication(application, {
-      apis: [echoBodyApi, asyncErrorApi],
+      apis: [echoBodyApi],
       disableJsonMiddleware: true,
-      disableProblemDetailsMiddleware: true,
     });
-    application.use(((error, _req, res, _next) => {
-      res.status(422).json({ detail: (error as Error).message });
-    }) satisfies ErrorRequestHandler);
+    // #endregion configure-custom-json-middleware
 
     const bodyResponse = await request(application)
       .post('/echo')
@@ -180,6 +235,19 @@ void describe('configureApplication', () => {
       (bodyResponse.body as { body: unknown }).body,
       '{"productId":"shoes"}',
     );
+  });
+
+  void it('uses caller-provided error middleware when the default is disabled', async () => {
+    // #region configure-custom-error-middleware
+    const application = express();
+    configureApplication(application, {
+      apis: [asyncErrorApi],
+      disableProblemDetailsMiddleware: true,
+    });
+    application.use(((error, _req, response, _next) => {
+      response.status(422).json({ detail: (error as Error).message });
+    }) satisfies ErrorRequestHandler);
+    // #endregion configure-custom-error-middleware
 
     const errorResponse = await request(application).get('/async-error').send();
     assertEqual(errorResponse.statusCode, 422);
@@ -189,7 +257,18 @@ void describe('configureApplication', () => {
 
 void describe('getApplication', () => {
   void it('parses JSON bodies by default', async () => {
-    const application = getApplication({ apis: [echoBodyApi] });
+    // #region default-application
+    const application = getApplication({
+      apis: [
+        (router) => {
+          router.post('/echo', (request, response) => {
+            const body: unknown = request.body;
+            response.status(200).json({ body });
+          });
+        },
+      ],
+    });
+    // #endregion default-application
 
     const response = await request(application)
       .post('/echo')
@@ -266,6 +345,34 @@ void describe('getApplication', () => {
     const response = await request(application).get('/body').send();
 
     assertTrue(typeof response.headers.etag === 'string');
+  });
+
+  void it('adds the active trace ID when observability is provided', async () => {
+    const traceId = '0123456789abcdef0123456789abcdef';
+    const getSpan = vi.spyOn(trace, 'getSpan').mockReturnValue({
+      spanContext: () => ({
+        traceId,
+        spanId: '0123456789abcdef',
+        traceFlags: 1,
+      }),
+    } as Span);
+    const application = getApplication({
+      apis: [
+        (router) =>
+          router.get('/trace', (_request, response) =>
+            response.sendStatus(204),
+          ),
+      ],
+      observability: {},
+    });
+
+    try {
+      const response = await request(application).get('/trace').send();
+
+      assertEqual(response.headers['x-trace-id'], traceId);
+    } finally {
+      getSpan.mockRestore();
+    }
   });
 
   void it('installs Problem Details middleware by default', async () => {

--- a/src/packages/emmett-expressjs/src/application.ts
+++ b/src/packages/emmett-expressjs/src/application.ts
@@ -1,9 +1,8 @@
 import type { Observability } from '@event-driven-io/almanac';
 import express, { Router, type Application } from 'express';
-import 'express-async-errors';
 import http from 'http';
-import { context, trace } from '@opentelemetry/api';
 import { problemDetailsMiddleware } from './middlewares/problemDetailsMiddleware';
+import { traceIdMiddleware } from './middlewares/traceIdMiddleware';
 import type { ErrorToProblemDetailsMapping } from './responses';
 
 // #region web-api-setup
@@ -20,9 +19,24 @@ export type ApplicationOptions = {
   observability?: Partial<Observability<string>>;
 };
 
-export const getApplication = (options: ApplicationOptions) => {
-  const app: Application = express();
+export const registerWebApi = (
+  application: Application,
+  apis: WebApiSetup[],
+): Application => {
+  const router = Router();
 
+  for (const api of apis) {
+    api(router);
+  }
+  application.use(router);
+
+  return application;
+};
+
+export const configureApplication = (
+  application: Application,
+  options: ApplicationOptions,
+): Application => {
   const {
     apis,
     mapError,
@@ -33,42 +47,34 @@ export const getApplication = (options: ApplicationOptions) => {
     observability,
   } = options;
 
-  const router = Router();
-
   // disabling default etag behaviour
   // to use etags in if-match and if-not-match headers
-  app.set('etag', enableDefaultExpressEtag ?? false);
+  application.set('etag', enableDefaultExpressEtag ?? false);
 
   // add json middleware
-  if (!disableJsonMiddleware) app.use(express.json());
+  if (!disableJsonMiddleware) application.use(express.json());
 
   // enable url encoded urls and bodies
   if (!disableUrlEncodingMiddleware)
-    app.use(
+    application.use(
       express.urlencoded({
         extended: true,
       }),
     );
 
-  if (observability) {
-    app.use((_req, res, next) => {
-      const traceId = trace.getSpan(context.active())?.spanContext()?.traceId;
-      if (traceId) res.setHeader('x-trace-id', traceId);
-      next();
-    });
-  }
+  if (observability) application.use(traceIdMiddleware);
 
-  for (const api of apis) {
-    api(router);
-  }
-  app.use(router);
+  registerWebApi(application, apis);
 
   // add problem details middleware
   if (!disableProblemDetailsMiddleware)
-    app.use(problemDetailsMiddleware(mapError));
+    application.use(problemDetailsMiddleware(mapError));
 
-  return app;
+  return application;
 };
+
+export const getApplication = (options: ApplicationOptions): Application =>
+  configureApplication(express(), options);
 
 export type StartApiOptions = {
   port?: number;

--- a/src/packages/emmett-expressjs/src/e2e/configureExistingApplication.e2e.spec.ts
+++ b/src/packages/emmett-expressjs/src/e2e/configureExistingApplication.e2e.spec.ts
@@ -1,0 +1,58 @@
+import {
+  assertDeepEqual,
+  assertEqual,
+  assertOk,
+  getInMemoryEventStore,
+} from '@event-driven-io/emmett';
+import express from 'express';
+import type { Application } from 'express';
+import request from 'supertest';
+import { describe, it } from 'vitest';
+import { configureApplication } from '..';
+import type { ShoppingCartEvent } from './decider/shoppingCart';
+import { shoppingCartApi } from './commandHandler/api';
+
+void describe('configureApplication E2E', () => {
+  void it('keeps existing routes and adds the shopping cart API', async () => {
+    const eventStore = getInMemoryEventStore();
+    const clientId = 'client-123';
+    const shoppingCarts = shoppingCartApi(eventStore);
+
+    // #region configure-existing-application
+    const existingApplication = express();
+
+    existingApplication.get('/health', (_request, response) => {
+      response.status(200).json({ status: 'ok' });
+    });
+
+    const configuredApplication: Application = configureApplication(
+      existingApplication,
+      {
+        apis: [shoppingCarts],
+      },
+    );
+    // #endregion configure-existing-application
+
+    assertOk(configuredApplication === existingApplication);
+
+    const healthResponse = await request(configuredApplication)
+      .get('/health')
+      .send();
+
+    assertEqual(healthResponse.statusCode, 200);
+    assertDeepEqual(healthResponse.body, { status: 'ok' });
+
+    const createCartResponse = await request(configuredApplication)
+      .post(`/clients/${clientId}/shopping-carts/`)
+      .send();
+
+    assertEqual(createCartResponse.statusCode, 201);
+
+    const result = await eventStore.readStream<ShoppingCartEvent>(clientId);
+
+    assertDeepEqual(
+      result.events.map((event) => event.type),
+      ['ShoppingCartOpened'],
+    );
+  });
+});

--- a/src/packages/emmett-expressjs/src/index.ts
+++ b/src/packages/emmett-expressjs/src/index.ts
@@ -1,7 +1,6 @@
-import 'express-async-errors';
-
 export * from './application';
 export * from './etag';
 export * from './handler';
+export * from './middlewares';
 export * from './responses';
 export * from './testing';

--- a/src/packages/emmett-expressjs/src/mapError.int.spec.ts
+++ b/src/packages/emmett-expressjs/src/mapError.int.spec.ts
@@ -115,3 +115,25 @@ void describe('mapping a foreign error', () => {
     assertEqual((response.body as ProblemDocument).title, 'Card Declined');
   });
 });
+
+void describe('default error mapping', () => {
+  void it('maps a non-Error rejected by an async handler', async () => {
+    const rejectedValueApplication = getApplication({
+      apis: [
+        (router) => {
+          router.get('/string-error', async () => {
+            // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+            await Promise.reject('Async rejection');
+          });
+        },
+      ],
+    });
+
+    const response = await request(rejectedValueApplication)
+      .get('/string-error')
+      .send();
+
+    assertEqual(response.statusCode, 500);
+    assertEqual((response.body as ProblemDocument).detail, 'Async rejection');
+  });
+});

--- a/src/packages/emmett-expressjs/src/middlewares/index.ts
+++ b/src/packages/emmett-expressjs/src/middlewares/index.ts
@@ -1,0 +1,2 @@
+export * from './problemDetailsMiddleware';
+export * from './traceIdMiddleware';

--- a/src/packages/emmett-expressjs/src/middlewares/problemDetailsMiddleware.ts
+++ b/src/packages/emmett-expressjs/src/middlewares/problemDetailsMiddleware.ts
@@ -6,7 +6,7 @@ import { sendProblem, type ErrorToProblemDetailsMapping } from '..';
 export const problemDetailsMiddleware =
   (mapError?: ErrorToProblemDetailsMapping) =>
   (
-    error: Error,
+    error: unknown,
     request: Request,
     response: Response,
     _next: NextFunction,
@@ -22,11 +22,14 @@ export const problemDetailsMiddleware =
   };
 
 export const defaultErrorToProblemDetailsMapping = (
-  error: Error,
+  error: unknown,
 ): ProblemDocument => {
   let statusCode = 500;
+  let detail = 'Internal Server Error';
 
   if (
+    typeof error === 'object' &&
+    error !== null &&
     'errorCode' in error &&
     isNumber(error.errorCode) &&
     error.errorCode >= 100 &&
@@ -35,8 +38,11 @@ export const defaultErrorToProblemDetailsMapping = (
     statusCode = error.errorCode;
   }
 
+  if (error instanceof Error) detail = error.message;
+  else if (typeof error === 'string') detail = error;
+
   return new ProblemDocument({
-    detail: error.message,
+    detail,
     status: statusCode,
   });
 };

--- a/src/packages/emmett-expressjs/src/middlewares/traceIdMiddleware.ts
+++ b/src/packages/emmett-expressjs/src/middlewares/traceIdMiddleware.ts
@@ -1,0 +1,8 @@
+import { context, trace } from '@opentelemetry/api';
+import type { RequestHandler } from 'express';
+
+export const traceIdMiddleware: RequestHandler = (_request, response, next) => {
+  const traceId = trace.getSpan(context.active())?.spanContext().traceId;
+  if (traceId) response.setHeader('x-trace-id', traceId);
+  next();
+};

--- a/src/packages/emmett-expressjs/src/responses.ts
+++ b/src/packages/emmett-expressjs/src/responses.ts
@@ -3,7 +3,7 @@ import { ProblemDocument } from 'http-problem-details';
 import { setETag, type ETag } from './etag';
 
 export type ErrorToProblemDetailsMapping = (
-  error: Error,
+  error: unknown,
   request: Request,
 ) => ProblemDocument | undefined;
 

--- a/src/packages/emmett-expressjs/src/testing/apiE2ESpecification.int.spec.ts
+++ b/src/packages/emmett-expressjs/src/testing/apiE2ESpecification.int.spec.ts
@@ -8,16 +8,45 @@ import { ApiE2ESpecification } from './apiE2ESpecification';
 import { expectError, expectResponse } from './apiSpecification';
 
 void describe('ApiE2ESpecification', () => {
+  // #region api-e2e-specification-setup
+  const apiE2ESpecification = ApiE2ESpecification.for({
+    getEventStore: () => getInMemoryEventStore(),
+    getApplication: (eventStore) =>
+      getApplication({
+        apis: [shoppingCartApi(eventStore)],
+      }),
+  });
+  // #endregion api-e2e-specification-setup
+
+  // #region api-e2e-specification-example
+  void it('prepares state through HTTP requests', () => {
+    const clientId = 'client-123';
+    const shoppingCartId = clientId;
+    const productItem = { productId: 'product-123', quantity: 2 };
+
+    return apiE2ESpecification(
+      (request) => request.post(`/clients/${clientId}/shopping-carts/`).send(),
+      (request) =>
+        request
+          .post(
+            `/clients/${clientId}/shopping-carts/${shoppingCartId}/product-items`,
+          )
+          .set(HeaderNames.IF_MATCH, toWeakETag(1))
+          .send(productItem),
+    )
+      .when((request) =>
+        request
+          .post(`/clients/${clientId}/shopping-carts/${shoppingCartId}/confirm`)
+          .set(HeaderNames.IF_MATCH, toWeakETag(2)),
+      )
+      .then([expectResponse(204, { headers: { etag: toWeakETag(3) } })]);
+  });
+  // #endregion api-e2e-specification-example
+
   const testCases = [
     {
       name: 'Options API',
-      given: ApiE2ESpecification.for({
-        getEventStore: () => getInMemoryEventStore(),
-        getApplication: (eventStore) =>
-          getApplication({
-            apis: [shoppingCartApi(eventStore)],
-          }),
-      }),
+      given: apiE2ESpecification,
     },
     {
       name: 'Obsolete Two-Arg API',

--- a/src/packages/emmett-expressjs/src/testing/apiSpecification.int.spec.ts
+++ b/src/packages/emmett-expressjs/src/testing/apiSpecification.int.spec.ts
@@ -17,16 +17,61 @@ import {
 } from './apiSpecification';
 
 void describe('ApiSpecification', () => {
+  // #region api-specification-setup
+  const apiSpecification = ApiSpecification.for({
+    getEventStore: () => getInMemoryEventStore(),
+    getApplication: (eventStore) =>
+      getApplication({
+        apis: [shoppingCartApi(eventStore)],
+      }),
+  });
+  // #endregion api-specification-setup
+
+  // #region api-specification-example
+  void it('checks an HTTP response and newly appended events', () => {
+    const clientId = 'client-123';
+    const shoppingCartId = `shopping_cart:${clientId}:current`;
+    const productItem = { productId: 'product-123', quantity: 2 };
+
+    return apiSpecification(
+      existingStream<ShoppingCartEvent>(shoppingCartId, [
+        {
+          type: 'ShoppingCartOpened',
+          data: {
+            shoppingCartId,
+            clientId,
+            openedAt: new Date('2024-01-01T00:00:00Z'),
+          },
+        },
+      ]),
+    )
+      .when((request) =>
+        request
+          .post(
+            `/clients/${clientId}/shopping-carts/${shoppingCartId}/product-items`,
+          )
+          .set(HeaderNames.IF_MATCH, toWeakETag(1))
+          .send(productItem),
+      )
+      .then([
+        expectResponse(204, { headers: { etag: toWeakETag(2) } }),
+        expectNewEvents(shoppingCartId, [
+          {
+            type: 'ProductItemAddedToShoppingCart',
+            data: {
+              shoppingCartId,
+              productItem: { ...productItem, unitPrice: 100 },
+            },
+          },
+        ]),
+      ]);
+  });
+  // #endregion api-specification-example
+
   const testCases = [
     {
       name: 'New API',
-      given: ApiSpecification.for({
-        getEventStore: () => getInMemoryEventStore(),
-        getApplication: (eventStore) =>
-          getApplication({
-            apis: [shoppingCartApi(eventStore)],
-          }),
-      }),
+      given: apiSpecification,
     },
     {
       name: 'Obsolete API',


### PR DESCRIPTION
Besides that:
- per @Bazze suggestion, split the `getApplication` into smaller methods, allowing Emmett to connect to the existing setup,
- de-hallucinated Express.js docs and README

Fixes #267