### PR TITLE
Support the 0.43.x PostgreSQL checkpoint format

### DIFF
--- a/src/packages/emmett-postgresql/src/eventStore/schema/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/index.ts
@@ -17,7 +17,10 @@ import {
   migration_0_42_0_3_FixProcessorLockTimeout,
   migration_0_42_0_FromSubscriptionsToProcessors,
 } from './migrations/0_42_0';
-import { migration_0_42_4_addMessagesPollIndexes } from './migrations/0_42_4';
+import {
+  migration_0_42_4_addMessagesPollIndexes,
+  migration_0_42_4_forwardCompatibleCheckpoints,
+} from './migrations/0_42_4';
 import {
   releaseProcessorLockSQL,
   tryAcquireProcessorLockSQL,
@@ -85,6 +88,7 @@ export const eventStoreSchemaMigrations: SQLMigration[] = [
   // DDL to messagesTableSQL instead would change schemaSQL, which is hashed into the
   // shipped 'initial' migration and would abort every existing database on mismatch.
   migration_0_42_4_addMessagesPollIndexes,
+  migration_0_42_4_forwardCompatibleCheckpoints,
 ];
 
 export type CreateEventStoreSchemaOptions = {

--- a/src/packages/emmett-postgresql/src/eventStore/schema/migrations/0_42_4/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/migrations/0_42_4/index.ts
@@ -3,7 +3,12 @@ import {
   sqlMigration,
   type SQLMigration,
 } from '@event-driven-io/dumbo';
-import { messagesTable } from '../../typing';
+import {
+  defaultTag,
+  messagesTable,
+  processorsTable,
+  unknownTag,
+} from '../../typing';
 
 // emt_messages carries no index beyond its primary key, so the consumer poll scans and
 // sorts the whole partition on every tick, including the caught-up poll that returns
@@ -47,3 +52,254 @@ export const migration_0_42_4_addMessagesPollIndexes: SQLMigration =
   sqlMigration('emt:postgresql:eventstore:0.42.4:add-messages-poll-indexes', [
     migration_0_42_4_addMessagesPollIndexesSQL,
   ]);
+
+const noLegacySubscriptionBridgeSQL = `
+CREATE OR REPLACE FUNCTION store_processor_checkpoint(
+  p_processor_id           TEXT,
+  p_version                BIGINT,
+  p_position               TEXT,
+  p_check_position         TEXT,
+  p_transaction_id         xid8,
+  p_partition              TEXT DEFAULT '${defaultTag}',
+  p_processor_instance_id  TEXT DEFAULT '${unknownTag}'
+) RETURNS INT AS $spc$
+DECLARE
+  current_position TEXT;
+BEGIN
+  IF p_check_position IS NOT NULL THEN
+      UPDATE "${processorsTable.name}"
+      SET
+        "last_processed_checkpoint" = p_position,
+        "last_processed_transaction_id" = p_transaction_id,
+        "last_updated" = now()
+      WHERE "processor_id" = p_processor_id
+        AND "last_processed_checkpoint" = p_check_position
+        AND "partition" = p_partition
+        AND "version" = p_version;
+
+      IF FOUND THEN
+          RETURN 1;
+      END IF;
+
+      -- TODO: Remove once all deployments have run the 0.43.0 migration.
+      -- Handles mixed-format checkpoints during blue-green deployment.
+      IF p_check_position LIKE '%:%' THEN
+          -- New code, stored value still in old format (plain global position).
+          UPDATE "${processorsTable.name}"
+          SET
+            "last_processed_checkpoint" = p_position,
+            "last_processed_transaction_id" = p_transaction_id,
+            "last_updated" = now()
+          WHERE "processor_id" = p_processor_id
+            AND "last_processed_checkpoint" = split_part(p_check_position, ':', 2)
+            AND "last_processed_checkpoint" NOT LIKE '%:%'
+            AND "partition" = p_partition
+            AND "version" = p_version;
+      ELSE
+          -- Old code, stored value already in new format (txid:globalpos).
+          UPDATE "${processorsTable.name}"
+          SET
+            "last_processed_checkpoint" = p_position,
+            "last_processed_transaction_id" = p_transaction_id,
+            "last_updated" = now()
+          WHERE "processor_id" = p_processor_id
+            AND split_part("last_processed_checkpoint", ':', 2) = p_check_position
+            AND "last_processed_checkpoint" LIKE '%:%'
+            AND "partition" = p_partition
+            AND "version" = p_version;
+      END IF;
+
+      IF FOUND THEN
+          RETURN 1;
+      END IF;
+
+      SELECT "last_processed_checkpoint" INTO current_position
+      FROM "${processorsTable.name}"
+      WHERE "processor_id" = p_processor_id
+        AND "partition" = p_partition
+        AND "version" = p_version;
+
+      IF current_position = p_position THEN
+          RETURN 0;
+      ELSIF current_position > p_position THEN
+          RETURN 3;
+      ELSE
+          RETURN 2;
+      END IF;
+  END IF;
+
+  BEGIN
+      INSERT INTO "${processorsTable.name}"("processor_id", "version", "last_processed_checkpoint", "partition", "last_processed_transaction_id", "created_at", "last_updated")
+      VALUES (p_processor_id, p_version, p_position, p_partition, p_transaction_id, now(), now());
+      RETURN 1;
+  EXCEPTION WHEN unique_violation THEN
+      SELECT "last_processed_checkpoint" INTO current_position
+      FROM "${processorsTable.name}"
+      WHERE "processor_id" = p_processor_id
+        AND "partition" = p_partition
+        AND "version" = p_version;
+
+      IF current_position = p_position THEN
+          RETURN 0;
+      ELSIF current_position > p_position THEN
+          RETURN 3;
+      ELSE
+          RETURN 2;
+      END IF;
+  END;
+END;
+$spc$ LANGUAGE plpgsql;
+`;
+
+const legacySubscriptionBridgeSQL = `
+DO $$
+BEGIN
+IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = 'emt_subscriptions') THEN
+  CREATE OR REPLACE FUNCTION store_processor_checkpoint(
+    p_processor_id           TEXT,
+    p_version                BIGINT,
+    p_position               TEXT,
+    p_check_position         TEXT,
+    p_transaction_id         xid8,
+    p_partition              TEXT DEFAULT '${defaultTag}',
+    p_processor_instance_id  TEXT DEFAULT '${unknownTag}'
+  ) RETURNS INT AS $fn$
+  DECLARE
+    current_position TEXT;
+    v_position_bigint BIGINT;
+  BEGIN
+    IF p_position IS NOT NULL THEN
+        v_position_bigint := CASE
+          WHEN p_position LIKE '%:%' THEN split_part(p_position, ':', 2)::BIGINT
+          ELSE p_position::BIGINT
+        END;
+    END IF;
+
+    IF p_check_position IS NOT NULL THEN
+        UPDATE "${processorsTable.name}"
+        SET
+          "last_processed_checkpoint" = p_position,
+          "last_processed_transaction_id" = p_transaction_id,
+          "last_updated" = now()
+        WHERE "processor_id" = p_processor_id
+          AND "last_processed_checkpoint" = p_check_position
+          AND "partition" = p_partition
+          AND "version" = p_version;
+
+        IF FOUND THEN
+            UPDATE "emt_subscriptions"
+            SET
+              "last_processed_position" = v_position_bigint,
+              "last_processed_transaction_id" = p_transaction_id
+            WHERE "subscription_id" = p_processor_id
+              AND "partition" = p_partition
+              AND "version" = p_version;
+
+            IF NOT FOUND THEN
+                INSERT INTO "emt_subscriptions"("subscription_id", "version", "last_processed_position", "partition", "last_processed_transaction_id")
+                VALUES (p_processor_id, p_version, v_position_bigint, p_partition, p_transaction_id)
+                ON CONFLICT DO NOTHING;
+            END IF;
+
+            RETURN 1;
+        END IF;
+
+        -- TODO: Remove once all deployments have run the 0.43.0 migration.
+        -- Handles mixed-format checkpoints during blue-green deployment.
+        IF p_check_position LIKE '%:%' THEN
+            -- New code, stored value still in old format (plain global position).
+            UPDATE "${processorsTable.name}"
+            SET
+              "last_processed_checkpoint" = p_position,
+              "last_processed_transaction_id" = p_transaction_id,
+              "last_updated" = now()
+            WHERE "processor_id" = p_processor_id
+              AND "last_processed_checkpoint" = split_part(p_check_position, ':', 2)
+              AND "last_processed_checkpoint" NOT LIKE '%:%'
+              AND "partition" = p_partition
+              AND "version" = p_version;
+        ELSE
+            -- Old code, stored value already in new format (txid:globalpos).
+            UPDATE "${processorsTable.name}"
+            SET
+              "last_processed_checkpoint" = p_position,
+              "last_processed_transaction_id" = p_transaction_id,
+              "last_updated" = now()
+            WHERE "processor_id" = p_processor_id
+              AND split_part("last_processed_checkpoint", ':', 2) = p_check_position
+              AND "last_processed_checkpoint" LIKE '%:%'
+              AND "partition" = p_partition
+              AND "version" = p_version;
+        END IF;
+
+        IF FOUND THEN
+            UPDATE "emt_subscriptions"
+            SET
+              "last_processed_position" = v_position_bigint,
+              "last_processed_transaction_id" = p_transaction_id
+            WHERE "subscription_id" = p_processor_id
+              AND "partition" = p_partition
+              AND "version" = p_version;
+
+            IF NOT FOUND THEN
+                INSERT INTO "emt_subscriptions"("subscription_id", "version", "last_processed_position", "partition", "last_processed_transaction_id")
+                VALUES (p_processor_id, p_version, v_position_bigint, p_partition, p_transaction_id)
+                ON CONFLICT DO NOTHING;
+            END IF;
+
+            RETURN 1;
+        END IF;
+
+        SELECT "last_processed_checkpoint" INTO current_position
+        FROM "${processorsTable.name}"
+        WHERE "processor_id" = p_processor_id
+          AND "partition" = p_partition
+          AND "version" = p_version;
+
+        IF current_position = p_position THEN
+            RETURN 0;
+        ELSIF current_position > p_position THEN
+            RETURN 3;
+        ELSE
+            RETURN 2;
+        END IF;
+    END IF;
+
+    BEGIN
+        INSERT INTO "${processorsTable.name}"("processor_id", "version", "last_processed_checkpoint", "partition", "last_processed_transaction_id", "created_at", "last_updated")
+        VALUES (p_processor_id, p_version, p_position, p_partition, p_transaction_id, now(), now());
+
+        INSERT INTO "emt_subscriptions"("subscription_id", "version", "last_processed_position", "partition", "last_processed_transaction_id")
+        VALUES (p_processor_id, p_version, v_position_bigint, p_partition, p_transaction_id)
+        ON CONFLICT DO NOTHING;
+
+        RETURN 1;
+    EXCEPTION WHEN unique_violation THEN
+        SELECT "last_processed_checkpoint" INTO current_position
+        FROM "${processorsTable.name}"
+        WHERE "processor_id" = p_processor_id
+          AND "partition" = p_partition
+          AND "version" = p_version;
+
+        IF current_position = p_position THEN
+            RETURN 0;
+        ELSIF current_position > p_position THEN
+            RETURN 3;
+        ELSE
+            RETURN 2;
+        END IF;
+    END;
+  END;
+  $fn$ LANGUAGE plpgsql;
+END IF;
+END $$;
+`;
+
+export const migration_0_42_4_forwardCompatibleCheckpoints: SQLMigration =
+  sqlMigration(
+    'emt:postgresql:eventstore:0.42.4:forward-compatible-checkpoints',
+    [
+      rawSql(noLegacySubscriptionBridgeSQL),
+      rawSql(legacySubscriptionBridgeSQL),
+    ],
+  );

--- a/src/packages/emmett-postgresql/src/eventStore/schema/migrations/migration.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/migrations/migration.int.spec.ts
@@ -373,6 +373,54 @@ void describe('Schema migrations tests', () => {
     await assertDualWriteConsistency(pool, processorId, 14n);
   });
 
+  void it('0.42.x migration accepts 0.43 composite checkpoint writes and keeps legacy dual-write consistent', async () => {
+    // Given
+    await pool.execute.command(schema_0_38_7);
+    await eventStore.schema.migrate();
+
+    const processorId = 'forward-compatible-composite-write-test';
+    const initialCheckpoint = 5n;
+    const nextCheckpoint = 10n;
+    const compositeCheckPosition = `00000000000000000100:${initialCheckpoint.toString().padStart(19, '0')}`;
+    const compositePosition = `00000000000000000101:${nextCheckpoint.toString().padStart(19, '0')}`;
+
+    const initialStore = await storeProcessorCheckpoint(pool.execute, {
+      processorId,
+      partition: undefined,
+      version: 1,
+      newCheckpoint: initialCheckpoint,
+      lastProcessedCheckpoint: null,
+      processorInstanceId: processorId,
+    });
+    assertTrue(initialStore.success);
+
+    // When: simulate a 0.43 node writing txid:globalpos through the 0.42.x DB function.
+    await pool.execute.command(
+      sql(
+        `SELECT store_processor_checkpoint(%L, 1, %L, %L, pg_current_xact_id(), %L, %L)`,
+        processorId,
+        compositePosition,
+        compositeCheckPosition,
+        defaultTag,
+        processorId,
+      ),
+    );
+
+    // Then
+    const processorData = await queryProcessorCheckpoint(pool, processorId);
+    const subscriptionData = await querySubscriptionCheckpoint(
+      pool,
+      processorId,
+    );
+
+    assertDeepEqual(processorData.lastProcessedCheckpoint, compositePosition);
+    assertDeepEqual(subscriptionData.position, nextCheckpoint);
+    assertDeepEqual(
+      subscriptionData.transactionId,
+      processorData.transactionId,
+    );
+  });
+
   void it('concurrent inserts via different APIs handled safely', async () => {
     // Given
     await pool.execute.command(schema_0_38_7);

--- a/src/packages/emmett-postgresql/src/eventStore/schema/readProcessorCheckpoint.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/readProcessorCheckpoint.ts
@@ -29,6 +29,12 @@ export const readProcessorCheckpoint = async (
 
   return {
     lastProcessedCheckpoint:
-      result !== null ? BigInt(result.last_processed_checkpoint) : null,
+      result !== null
+        ? BigInt(
+            result.last_processed_checkpoint.includes(':')
+              ? result.last_processed_checkpoint.split(':')[1]!
+              : result.last_processed_checkpoint,
+          )
+        : null,
   };
 };

--- a/src/packages/emmett-postgresql/src/eventStore/schema/storeProcessorCheckpoint.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/storeProcessorCheckpoint.int.spec.ts
@@ -181,6 +181,169 @@ void describe('storeProcessorCheckpoint and readProcessorCheckpoint tests', () =
     assertDeepEqual(result, { lastProcessedCheckpoint: checkpoint2 });
   });
 
+  void it('can read a composite checkpoint as a 0.42 global position', async () => {
+    const processorId = 'processor-read-composite';
+    const compositeCheckpoint = `00000000000000000123:${checkpoint2.toString().padStart(19, '0')}`;
+
+    await pool.execute.command(
+      sql(
+        `INSERT INTO emt_processors (
+            processor_id,
+            version,
+            last_processed_checkpoint,
+            partition,
+            last_processed_transaction_id,
+            created_at,
+            last_updated
+          )
+          VALUES (%L, 1, %L, %L, pg_current_xact_id(), now(), now())`,
+        processorId,
+        compositeCheckpoint,
+        defaultTag,
+      ),
+    );
+
+    const result = await readProcessorCheckpoint(pool.execute, {
+      processorId,
+    });
+
+    assertDeepEqual(result, { lastProcessedCheckpoint: checkpoint2 });
+  });
+
+  void it('can update when the stored checkpoint is composite and caller uses 0.42 global positions', async () => {
+    const processorId = 'processor-update-composite-from-global';
+    const compositeCheckpoint = `00000000000000000123:${checkpoint1.toString().padStart(19, '0')}`;
+
+    await pool.execute.command(
+      sql(
+        `INSERT INTO emt_processors (
+            processor_id,
+            version,
+            last_processed_checkpoint,
+            partition,
+            last_processed_transaction_id,
+            created_at,
+            last_updated
+          )
+          VALUES (%L, 1, %L, %L, pg_current_xact_id(), now(), now())`,
+        processorId,
+        compositeCheckpoint,
+        defaultTag,
+      ),
+    );
+
+    const result = await storeProcessorCheckpoint(pool.execute, {
+      processorId,
+      lastProcessedCheckpoint: checkpoint1,
+      newCheckpoint: checkpoint2,
+      version: 1,
+    });
+
+    assertDeepEqual(result, {
+      success: true,
+      newCheckpoint: checkpoint2,
+    });
+
+    const readResult = await readProcessorCheckpoint(pool.execute, {
+      processorId,
+    });
+
+    assertDeepEqual(readResult, { lastProcessedCheckpoint: checkpoint2 });
+  });
+
+  void it('supports mixed 0.42 and 0.43 checkpoint writes during rolling deployment', async () => {
+    const processorId = 'processor-blue-green-checkpoint-sequence';
+    const checkpoint4 = 400n;
+    const normalizedCheckpoint1 = checkpoint1.toString().padStart(19, '0');
+    const normalizedCheckpoint2 = checkpoint2.toString().padStart(19, '0');
+    const normalizedCheckpoint3 = checkpoint3.toString().padStart(19, '0');
+    const normalizedCheckpoint4 = checkpoint4.toString().padStart(19, '0');
+    const compositeCheckpoint2 = `00000000000000000102:${normalizedCheckpoint2}`;
+    const compositeCheckpoint4 = `00000000000000000104:${normalizedCheckpoint4}`;
+
+    const initialStore = await storeProcessorCheckpoint(pool.execute, {
+      processorId,
+      lastProcessedCheckpoint: null,
+      newCheckpoint: checkpoint1,
+      version: 1,
+    });
+
+    assertDeepEqual(initialStore, {
+      success: true,
+      newCheckpoint: checkpoint1,
+    });
+
+    // Simulate 0.43 node writing composite checkpoint over 0.42 plain checkpoint.
+    await pool.execute.command(
+      sql(
+        `SELECT store_processor_checkpoint(%L, 1, %L, %L, pg_current_xact_id(), %L, %L)`,
+        processorId,
+        compositeCheckpoint2,
+        `00000000000000000101:${normalizedCheckpoint1}`,
+        defaultTag,
+        processorId,
+      ),
+    );
+
+    const afterCompositeWrite = await readProcessorCheckpoint(pool.execute, {
+      processorId,
+    });
+
+    assertDeepEqual(afterCompositeWrite, {
+      lastProcessedCheckpoint: checkpoint2,
+    });
+
+    // Simulate 0.42 node reading composite as bigint and writing next plain checkpoint.
+    const plainWrite = await storeProcessorCheckpoint(pool.execute, {
+      processorId,
+      lastProcessedCheckpoint: checkpoint2,
+      newCheckpoint: checkpoint3,
+      version: 1,
+    });
+
+    assertDeepEqual(plainWrite, {
+      success: true,
+      newCheckpoint: checkpoint3,
+    });
+
+    // Simulate 0.43 node continuing from the 0.42 plain checkpoint.
+    await pool.execute.command(
+      sql(
+        `SELECT store_processor_checkpoint(%L, 1, %L, %L, pg_current_xact_id(), %L, %L)`,
+        processorId,
+        compositeCheckpoint4,
+        `00000000000000000103:${normalizedCheckpoint3}`,
+        defaultTag,
+        processorId,
+      ),
+    );
+
+    const finalRead = await readProcessorCheckpoint(pool.execute, {
+      processorId,
+    });
+
+    assertDeepEqual(finalRead, {
+      lastProcessedCheckpoint: checkpoint4,
+    });
+
+    const rawCheckpoint = await pool.execute.query<{
+      last_processed_checkpoint: string;
+    }>(
+      sql(
+        `SELECT last_processed_checkpoint
+         FROM emt_processors
+         WHERE processor_id = %L AND partition = %L AND version = 1`,
+        processorId,
+        defaultTag,
+      ),
+    );
+
+    assertDeepEqual(
+      rawCheckpoint.rows[0]?.last_processed_checkpoint,
+      compositeCheckpoint4,
+    );
+  });
+
   void it('can read a position of a processor with a defined partition', async () => {
     const processorId = 'processor-read-custom-partition';
 

--- a/src/packages/emmett-postgresql/src/eventStore/schema/storeProcessorCheckpoint.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/storeProcessorCheckpoint.ts
@@ -35,6 +35,38 @@ BEGIN
           RETURN 1;  -- Successfully updated
       END IF;
 
+      -- TODO: Remove once all deployments have run the 0.43.0 migration.
+      -- Handles mixed-format scenarios during blue-green deployment.
+      IF p_check_position LIKE '%:%' THEN
+          -- New code, stored value still in old format (plain global position).
+          UPDATE "${processorsTable.name}"
+          SET
+            "last_processed_checkpoint" = p_position,
+            "last_processed_transaction_id" = p_transaction_id,
+            "last_updated" = now()
+          WHERE "processor_id" = p_processor_id
+            AND "last_processed_checkpoint" = split_part(p_check_position, ':', 2)
+            AND "last_processed_checkpoint" NOT LIKE '%:%'
+            AND "partition" = p_partition
+            AND "version" = p_version;
+      ELSE
+          -- Old code, stored value already in new format (txid:globalpos).
+          UPDATE "${processorsTable.name}"
+          SET
+            "last_processed_checkpoint" = p_position,
+            "last_processed_transaction_id" = p_transaction_id,
+            "last_updated" = now()
+          WHERE "processor_id" = p_processor_id
+            AND split_part("last_processed_checkpoint", ':', 2) = p_check_position
+            AND "last_processed_checkpoint" LIKE '%:%'
+            AND "partition" = p_partition
+            AND "version" = p_version;
+      END IF;
+
+      IF FOUND THEN
+          RETURN 1;  -- Successfully updated
+      END IF;
+
       -- Retrieve the current position
       SELECT "last_processed_checkpoint" INTO current_position
       FROM "${processorsTable.name}"


### PR DESCRIPTION
The 0.43.x fixed the checkpoint format to include transaction id not to lose messages. This change enables the 0.42.x branch to read it and parse the bigint checkpoint.

This is needed to support blue/green migration when both 0.42.x and 0.43.x nodes are up and running.