### PR TITLE
Hoist processor locking into a core `ProcessorLock` interface

### DIFF
--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.handling.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.handling.int.spec.ts
@@ -5,6 +5,8 @@ import {
   assertThatArray,
   assertThrowsAsync,
   defaultTag,
+  getProjectorId,
+  unknownTag,
   type Event,
 } from '@event-driven-io/emmett';
 import { v4 as uuid } from 'uuid';
@@ -1099,6 +1101,46 @@ void describe('PostgreSQL event store started consumer', () => {
           processorId,
           startFrom: 'CURRENT',
           eachMessage: () => {},
+        });
+
+        try {
+          await assertThrowsAsync<EmmettError>(
+            () => consumer.start(),
+            (error) => error.message.includes(processorId),
+          );
+        } finally {
+          await consumer.close();
+        }
+      },
+    );
+
+    void it(
+      'fails to start a projector when another instance holds the processor lock',
+      withDeadline,
+      async () => {
+        const projectionName = `lockedProjection-${uuid()}`;
+        const processorId = getProjectorId({ projectionName });
+
+        const otherInstanceLock = postgreSQLProcessorLock({
+          processorId,
+          version: 1,
+          partition: defaultTag,
+          processorInstanceId: 'other-crashed-instance',
+          projection: {
+            name: projectionName,
+            kind: unknownTag,
+            version: 1,
+            handlingType: 'async',
+          },
+        });
+        await pool.withConnection((connection) =>
+          otherInstanceLock.tryAcquire({ execute: connection.execute }),
+        );
+
+        const consumer = postgreSQLEventStoreConsumer({ connectionString });
+        consumer.projector<GuestStayEvent>({
+          projection: collectingProjection([], projectionName),
+          startFrom: 'CURRENT',
         });
 
         try {

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.handling.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.handling.int.spec.ts
@@ -1081,7 +1081,7 @@ void describe('PostgreSQL event store started consumer', () => {
 
   void describe('processor lock', () => {
     void it(
-      'fails to start when another instance holds the processor lock',
+      'fails to start when another instance holds the processor lock and the acquisition policy is fail',
       withDeadline,
       async () => {
         const processorId = uuid();
@@ -1115,7 +1115,7 @@ void describe('PostgreSQL event store started consumer', () => {
     );
 
     void it(
-      'fails to start a projector when another instance holds the processor lock',
+      'fails to start a projector when another instance holds the processor lock and the acquisition policy is fail',
       withDeadline,
       async () => {
         const projectionName = `lockedProjection-${uuid()}`;

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLProcessor.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLProcessor.ts
@@ -10,6 +10,8 @@ import type {
 import type {
   AnyCommand,
   AnyEvent,
+  ProcessorLock,
+  ProcessorLockOptions,
   AnyMessage,
   AnyRecordedMessageMetadata,
   BatchRecordedMessageHandlerWithContext,
@@ -54,6 +56,7 @@ import {
   DefaultPostgreSQLProcessorLockPolicy,
   postgreSQLProcessorLock,
   type LockAcquisitionPolicy,
+  type PostgreSQLProcessorLock,
 } from '../projections';
 import {
   readProcessorCheckpoint,
@@ -198,6 +201,8 @@ type PostgreSQLConnectionOptions = {
 
 type PostgreSQLProcessorOptionsBase = PostgreSQLConnectionOptions & {
   lock?: {
+    /** Defaults to the PostgreSQL processor lock backed by the message store */
+    lock?: ProcessorLock<PostgreSQLProcessorHandlerContext>;
     acquisitionPolicy?: LockAcquisitionPolicy;
     timeoutSeconds?: number;
   };
@@ -341,26 +346,13 @@ const getProcessorPool = (options: PostgreSQLConnectionOptions) => {
   };
 };
 
-const wrapHooksWithProcessorLocks = <
-  HandlerContext extends PostgreSQLProcessorHandlerContext,
->(
-  hooks: ProcessorHooks<HandlerContext> | undefined,
-  processorLock: ReturnType<typeof postgreSQLProcessorLock>,
-): ProcessorHooks<HandlerContext> => ({
-  ...(hooks ?? {}),
-  onStart: async (context) => {
-    await processorLock.tryAcquire({ execute: context.execute });
-
-    if (hooks?.onStart) await hooks.onStart(context);
-  },
-  onClose:
-    hooks?.onClose || processorLock
-      ? async (context) => {
-          await processorLock.release({ execute: context.execute });
-
-          if (hooks?.onClose) await hooks.onClose(context);
-        }
-      : undefined,
+const toProcessorLockOptions = (
+  processorLock: PostgreSQLProcessorLock,
+  lock: PostgreSQLProcessorOptionsBase['lock'],
+): ProcessorLockOptions<PostgreSQLProcessorHandlerContext> => ({
+  lock: lock?.lock ?? processorLock,
+  acquisitionPolicy:
+    lock?.acquisitionPolicy ?? DefaultPostgreSQLProcessorLockPolicy,
 });
 
 export const postgreSQLProjector = <
@@ -394,44 +386,38 @@ export const postgreSQLProjector = <
           handlingType: 'async' as const,
         }
       : undefined,
-    lockAcquisitionPolicy:
-      lock?.acquisitionPolicy ?? DefaultPostgreSQLProcessorLockPolicy,
     lockTimeoutSeconds: lock?.timeoutSeconds,
   });
 
-  const hooks: ProcessorHooks<PostgreSQLProcessorHandlerContext> =
-    wrapHooksWithProcessorLocks(
-      {
-        ...(options.hooks ?? {}),
-        onInit:
-          options.projection.init !== undefined || options.hooks?.onInit
-            ? async (context) => {
-                if (options.projection.init)
-                  await options.projection.init({
-                    version: options.projection.version ?? version,
-                    status: 'active',
-                    registrationType: 'async',
-                    context: {
-                      ...context,
-                      migrationOptions: options.migrationOptions,
-                    },
-                  });
-                if (options.hooks?.onInit)
-                  await options.hooks.onInit({
-                    ...context,
-                    migrationOptions: options.migrationOptions,
-                  });
-              }
-            : options.hooks?.onInit,
-        onClose: close
-          ? async (context) => {
-              if (options.hooks?.onClose) await options.hooks?.onClose(context);
-              if (close) await close();
-            }
-          : options.hooks?.onClose,
-      },
-      processorLock,
-    );
+  const hooks: ProcessorHooks<PostgreSQLProcessorHandlerContext> = {
+    ...(options.hooks ?? {}),
+    onInit:
+      options.projection.init !== undefined || options.hooks?.onInit
+        ? async (context) => {
+            if (options.projection.init)
+              await options.projection.init({
+                version: options.projection.version ?? version,
+                status: 'active',
+                registrationType: 'async',
+                context: {
+                  ...context,
+                  migrationOptions: options.migrationOptions,
+                },
+              });
+            if (options.hooks?.onInit)
+              await options.hooks.onInit({
+                ...context,
+                migrationOptions: options.migrationOptions,
+              });
+          }
+        : options.hooks?.onInit,
+    onClose: close
+      ? async (context) => {
+          if (options.hooks?.onClose) await options.hooks?.onClose(context);
+          if (close) await close();
+        }
+      : options.hooks?.onClose,
+  };
 
   const processor = projector<
     EventType,
@@ -445,6 +431,7 @@ export const postgreSQLProjector = <
     version,
     partition,
     hooks,
+    lock: toProcessorLockOptions(processorLock, lock),
     processingScope: postgreSQLProcessingScope({
       pool,
       connectionString,
@@ -498,24 +485,19 @@ export const postgreSQLWorkflowProcessor = <
     partition,
     processorInstanceId,
     projection: undefined,
-    lockAcquisitionPolicy:
-      lock?.acquisitionPolicy ?? DefaultPostgreSQLProcessorLockPolicy,
     lockTimeoutSeconds: lock?.timeoutSeconds,
   });
 
-  const hooks: ProcessorHooks<HandlerContext> = wrapHooksWithProcessorLocks(
-    {
-      ...(options.hooks ?? {}),
-      onClose: close
-        ? async (context: PostgreSQLProcessorHandlerContext) => {
-            if (options.hooks?.onClose)
-              await options.hooks?.onClose(context as HandlerContext);
-            if (close) await close();
-          }
-        : options.hooks?.onClose,
-    },
-    processorLock,
-  );
+  const hooks: ProcessorHooks<HandlerContext> = {
+    ...(options.hooks ?? {}),
+    onClose: close
+      ? async (context: PostgreSQLProcessorHandlerContext) => {
+          if (options.hooks?.onClose)
+            await options.hooks?.onClose(context as HandlerContext);
+          if (close) await close();
+        }
+      : options.hooks?.onClose,
+  };
 
   return workflowProcessor({
     ...options,
@@ -524,6 +506,7 @@ export const postgreSQLWorkflowProcessor = <
     version,
     partition,
     hooks,
+    lock: toProcessorLockOptions(processorLock, lock),
     processingScope: postgreSQLProcessingScope({
       pool,
       connectionString,
@@ -563,24 +546,18 @@ export const postgreSQLReactor = <
     partition,
     processorInstanceId,
     projection: undefined,
-    lockAcquisitionPolicy:
-      lock?.acquisitionPolicy ?? DefaultPostgreSQLProcessorLockPolicy,
     lockTimeoutSeconds: lock?.timeoutSeconds,
   });
 
-  const hooks: ProcessorHooks<PostgreSQLProcessorHandlerContext> =
-    wrapHooksWithProcessorLocks(
-      {
-        ...(options.hooks ?? {}),
-        onClose: close
-          ? async (context) => {
-              if (options.hooks?.onClose) await options.hooks?.onClose(context);
-              if (close) await close();
-            }
-          : options.hooks?.onClose,
-      },
-      processorLock,
-    );
+  const hooks: ProcessorHooks<PostgreSQLProcessorHandlerContext> = {
+    ...(options.hooks ?? {}),
+    onClose: close
+      ? async (context) => {
+          if (options.hooks?.onClose) await options.hooks?.onClose(context);
+          if (close) await close();
+        }
+      : options.hooks?.onClose,
+  };
 
   return reactor({
     ...options,
@@ -589,6 +566,7 @@ export const postgreSQLReactor = <
     version,
     partition,
     hooks,
+    lock: toProcessorLockOptions(processorLock, lock),
     processingScope: postgreSQLProcessingScope({
       pool,
       connectionString,

--- a/src/packages/emmett-postgresql/src/eventStore/projections/locks/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/locks/index.ts
@@ -1,3 +1,3 @@
 export * from './postgreSQLProcessorLock';
 export * from './postgreSQLProjectionLock';
-export type { LockAcquisitionPolicy } from './tryAcquireProcessorLock';
+export type { LockAcquisitionPolicy } from '@event-driven-io/emmett';

--- a/src/packages/emmett-postgresql/src/eventStore/projections/locks/postgreSQLProcessorLock.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/locks/postgreSQLProcessorLock.ts
@@ -1,13 +1,14 @@
 import type { SQLExecutor } from '@event-driven-io/dumbo';
 import {
-  EmmettError,
+  DefaultProcessorLockPolicy,
+  type LockAcquisitionPolicy,
+  type ProcessorLock,
   type ProjectionHandlingType,
 } from '@event-driven-io/emmett';
 import { toProjectionLockKey } from './postgreSQLProjectionLock';
 import {
   releaseProcessorLock,
-  tryAcquireProcessorLockWithRetry,
-  type LockAcquisitionPolicy,
+  tryAcquireProcessorLock,
   type TryAcquireProcessorLockOptions,
 } from './tryAcquireProcessorLock';
 
@@ -24,6 +25,7 @@ export type PostgreSQLProcessorLockOptions = {
   };
   lockKey?: string | bigint;
   lockTimeoutSeconds?: number;
+  /** @deprecated Pass `lock.acquisitionPolicy` to the processor options instead */
   lockAcquisitionPolicy?: LockAcquisitionPolicy;
 };
 
@@ -31,14 +33,11 @@ export type PostgreSQLProcessorLockContext = {
   execute: SQLExecutor;
 };
 
-export type PostgreSQLProcessorLock = {
-  tryAcquire: (options: PostgreSQLProcessorLockContext) => Promise<boolean>;
-  release: (options: PostgreSQLProcessorLockContext) => Promise<void>;
-};
+export type PostgreSQLProcessorLock =
+  ProcessorLock<PostgreSQLProcessorLockContext>;
 
-export const DefaultPostgreSQLProcessorLockPolicy: LockAcquisitionPolicy = {
-  type: 'fail',
-};
+export const DefaultPostgreSQLProcessorLockPolicy: LockAcquisitionPolicy =
+  DefaultProcessorLockPolicy;
 
 export const postgreSQLProcessorLock = (
   options: PostgreSQLProcessorLockOptions,
@@ -57,20 +56,11 @@ export const postgreSQLProcessorLock = (
         return true;
       }
 
-      const result = await tryAcquireProcessorLockWithRetry(context.execute, {
+      const result = await tryAcquireProcessorLock(context.execute, {
         ...options,
         lockKey,
       });
 
-      // TODO: This should be moved o prcessor
-      if (!result.acquired && options.lockAcquisitionPolicy?.type !== 'skip') {
-        console.log(
-          `Failed to acquire lock for processor '${options.processorId}' with policy '${options.lockAcquisitionPolicy?.type}'.`,
-        );
-        throw new EmmettError(
-          `Failed to acquire lock for processor '${options.processorId}'`,
-        );
-      }
       acquired = result.acquired;
       return acquired;
     },

--- a/src/packages/emmett-postgresql/src/eventStore/projections/locks/tryAcquireProcessorLock.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/locks/tryAcquireProcessorLock.ts
@@ -1,6 +1,5 @@
 import { single, type SQLExecutor } from '@event-driven-io/dumbo';
 import {
-  asyncRetry,
   hashText,
   isBigint,
   type ProjectionHandlingType,
@@ -9,7 +8,6 @@ import {
   callReleaseProcessorLock,
   callTryAcquireProcessorLock,
 } from '../../schema/processors/processorsLocks';
-import { DefaultPostgreSQLProcessorLockPolicy } from './postgreSQLProcessorLock';
 
 export type TryAcquireProcessorLockOptions = {
   processorId: string;
@@ -32,16 +30,6 @@ export type TryAcquireProcessorLockResult =
       checkpoint: string;
     }
   | { acquired: false };
-
-export type LockAcquisitionPolicy =
-  | { type: 'fail' }
-  | { type: 'skip' }
-  | {
-      type: 'retry';
-      retries: number;
-      minTimeout?: number;
-      maxTimeout?: number;
-    };
 
 export const PROCESSOR_LOCK_DEFAULT_TIMEOUT_SECONDS = 300;
 
@@ -81,27 +69,6 @@ export const tryAcquireProcessorLock = async (
   return acquired
     ? { acquired: true, checkpoint: checkpoint! }
     : { acquired: false };
-};
-
-export const tryAcquireProcessorLockWithRetry = async (
-  execute: SQLExecutor,
-  options: TryAcquireProcessorLockOptions & {
-    lockAcquisitionPolicy?: LockAcquisitionPolicy;
-  },
-): Promise<TryAcquireProcessorLockResult> => {
-  const policy =
-    options.lockAcquisitionPolicy ?? DefaultPostgreSQLProcessorLockPolicy;
-
-  if (policy.type === 'retry') {
-    return asyncRetry(() => tryAcquireProcessorLock(execute, options), {
-      retries: policy.retries - 1,
-      minTimeout: policy.minTimeout,
-      maxTimeout: policy.maxTimeout,
-      shouldRetryResult: (r) => !r.acquired,
-    });
-  }
-
-  return tryAcquireProcessorLock(execute, options);
 };
 
 export type ReleaseProcessorLockOptions = {

--- a/src/packages/emmett-tests/src/processors/postgreSQLProcessorLock.int.spec.ts
+++ b/src/packages/emmett-tests/src/processors/postgreSQLProcessorLock.int.spec.ts
@@ -1,0 +1,58 @@
+import { dumbo } from '@event-driven-io/dumbo';
+import { pgDumboDriver, type PgPool } from '@event-driven-io/dumbo/pg';
+import { defaultTag } from '@event-driven-io/emmett';
+import {
+  createEventStoreSchema,
+  postgreSQLProcessorLock,
+  type PostgreSQLProcessorLockContext,
+} from '@event-driven-io/emmett-postgresql';
+import { getPostgreSQLStartedContainer } from '@event-driven-io/emmett-testcontainers';
+import type { StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { afterAll, beforeAll, describe } from 'vitest';
+import {
+  testProcessorLock,
+  type ProcessorLockFactory,
+} from './processorLock.features';
+
+let postgres: StartedPostgreSqlContainer;
+let pool: PgPool;
+
+beforeAll(async () => {
+  postgres = await getPostgreSQLStartedContainer();
+  const connectionString = postgres.getConnectionUri();
+
+  pool = dumbo({
+    connectionString,
+    driver: pgDumboDriver,
+    transactionOptions: { allowNestedTransactions: true },
+  });
+  await createEventStoreSchema(connectionString, pool);
+}, 120000);
+
+afterAll(async () => {
+  await pool?.close();
+  await postgres?.stop();
+});
+
+const postgreSQLProcessorLockFactory: ProcessorLockFactory<
+  PostgreSQLProcessorLockContext
+> = () =>
+  Promise.resolve({
+    createLock: ({ processorId, processorInstanceId }) =>
+      postgreSQLProcessorLock({
+        processorId,
+        processorInstanceId,
+        partition: defaultTag,
+        version: 1,
+      }),
+    // each operation gets its own transaction, as the processor's processing
+    // scope does
+    withContext: (handler) =>
+      pool.withTransaction((transaction) =>
+        handler({ execute: transaction.execute }),
+      ),
+  });
+
+void describe('PostgreSQL processor lock', () => {
+  testProcessorLock(postgreSQLProcessorLockFactory);
+});

--- a/src/packages/emmett-tests/src/processors/processorLock.features.ts
+++ b/src/packages/emmett-tests/src/processors/processorLock.features.ts
@@ -1,0 +1,83 @@
+import {
+  assertFalse,
+  assertTrue,
+  type DefaultRecord,
+  type ProcessorLock,
+} from '@event-driven-io/emmett';
+import { v4 as uuid } from 'uuid';
+import { beforeEach, describe, it } from 'vitest';
+
+export type ProcessorLockTestContext<HandlerContext extends DefaultRecord> = {
+  createLock: (options: {
+    processorId: string;
+    processorInstanceId: string;
+  }) => ProcessorLock<HandlerContext>;
+  /**
+   * Runs the handler with a fresh context, mirroring what the processor's
+   * processing scope does for a single lock operation.
+   */
+  withContext: <T>(
+    handler: (context: HandlerContext) => Promise<T>,
+  ) => Promise<T>;
+};
+
+export type ProcessorLockFactory<HandlerContext extends DefaultRecord> =
+  () => Promise<ProcessorLockTestContext<HandlerContext>>;
+
+export function testProcessorLock<HandlerContext extends DefaultRecord>(
+  factory: ProcessorLockFactory<HandlerContext>,
+) {
+  describe('ProcessorLock', () => {
+    let context: ProcessorLockTestContext<HandlerContext>;
+
+    beforeEach(async () => {
+      context = await factory();
+    });
+
+    const lockFor = (processorId: string, processorInstanceId: string) =>
+      context.createLock({ processorId, processorInstanceId });
+
+    it('grants the lock to the first instance', async () => {
+      const lock = lockFor(uuid(), 'first');
+
+      assertTrue(await context.withContext((c) => lock.tryAcquire(c)));
+    });
+
+    it('refuses the lock while another instance holds it', async () => {
+      const processorId = uuid();
+      const first = lockFor(processorId, 'first');
+      const second = lockFor(processorId, 'second');
+
+      assertTrue(await context.withContext((c) => first.tryAcquire(c)));
+
+      assertFalse(await context.withContext((c) => second.tryAcquire(c)));
+    });
+
+    it('grants the lock to another instance after release', async () => {
+      const processorId = uuid();
+      const first = lockFor(processorId, 'first');
+      const second = lockFor(processorId, 'second');
+
+      await context.withContext((c) => first.tryAcquire(c));
+      await context.withContext((c) => first.release(c));
+
+      assertTrue(await context.withContext((c) => second.tryAcquire(c)));
+    });
+
+    // the processor calls tryAcquire again on restart, and release on close
+    // regardless of how start went, so both have to be idempotent
+    it('grants the lock again to the instance already holding it', async () => {
+      const lock = lockFor(uuid(), 'first');
+
+      await context.withContext((c) => lock.tryAcquire(c));
+
+      assertTrue(await context.withContext((c) => lock.tryAcquire(c)));
+    });
+
+    it('releases a lock that was never acquired without throwing', async () => {
+      const lock = lockFor(uuid(), 'first');
+
+      await context.withContext((c) => lock.release(c));
+    });
+  });
+}

--- a/src/packages/emmett/src/processors/index.ts
+++ b/src/packages/emmett/src/processors/index.ts
@@ -1,5 +1,6 @@
 export * from './checkpoints';
 export * from './inMemoryProcessors';
 export * from './observability';
+export * from './processorLock';
 export * from './processors';
 export * from './processorStartPositions';

--- a/src/packages/emmett/src/processors/processorLock.ts
+++ b/src/packages/emmett/src/processors/processorLock.ts
@@ -1,0 +1,37 @@
+import type { DefaultRecord } from '../typing';
+
+/**
+ * Exclusive lock guarding a single processor instance.
+ *
+ * Identity (processor id, instance id, partition, version) is provided at
+ * construction time, the same way the store-specific locks already do it.
+ * The handler context is passed per call, so locks living in the message store
+ * can run inside the processor's transaction, while external locks ignore it.
+ */
+export type ProcessorLock<
+  HandlerContext extends DefaultRecord = DefaultRecord,
+> = {
+  tryAcquire: (context: HandlerContext) => Promise<boolean>;
+  release: (context: HandlerContext) => Promise<void>;
+};
+
+export type LockAcquisitionPolicy =
+  | { type: 'fail' }
+  | { type: 'skip' }
+  | {
+      type: 'retry';
+      retries: number;
+      minTimeout?: number;
+      maxTimeout?: number;
+    };
+
+export type ProcessorLockOptions<
+  HandlerContext extends DefaultRecord = DefaultRecord,
+> = {
+  lock?: ProcessorLock<HandlerContext>;
+  acquisitionPolicy?: LockAcquisitionPolicy;
+};
+
+export const DefaultProcessorLockPolicy: LockAcquisitionPolicy = {
+  type: 'fail',
+};

--- a/src/packages/emmett/src/processors/processorLock.unit.spec.ts
+++ b/src/packages/emmett/src/processors/processorLock.unit.spec.ts
@@ -1,0 +1,302 @@
+import { v7 as uuid } from 'uuid';
+import { describe, it } from 'vitest';
+import { EmmettError } from '../errors';
+import {
+  assertDeepEqual,
+  assertEqual,
+  assertFalse,
+  assertRejects,
+  assertTrue,
+} from '../testing';
+import type { Event } from '../typing';
+import type { Checkpointer } from './checkpoints';
+import type { ProcessorLock } from './processorLock';
+import { reactor } from './processors';
+
+type TestEvent = Event<'test', { counter: number }>;
+
+const inMemoryProcessorLock = (
+  options: { acquiresAfterAttempts?: number; acquires?: boolean } = {},
+): ProcessorLock & { attempts: number; isHeld: boolean } => {
+  const { acquiresAfterAttempts = 0, acquires = true } = options;
+
+  const lock = {
+    attempts: 0,
+    isHeld: false,
+    tryAcquire: () => {
+      lock.attempts++;
+      lock.isHeld = acquires && lock.attempts > acquiresAfterAttempts;
+      return Promise.resolve(lock.isHeld);
+    },
+    release: () => {
+      lock.isHeld = false;
+      return Promise.resolve();
+    },
+  };
+
+  return lock;
+};
+
+const recordingCheckpointer = (order: string[]): Checkpointer<TestEvent> => ({
+  read: () => {
+    order.push('checkpoint');
+    return Promise.resolve({ lastCheckpoint: null });
+  },
+  store: () => Promise.resolve({ success: false, reason: 'IGNORED' }),
+});
+
+void describe('Processor lock', () => {
+  void it('starts without a lock when none is supplied', async () => {
+    const processor = reactor<TestEvent>({
+      processorId: uuid(),
+      eachMessage: () => Promise.resolve(),
+    });
+
+    await processor.start();
+
+    assertTrue(processor.isActive);
+  });
+
+  void describe('fail policy', () => {
+    void it('throws when the lock is not acquired', async () => {
+      const processorId = uuid();
+      const lock = inMemoryProcessorLock({ acquires: false });
+
+      const processor = reactor<TestEvent>({
+        processorId,
+        eachMessage: () => Promise.resolve(),
+        lock: { lock, acquisitionPolicy: { type: 'fail' } },
+      });
+
+      await assertRejects(processor.start(), (error: EmmettError) =>
+        error.message.includes(processorId),
+      );
+    });
+
+    void it('is the default when a lock is supplied without a policy', async () => {
+      const processorId = uuid();
+      const lock = inMemoryProcessorLock({ acquires: false });
+
+      const processor = reactor<TestEvent>({
+        processorId,
+        eachMessage: () => Promise.resolve(),
+        lock: { lock },
+      });
+
+      await assertRejects(processor.start(), (error: EmmettError) =>
+        error.message.includes(processorId),
+      );
+    });
+  });
+
+  void it('proceeds unlocked with the skip policy', async () => {
+    const lock = inMemoryProcessorLock({ acquires: false });
+
+    const processor = reactor<TestEvent>({
+      processorId: uuid(),
+      eachMessage: () => Promise.resolve(),
+      lock: { lock, acquisitionPolicy: { type: 'skip' } },
+    });
+
+    await processor.start();
+
+    assertTrue(processor.isActive);
+    assertEqual(lock.attempts, 1);
+  });
+
+  void describe('retry policy', () => {
+    void it('retries until acquired', async () => {
+      const lock = inMemoryProcessorLock({ acquiresAfterAttempts: 2 });
+
+      const processor = reactor<TestEvent>({
+        processorId: uuid(),
+        eachMessage: () => Promise.resolve(),
+        lock: {
+          lock,
+          acquisitionPolicy: {
+            type: 'retry',
+            retries: 5,
+            minTimeout: 1,
+            maxTimeout: 5,
+          },
+        },
+      });
+
+      await processor.start();
+
+      assertEqual(lock.attempts, 3);
+      assertTrue(lock.isHeld);
+    });
+
+    void it('throws once the retries are exhausted', async () => {
+      const lock = inMemoryProcessorLock({ acquires: false });
+
+      const processor = reactor<TestEvent>({
+        processorId: uuid(),
+        eachMessage: () => Promise.resolve(),
+        lock: {
+          lock,
+          acquisitionPolicy: {
+            type: 'retry',
+            retries: 3,
+            minTimeout: 1,
+            maxTimeout: 5,
+          },
+        },
+      });
+
+      // asyncRetry rejects from within the retry loop, so exhaustion surfaces
+      // its own error rather than the tailored 'Failed to acquire lock' one
+      await assertRejects(processor.start(), (error: EmmettError) =>
+        error.message.includes('Retrying because of'),
+      );
+
+      assertEqual(lock.attempts, 3);
+    });
+
+    void it('falls back to failing when a single attempt is not acquired', async () => {
+      const processorId = uuid();
+      const lock = inMemoryProcessorLock({ acquires: false });
+
+      const processor = reactor<TestEvent>({
+        processorId,
+        eachMessage: () => Promise.resolve(),
+        lock: { lock, acquisitionPolicy: { type: 'retry', retries: 1 } },
+      });
+
+      await assertRejects(processor.start(), (error: EmmettError) =>
+        error.message.includes(processorId),
+      );
+
+      assertEqual(lock.attempts, 1);
+    });
+  });
+
+  void it('acquires the lock before the onStart hook and the checkpoint read', async () => {
+    const order: string[] = [];
+    const lock = inMemoryProcessorLock();
+
+    const processor = reactor<TestEvent>({
+      processorId: uuid(),
+      eachMessage: () => Promise.resolve(),
+      checkpoints: recordingCheckpointer(order),
+      lock: {
+        lock: {
+          tryAcquire: (context) => {
+            order.push('acquire');
+            return lock.tryAcquire(context);
+          },
+          release: (context) => lock.release(context),
+        },
+      },
+      hooks: {
+        onStart: () => {
+          order.push('onStart');
+          return Promise.resolve();
+        },
+      },
+    });
+
+    await processor.start();
+
+    assertDeepEqual(order, ['acquire', 'onStart', 'checkpoint']);
+  });
+
+  void it('does not read the checkpoint when acquisition fails', async () => {
+    const processorId = uuid();
+    const order: string[] = [];
+
+    const processor = reactor<TestEvent>({
+      processorId,
+      eachMessage: () => Promise.resolve(),
+      checkpoints: recordingCheckpointer(order),
+      lock: { lock: inMemoryProcessorLock({ acquires: false }) },
+    });
+
+    await assertRejects(processor.start(), (error: EmmettError) =>
+      error.message.includes(processorId),
+    );
+
+    assertDeepEqual(order, []);
+  });
+
+  void describe('release', () => {
+    void it('releases the lock before the onClose hook runs', async () => {
+      const order: string[] = [];
+      const lock = inMemoryProcessorLock();
+
+      const processor = reactor<TestEvent>({
+        processorId: uuid(),
+        eachMessage: () => Promise.resolve(),
+        lock: {
+          lock: {
+            tryAcquire: (context) => lock.tryAcquire(context),
+            release: (context) => {
+              order.push('release');
+              return lock.release(context);
+            },
+          },
+        },
+        hooks: {
+          onClose: () => {
+            // the PostgreSQL processor tears down its pool here, so the lock
+            // has to be released first
+            order.push('onClose');
+            return Promise.resolve();
+          },
+        },
+      });
+
+      await processor.start();
+      assertTrue(lock.isHeld);
+
+      await processor.close();
+
+      assertFalse(lock.isHeld);
+      assertDeepEqual(order, ['release', 'onClose']);
+    });
+
+    void it('releases the lock even when the onClose hook throws', async () => {
+      const lock = inMemoryProcessorLock();
+
+      const processor = reactor<TestEvent>({
+        processorId: uuid(),
+        eachMessage: () => Promise.resolve(),
+        lock: { lock },
+        hooks: {
+          onClose: () => Promise.reject(new EmmettError('onClose failed')),
+        },
+      });
+
+      await processor.start();
+
+      await assertRejects(processor.close(), (error: EmmettError) =>
+        error.message.includes('onClose failed'),
+      );
+
+      assertFalse(lock.isHeld);
+    });
+
+    void it('does not release a lock it never acquired', async () => {
+      let released = false;
+      const lock: ProcessorLock = {
+        tryAcquire: () => Promise.resolve(false),
+        release: () => {
+          released = true;
+          return Promise.resolve();
+        },
+      };
+
+      const processor = reactor<TestEvent>({
+        processorId: uuid(),
+        eachMessage: () => Promise.resolve(),
+        lock: { lock, acquisitionPolicy: { type: 'skip' } },
+      });
+
+      await processor.start();
+      await processor.close();
+
+      assertFalse(released);
+    });
+  });
+});

--- a/src/packages/emmett/src/processors/processors.ts
+++ b/src/packages/emmett/src/processors/processors.ts
@@ -26,6 +26,7 @@ import {
   type BatchMessageHandlerResult,
   type BatchRecordedMessageHandlerWithContext,
   type CanHandle,
+  type DefaultRecord,
   type Event,
   type Message,
   type MessageHandlerContext,
@@ -35,6 +36,7 @@ import {
 } from '../typing';
 import { onShutdown } from '../utils/lifecycle';
 import { asyncAwaiter } from '../utils/promises';
+import { asyncRetry } from '../utils/retry';
 import {
   getCheckpoint,
   ProcessorCheckpoint,
@@ -43,6 +45,12 @@ import {
 } from './checkpoints';
 import { inMemoryCheckpointer } from './inMemoryProcessors';
 import { processorCollector, processorObservability } from './observability';
+import {
+  DefaultProcessorLockPolicy,
+  type LockAcquisitionPolicy,
+  type ProcessorLock,
+  type ProcessorLockOptions,
+} from './processorLock';
 
 export type CurrentMessageProcessorPosition =
   { lastCheckpoint: ProcessorCheckpoint } | 'BEGINNING' | 'END';
@@ -311,6 +319,7 @@ export type BaseMessageProcessorOptions<
     Checkpointer<MessageType, MessageMetadataType, HandlerContext> | 'DISABLED';
   canHandle?: CanHandle<MessageType>;
   hooks?: ProcessorHooks<HandlerContext>;
+  lock?: ProcessorLockOptions<HandlerContext>;
 } & JSONSerializationOptions & {
     observability?: ProcessorObservabilityConfig;
   };
@@ -467,6 +476,36 @@ export const getProjectorId = (options: { projectionName: string }): string =>
 
 const { info, error: error } = LogEvent;
 
+const acquireProcessorLock = async <HandlerContext extends DefaultRecord>(
+  options: {
+    processorId: string;
+    lock: ProcessorLock<HandlerContext>;
+    acquisitionPolicy?: LockAcquisitionPolicy;
+  },
+  context: HandlerContext,
+): Promise<boolean> => {
+  const policy = options.acquisitionPolicy ?? DefaultProcessorLockPolicy;
+
+  // exhausting the retries rejects from within asyncRetry, so the throw below
+  // is only reached by the single-attempt policies
+  const acquired =
+    policy.type === 'retry'
+      ? await asyncRetry(() => options.lock.tryAcquire(context), {
+          retries: policy.retries - 1,
+          minTimeout: policy.minTimeout,
+          maxTimeout: policy.maxTimeout,
+          shouldRetryResult: (acquired) => !acquired,
+        })
+      : await options.lock.tryAcquire(context);
+
+  if (!acquired && policy.type !== 'skip')
+    throw new EmmettError(
+      `Failed to acquire lock for processor '${options.processorId}'`,
+    );
+
+  return acquired;
+};
+
 export const reactor = <
   MessageType extends Message = AnyMessage,
   MessageMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
@@ -488,6 +527,7 @@ export const reactor = <
     version = defaultProcessorVersion,
     partition = defaultProcessorPartition,
     hooks = {},
+    lock: lockOptions = {},
     processingScope = defaultProcessingMessageProcessingScope,
     startFrom,
     canHandle,
@@ -575,6 +615,7 @@ export const reactor = <
 
   let isInitiated = false;
   let isActive = false;
+  let isLockAcquired = false;
 
   let lastCheckpoint: ProcessorCheckpoint | null = null;
   let lastStoredCheckpoint: ProcessorCheckpoint | null = null;
@@ -645,8 +686,17 @@ export const reactor = <
       closeSignal = null;
     }
 
-    if (hooks.onClose) {
-      await processingScope(hooks.onClose, closeOptions);
+    if (isLockAcquired || hooks.onClose) {
+      await processingScope(async (context) => {
+        // released before the close hooks, as those may tear down the
+        // connection the lock is held on
+        if (isLockAcquired && lockOptions.lock) {
+          await lockOptions.lock.release(context);
+          isLockAcquired = false;
+        }
+
+        if (hooks.onClose) await hooks.onClose(context);
+      }, closeOptions);
     }
   };
 
@@ -718,6 +768,23 @@ export const reactor = <
 
       return await processingScope(async (context) => {
         const log = context.observabilityScope.log;
+
+        if (lockOptions.lock) {
+          log(
+            info(
+              `Acquiring lock for processor ${processorId} with instance id ${instanceId}`,
+            ),
+          );
+          isLockAcquired = await acquireProcessorLock(
+            {
+              processorId,
+              lock: lockOptions.lock,
+              acquisitionPolicy: lockOptions.acquisitionPolicy,
+            },
+            context,
+          );
+        }
+
         if (hooks.onStart) {
           log(
             info(


### PR DESCRIPTION
## Why

Locking lives in a PostgreSQL-specific hook decorator (`wrapHooksWithProcessorLocks`), so ESDB, MongoDB and SQLite processors have no way to lock at all, and no external service can supply one. This is the first (of probably three PRs) discussed in #328 — it moves the seam into core and adapts PostgreSQL to it, without adding any new locking capability.

## What changed

The processor now owns the lock lifecycle. It acquires inside the processing scope before reading the checkpoint, applies the acquisition policy, and releases on close ahead of the close hooks, which may tear down the connection the lock is held on.

`ProcessorLock` and `LockAcquisitionPolicy` are new in `@event-driven-io/emmett`, and `BaseMessageProcessorOptions` gained `lock?: { lock?, acquisitionPolicy? }`. `LockAcquisitionPolicy` is re-exported from `@event-driven-io/emmett-postgresql`, so existing imports keep working. ESDB, MongoDB and SQLite inherit the option through their existing option spreads, with no code change.

`postgreSQLProcessorLock` keeps its signature and its SQL, and is now typed as `ProcessorLock<PostgreSQLProcessorLockContext>`. It no longer throws or retries by itself — that logic moved to core, where the `// TODO: This should be moved o prcessor` comment asked for it.

## Behaviour changes

Projectors acquire the lock before `truncateOnStart` runs, where the truncate used to come first. Under `rebuildPostgreSQLProjections`' default retry policy, a losing instance previously deleted every projection row and then held those row locks for the length of its retry loop. It now blocks on the lock first.

`postgreSQLProcessorLock`'s `lockAcquisitionPolicy` option is deprecated and ignored, since the policy is the processor's job now. No in-repo caller passes it for anything but `skip`, which was the no-throw case, but a direct caller outside the processors would see `tryAcquire` return `false` where it previously threw.

The PostgreSQL processor `lock` option gained an optional `lock`, so a caller can supply their own `ProcessorLock` instead of the message-store one. The intersection with the core option made it typecheck already; honouring it beats silently dropping it.

## Compatibility

No export was removed from either package and no exported type narrowed — verified by diffing the emitted `dist/index.d.ts` for both packages against `main`, and by compiling a consumer against them. `tryAcquireProcessorLockWithRetry` was deleted, but it was never in a barrel and the package has no wildcard subpath export, so it was never reachable.

## Testing

`postgreSQLProcessorLock.int.spec.ts` passes unmodified (26 cases) — it drives the SQL directly, which does not move, so it is the regression proof for this PR. New: a core unit spec for the policy and lifecycle, a store-agnostic conformance suite in `emmett-tests` that PR2 can reuse, and an int case pinning the projector's lock wiring. Full PostgreSQL int suite and the workspace unit suite are green.

## Not in this PR

Leases, `renew`/heartbeat and loss handling, and the Redis package. No `noopProcessorLock` either — absence of a lock means no lock.

## Open questions

Is the nested `lock: { lock, acquisitionPolicy }` shape right, or would top-level `lock?: ProcessorLock` plus `lockOptions?` read better? Nested keeps the existing PostgreSQL option shape unchanged, which is why it is proposed.

`timeoutSeconds` stays construction-time on the PostgreSQL lock and core never sees it, since it is meaningless for a lock without a lease. Happy to move it if you would rather core carry it.

On an exhausted `retry` policy, `asyncRetry` rejects from inside its own loop, so the error is `Retrying because of result: false` rather than the tailored `Failed to acquire lock for processor '<id>'`. That is pre-existing behaviour carried over verbatim; fixing it means touching `asyncRetry`, so it is left alone here.
