### PR TITLE
Added explicit dumbo pg driver to all pool creation

### DIFF
--- a/qa.md
+++ b/qa.md
@@ -1,0 +1,199 @@
+# Q&A: PostgreSQL multi-driver migration
+
+## Q1 — Public API shape for `getPostgreSQLEventStore`
+
+SQLite uses `getSQLiteEventStore({ driver, ... })` with no positional connection
+argument. PostgreSQL uses `getPostgreSQLEventStore(connectionString, options)`.
+
+Options offered:
+
+- **A** — Match SQLite exactly, options-object only. Breaking for all users.
+- **B** — Keep the positional signature, add optional `options.driver`. No break,
+  but PG and SQLite stay asymmetric.
+- **C** — Overload: support both, A documented, B kept working (deprecated) until
+  the next major.
+
+**A1: C.**
+
+Support both forms. The options-object form carrying `driver` is the documented,
+forward-looking API; the `(connectionString, options)` form keeps working and is
+marked deprecated, to be removed in the next major.
+
+## Q2 — Where does the `EventStoreDriver` abstraction live?
+
+`emmett-sqlite/src/eventStore/eventStoreDriver.ts` is 35 lines of storage-neutral
+types that PostgreSQL needs verbatim.
+
+Options offered:
+
+- **A** — Duplicate it in `emmett-postgresql`. One repo, one release; the two
+  packages already duplicate `schema/`, `projections/` and `consumers/`.
+- **B** — Hoist to `@event-driven-io/emmett` core. Cost: core has no dumbo
+  dependency today, so this drags SQL storage into the storage-agnostic package.
+- **C** — Move it into dumbo, next to `DumboDatabaseDriver` and the registry.
+  Cost: cross-repo release lockstep with Pongo.
+
+**A2: A.**
+
+Duplicate the interface in `emmett-postgresql` for this migration.
+
+Open: whether to file a follow-up issue for an eventual hoist to a shared home
+(revisited in a later question).
+
+## Q3 — How far does this pass go on `connectionString`?
+
+`connectionString` is a required field of the PostgreSQL handler contexts
+(`postgreSQLProcessor.ts:78`, `postgreSQLProjection.ts:34`), the processor throws
+when it cannot find one (`postgreSQLProcessor.ts:284`), and the nested
+`messageStore` is rebuilt from the string rather than from the driver
+(`postgreSQLProcessor.ts:313`). SQLite's context carries `connection` and
+`driverType` instead, and no connection string.
+
+Options offered:
+
+- **A** — Fix only the `dumbo()` driver plumbing; leave `connectionString`
+  required and the `TODO` comments in place.
+- **B** — Make `connectionString` optional but keep populating it; derive the
+  nested store from `driver` + pool/connection; drop the throw.
+- **C** — Remove `connectionString` from the contexts entirely, replacing it with
+  `driver` + `pool` + `connection`, matching SQLite.
+
+**A3: C.**
+
+Remove `connectionString` from the handler contexts. This is a breaking change
+for user reactors and projections that read `context.connection.connectionString`,
+and it fails at runtime rather than compile time for plain-JS consumers, so it
+needs a release note and a migration entry.
+
+## Q4 — Driver option surface
+
+SQLite delegates to dumbo: `{ connectionOptions?: ExtractDumboDatabaseDriverOptions<Driver> }`
+plus a top-level `{ pool?: Dumbo }` escape hatch. PostgreSQL hand-rolls a 9-member
+union (`connector`, `connectionString`, `database`, `pooled`, `pool` as raw
+`pg.Pool`, `client` as raw `pg.Client`, `connection`, `dumbo` as `PgPool`).
+
+Options offered:
+
+- **A** — Delegate like SQLite; `connectionOptions` becomes `PgPoolOptions`,
+  `dumbo` renamed to `pool: Dumbo`, `connector` dropped.
+- **B** — Keep the union, move it behind `pgEventStoreDriver.mapToDumboOptions`.
+- **C** — A, with the old union still accepted and deprecated.
+
+**A4: C.**
+
+Delegate to dumbo's `PgPoolOptions` as the documented shape; keep the existing
+union compiling and deprecated. `connector` becomes a deprecated alias for
+`driverType`.
+
+Open: the `dumbo` vs `pool` naming collision is the one part that cannot be
+deprecation-ramped by overloading (see Q5).
+
+## Q5 — The `pool` naming collision
+
+SQLite's top-level `pool` is a `Dumbo`; PostgreSQL's is a raw `pg.Pool`, and its
+Dumbo escape hatch is `dumbo`. After Q4's delegation, the raw `pg.Pool` belongs
+inside `connectionOptions`, freeing the top-level slot.
+
+Options offered:
+
+- **A** — PostgreSQL adopts SQLite's meaning: top-level `pool: Dumbo` in both
+  packages, raw `pg.Pool` moves to `connectionOptions.pool`, `dumbo` becomes a
+  deprecated alias.
+- **B** — SQLite adopts PostgreSQL's meaning: rename SQLite's `pool` to `dumbo`.
+- **C** — Accept both at `pool` and discriminate at runtime.
+
+**A5: A**, plus the existing `getPostgreSQLEventStore` overload must stay
+backward compatible.
+
+So the compatibility contract is:
+
+Guaranteed to keep working:
+
+- `getPostgreSQLEventStore(connectionString, options)` positional form
+- the existing `PostgresEventStoreConnectionOptions` union, deprecated
+- `dumbo: PgPool` as a deprecated alias for `pool: Dumbo`
+- `connector` as a deprecated alias for `driverType`
+
+Accepted breaks:
+
+- `context.connection.connectionString` removed from the processor and projection
+  handler contexts (from Q3); runtime break for plain-JS handlers
+- top-level `pool: pg.Pool` moves to `connectionOptions.pool`; compile-time break
+
+Still open: which release this lands in.
+
+## Q6 — What second driver does the seam have to carry?
+
+Two families: same wire protocol with a different client library (`postgres.js`,
+`pglite`, Hyperdrive), where the SQL and the `pg_try_advisory_xact_lock` calls
+baked into the stored functions still work; or a different execution model (Neon
+over HTTP), where advisory locks and `projections/locks/` stop working entirely.
+
+Options offered:
+
+- **A** — Same protocol only; `EventStoreDriver` maps options and names a dumbo
+  driver, nothing more.
+- **B** — Add capability flags now (`supportsAdvisoryLocks`, transaction mode) and
+  make lock and consumer paths consult them.
+- **C** — Same protocol now, but shape the seam so B is additive later.
+
+**A6: C, kept minimal.**
+
+No speculative capability model and no broad refactor. The goal is only that
+pg-specific code is already separated behind a named boundary, so capability flags
+can be added later without re-threading everything.
+
+## Q7 — Where does the default driver come from?
+
+SQLite makes `driver` required and exports drivers only from subpaths, keeping the
+root index driver-free. PostgreSQL cannot copy that, because the existing
+no-driver call must keep working, so a default must come from somewhere.
+
+Options offered:
+
+- **A** — Static default in the root index; `emmett-postgresql/pg` also exports
+  the driver for the explicit form.
+- **B** — Match SQLite exactly: `driver` required, root index driver-free.
+- **C** — Lazy default resolved through `dumboDatabaseDriverRegistry`.
+
+**A7: A**, with two explicit overloads:
+
+1. `getPostgreSQLEventStore(connectionString, options?)` — the existing shape.
+   No `driver`, defaults to the pg driver. Kept for backward compatibility.
+2. `getPostgreSQLEventStore(options)` — options object carrying `driver`, with no
+   positional connection string. Connection details arrive through the driver's
+   own option shape rather than as a separate argument.
+
+C is rejected outright: the registry plus import-side-effect path is the mechanism
+that produced `No plugin found for driver type: undefined`.
+
+Consequence to state plainly in the docs: the root entrypoint still pulls in
+`dumbo/pg` and `pg`, exactly as it does today. The separation makes the next
+driver cheap to add; it does not make `pg` tree-shakeable out of the default
+entrypoint.
+
+## Q8 — Regression guard against `dumbo()` without a driver
+
+The bug class is a `dumbo({...})` call whose options object has no `driver` key.
+Types cannot catch it, because dumbo's second overload deliberately accepts
+`driver?: never`. dumbo itself already uses `no-restricted-syntax` selectors
+verified by `eslintRules.unit.spec.ts`, and emmett's `eslint.config.mjs` already
+uses `no-restricted-imports`.
+
+Options offered:
+
+- **A** — A `no-restricted-syntax` rule plus a unit spec asserting the rule
+  exists, mirroring dumbo.
+- **B** — A unit test that AST-walks package sources for offending calls.
+- **C** — Neither; rely on review.
+
+**A8: A.**
+
+Caveat carried forward: the selector must exempt spread elements, because SQLite's
+call sites legitimately supply `driver` via
+`...options.driver.mapToDumboOptions(options)`. The rule therefore catches the
+plain-object-literal case only, which is the case that broke in all five places.
+
+Assumed unless corrected: the rule lives in the shared `eslint.config.mjs` and
+applies to both `emmett-postgresql` and `emmett-sqlite`, since the spread
+exemption lets SQLite pass as written.

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.handling.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.handling.int.spec.ts
@@ -1,4 +1,5 @@
 import { dumbo, type Dumbo } from '@event-driven-io/dumbo';
+import { pgDumboDriver } from '@event-driven-io/dumbo/pg';
 import type { EmmettError } from '@event-driven-io/emmett';
 import {
   assertEqual,
@@ -57,6 +58,7 @@ void describe('PostgreSQL event store started consumer', () => {
     await eventStore.schema.migrate();
     pool = dumbo({
       connectionString,
+      driver: pgDumboDriver,
       transactionOptions: {
         allowNestedTransactions: true,
       },
@@ -1051,6 +1053,7 @@ void describe('PostgreSQL event store started consumer', () => {
         // Given
         const pool = dumbo({
           connectionString,
+          driver: pgDumboDriver,
           transactionOptions: {
             allowNestedTransactions: true,
           },

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
@@ -13,11 +13,11 @@ import {
   type RecordedMessageMetadataWithGlobalPosition,
   type WorkflowProcessorContext,
 } from '@event-driven-io/emmett';
-import { postgreSQLMessageSource } from './messageSource';
 import {
   eventStoreDatabaseSchema,
   type EventStoreDatabaseSchemaOptions,
 } from '../schema';
+import { postgreSQLMessageSource } from './messageSource';
 import {
   postgreSQLProjector,
   postgreSQLReactor,
@@ -28,6 +28,7 @@ import {
   type PostgreSQLReactorOptions,
   type PostgreSQLWorkflowProcessorOptions,
 } from './postgreSQLProcessor';
+import { pgDumboDriver } from '@event-driven-io/dumbo/pg';
 
 export type PostgreSQLEventStoreConsumerConfig<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -119,6 +120,7 @@ export const postgreSQLEventStoreConsumer = <
   const pool = options.pool
     ? options.pool
     : dumbo({
+        driver: pgDumboDriver,
         connectionString: options.connectionString,
         serialization: options.serialization,
         transactionOptions: {

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLProcessor.transactions.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLProcessor.transactions.int.spec.ts
@@ -1,4 +1,4 @@
-import { dumbo, type Dumbo, SQL } from '@event-driven-io/dumbo';
+import { dumbo, SQL, type Dumbo } from '@event-driven-io/dumbo';
 import { assertEqual, type Event } from '@event-driven-io/emmett';
 import { v4 as uuid } from 'uuid';
 import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
@@ -11,6 +11,7 @@ import {
   type PostgresEventStore,
 } from '../postgreSQLEventStore';
 import { postgreSQLEventStoreConsumer } from './postgreSQLEventStoreConsumer';
+import { pgDumboDriver } from '@event-driven-io/dumbo/pg';
 
 const withDeadline = { timeout: 30000 };
 
@@ -25,7 +26,10 @@ void describe('PostgreSQL processor transaction handling', () => {
     connectionString = database.connectionString;
     eventStore = getPostgreSQLEventStore(connectionString);
     await eventStore.schema.migrate();
-    observerPool = dumbo({ connectionString });
+    observerPool = dumbo({
+      driver: pgDumboDriver,
+      connectionString,
+    });
   }, 120000);
 
   beforeEach(async () => {

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLProcessor.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLProcessor.ts
@@ -1,22 +1,20 @@
 import {
   dumbo,
   type DatabaseDriverType,
-  type Dumbo,
   type SQLExecutor,
 } from '@event-driven-io/dumbo';
-import type {
-  PgClient,
-  PgClientConnection,
-  PgDriverType,
-  PgPool,
-  PgPoolClientConnection,
-  PgTransaction,
+import {
+  pgDumboDriver,
+  type PgClient,
+  type PgClientConnection,
+  type PgDriverType,
+  type PgPool,
+  type PgPoolClientConnection,
+  type PgTransaction,
 } from '@event-driven-io/dumbo/pg';
 import type {
   AnyCommand,
   AnyEvent,
-  ProcessorLock,
-  ProcessorLockOptions,
   AnyMessage,
   AnyRecordedMessageMetadata,
   BatchRecordedMessageHandlerWithContext,
@@ -29,6 +27,8 @@ import type {
   MessageProcessingScope,
   MessageProcessor,
   ProcessorHooks,
+  ProcessorLock,
+  ProcessorLockOptions,
   ProjectorOptions,
   ReactorOptions,
   ReadEventMetadataWithGlobalPosition,
@@ -78,7 +78,7 @@ export type PostgreSQLProcessorHandlerContext = MessageHandlerContext<
       connectionString: string;
       client: PgClient;
       transaction: PgTransaction;
-      pool: Dumbo;
+      pool: PgPool;
       messageStore: PostgresEventStore;
     };
   } &
@@ -259,7 +259,7 @@ export type PostgreSQLWorkflowProcessorOptions<
   PostgreSQLProcessorOptionsBase;
 
 const postgreSQLProcessingScope = (options: {
-  pool: Dumbo | null;
+  pool: PgPool | null;
   connectionString: string | null;
   processorId: string;
   partition: string;
@@ -298,7 +298,6 @@ const postgreSQLProcessingScope = (options: {
       );
 
     return pool.withTransaction(async (transaction) => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       const client = (await transaction.connection.open()) as PgClient;
       return handler({
         ...partialContext,
@@ -309,7 +308,7 @@ const postgreSQLProcessingScope = (options: {
           connectionString,
           pool,
           client,
-          transaction: transaction as PgTransaction,
+          transaction: transaction,
           messageStore: getPostgreSQLEventStore(connectionString, {
             connectionOptions: {
               connection: transaction.connection as PgPoolClientConnection,
@@ -343,6 +342,7 @@ const getProcessorPool = (options: PostgreSQLConnectionOptions) => {
       ? (poolOptions.dumbo as PgPool)
       : processorConnectionString
         ? dumbo({
+            driver: pgDumboDriver,
             connectionString: processorConnectionString,
             ...poolOptions,
             serialization: options.serialization,

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/rebuildPostgreSQLProjections.e2e.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/rebuildPostgreSQLProjections.e2e.spec.ts
@@ -36,8 +36,8 @@ void describe('PostgreSQL projection rebuild with advisory locking', () => {
       projections: projections.inline([]),
     });
     pool = dumbo({
-      connectionString,
       driver: pgDumboDriver,
+      connectionString,
       transactionOptions: {
         allowNestedTransactions: true,
       },

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/rebuildPostgreSQLProjections.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/rebuildPostgreSQLProjections.int.spec.ts
@@ -29,6 +29,7 @@ import {
   isolatedPostgreSQLDatabase,
   type PostgreSQLTestDatabase,
 } from '../../testing/postgreSQLTestDatabase';
+import { tableExists } from '../../testing/schemaObjects';
 import type {
   ProductItemAdded,
   ShoppingCartConfirmed,
@@ -41,7 +42,6 @@ import {
   pongoSingleStreamProjection,
   postgreSQLRawSQLProjection,
 } from '../projections';
-import { tableExists } from '../../testing/schemaObjects';
 import { rebuildPostgreSQLProjections } from './rebuildPostgreSQLProjections';
 
 const withDeadline = { timeout: 30000 };
@@ -87,8 +87,8 @@ void describe('Rebuilding PostgreSQL Projections', () => {
       `${otherShoppingCartsSummaryCollectionName}_v2`,
     );
     pool = dumbo({
-      connectionString,
       driver: pgDumboDriver,
+      connectionString,
       transactionOptions: {
         allowNestedTransactions: true,
       },

--- a/src/packages/emmett-postgresql/src/eventStore/projections/locks/postgreSQLProcessorLock.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/locks/postgreSQLProcessorLock.int.spec.ts
@@ -31,8 +31,8 @@ void describe('tryAcquireProcessorLock', () => {
     database = await sharedPostgreSQLDatabase();
     connectionString = database.connectionString;
     pool = dumbo({
-      connectionString,
       driver: pgDumboDriver,
+      connectionString,
       transactionOptions: {
         allowNestedTransactions: true,
       },

--- a/src/packages/emmett-postgresql/src/eventStore/projections/locks/postgreSQLProjectionLock.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/locks/postgreSQLProjectionLock.int.spec.ts
@@ -29,8 +29,8 @@ void describe('tryAcquireProjectionLock', () => {
     database = await sharedPostgreSQLDatabase();
     connectionString = database.connectionString;
     pool = dumbo({
-      connectionString,
       driver: pgDumboDriver,
+      connectionString,
       transactionOptions: {
         allowNestedTransactions: true,
       },

--- a/src/packages/emmett-postgresql/src/eventStore/projections/management/projectionRegistration.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/management/projectionRegistration.int.spec.ts
@@ -12,11 +12,11 @@ import {
   type ProjectionRegistration,
 } from '@event-driven-io/emmett';
 import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import type { PostgreSQLProjectionHandlerContext } from '..';
 import {
   sharedPostgreSQLDatabase,
   type PostgreSQLTestDatabase,
 } from '../../../testing/postgreSQLTestDatabase';
-import type { PostgreSQLProjectionHandlerContext } from '..';
 import type { PostgresReadEventMetadata } from '../../postgreSQLEventStore';
 import { createEventStoreSchema } from '../../schema';
 import {
@@ -34,8 +34,8 @@ void describe('projectionRegistration', () => {
     database = await sharedPostgreSQLDatabase();
     const connectionString = database.connectionString;
     pool = dumbo({
-      connectionString,
       driver: pgDumboDriver,
+      connectionString,
       transactionOptions: {
         allowNestedTransactions: true,
       },

--- a/src/packages/emmett-postgresql/src/eventStore/projections/pongo/postgreSQLPongoProjection.schema.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/pongo/postgreSQLPongoProjection.schema.int.spec.ts
@@ -2,23 +2,23 @@ import { dumbo, mapRows, SQL, SQLTableReference } from '@event-driven-io/dumbo';
 import { pgDumboDriver, type PgPool } from '@event-driven-io/dumbo/pg';
 import {
   assertDeepEqual,
-  assertIsNull,
   assertFalse,
+  assertIsNull,
   assertRejects,
   assertTrue,
   type Event,
 } from '@event-driven-io/emmett';
+import { pongoClient, type PongoCollection } from '@event-driven-io/pongo';
+import { pgDriver } from '@event-driven-io/pongo/pg';
 import { v4 as uuid } from 'uuid';
 import { afterAll, beforeAll, describe, it } from 'vitest';
 import {
   sharedPostgreSQLDatabase,
   type PostgreSQLTestDatabase,
 } from '../../../testing/postgreSQLTestDatabase';
-import { getPostgreSQLEventStore } from '../../postgreSQLEventStore';
 import { tableExists } from '../../../testing/schemaObjects';
+import { getPostgreSQLEventStore } from '../../postgreSQLEventStore';
 import { PostgreSQLProjectionSpec } from '../postgresProjectionSpec';
-import { pongoClient, type PongoCollection } from '@event-driven-io/pongo';
-import { pgDriver } from '@event-driven-io/pongo/pg';
 import { pongoSingleStreamProjection } from './pongoProjections';
 import { expectPongoDocuments } from './pongoProjectionSpec';
 
@@ -33,8 +33,8 @@ void describe('PostgreSQL Pongo projection schema configuration', () => {
     database = await sharedPostgreSQLDatabase();
     connectionString = database.connectionString;
     pool = dumbo({
-      connectionString,
       driver: pgDumboDriver,
+      connectionString,
       transactionOptions: {
         allowNestedTransactions: true,
       },

--- a/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjectionSpec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjectionSpec.ts
@@ -1,11 +1,15 @@
 import {
   dumbo,
-  type MigrationStyle,
   type Dumbo,
+  type MigrationStyle,
   type QueryResultRow,
   type SQL,
 } from '@event-driven-io/dumbo';
-import type { PgPool, PgPoolOptions } from '@event-driven-io/dumbo/pg';
+import {
+  pgDumboDriver,
+  type PgPool,
+  type PgPoolOptions,
+} from '@event-driven-io/dumbo/pg';
 import {
   assertFails,
   AssertionError,
@@ -80,6 +84,7 @@ export const PostgreSQLProjectionSpec = {
     {
       const { projection, ...restOptions } = options;
       const dumboOptions = {
+        driver: pgDumboDriver,
         ...restOptions,
         serialization: projection.serialization,
         transactionOptions: {

--- a/src/packages/emmett-postgresql/src/eventStore/schema/appendToStream.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/appendToStream.int.spec.ts
@@ -12,11 +12,11 @@ import {
 } from '@event-driven-io/emmett';
 import { v4 as uuid } from 'uuid';
 import { afterAll, beforeAll, describe, it } from 'vitest';
+import { createEventStoreSchema } from '.';
 import {
   sharedPostgreSQLDatabase,
   type PostgreSQLTestDatabase,
 } from '../../testing/postgreSQLTestDatabase';
-import { createEventStoreSchema } from '.';
 import type { PostgresReadEventMetadata } from '../postgreSQLEventStore';
 import {
   appendToStream,
@@ -55,8 +55,8 @@ void describe('appendEvent', () => {
     database = await sharedPostgreSQLDatabase();
     const connectionString = database.connectionString;
     pool = dumbo({
-      connectionString,
       driver: pgDumboDriver,
+      connectionString,
       transactionOptions: {
         allowNestedTransactions: true,
       },

--- a/src/packages/emmett-postgresql/src/eventStore/schema/createEventStoreSchema.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/createEventStoreSchema.int.spec.ts
@@ -42,8 +42,8 @@ void describe('createEventStoreSchema', () => {
     database = await sharedPostgreSQLDatabase();
     const connectionString = database.connectionString;
     pool = dumbo({
-      connectionString,
       driver: pgDumboDriver,
+      connectionString,
       transactionOptions: {
         allowNestedTransactions: true,
       },
@@ -211,8 +211,8 @@ void describe('createEventStoreSchema with configured database schemas', () => {
     database = await sharedPostgreSQLDatabase();
     connectionString = database.connectionString;
     pool = dumbo({
-      connectionString,
       driver: pgDumboDriver,
+      connectionString,
       transactionOptions: {
         allowNestedTransactions: true,
       },

--- a/src/packages/emmett-postgresql/src/eventStore/schema/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/index.ts
@@ -3,7 +3,11 @@ import {
   runSQLMigrations,
   type RunSQLMigrationsResult,
 } from '@event-driven-io/dumbo';
-import type { PgPool, PgTransaction } from '@event-driven-io/dumbo/pg';
+import {
+  pgDumboDriver,
+  type PgPool,
+  type PgTransaction,
+} from '@event-driven-io/dumbo/pg';
 import type { JSONSerializationOptions } from '@event-driven-io/emmett';
 import type { PostgresEventStoreOptions } from '../postgreSQLEventStore';
 import { transactionToPostgreSQLProjectionHandlerContext } from '../projections';
@@ -54,6 +58,7 @@ export const createEventStoreSchema = (
       tx,
     );
     const nestedPool = dumbo({
+      driver: pgDumboDriver,
       connectionString,
       connection: tx.connection,
       serialization: options?.serialization,

--- a/src/packages/emmett-postgresql/src/eventStore/schema/messagesPollIndex.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/messagesPollIndex.int.spec.ts
@@ -1,11 +1,11 @@
 import { dumbo, SQL } from '@event-driven-io/dumbo';
 import { pgDumboDriver, type PgPool } from '@event-driven-io/dumbo/pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createEventStoreSchema } from '.';
 import {
   sharedPostgreSQLDatabase,
   type PostgreSQLTestDatabase,
 } from '../../testing/postgreSQLTestDatabase';
-import { createEventStoreSchema } from '.';
 import {
   readMessagesBatchSQL,
   type PostgreSQLEventStoreCheckpoint,
@@ -34,8 +34,8 @@ void describe('emt_messages consumer poll index', () => {
     database = await sharedPostgreSQLDatabase();
     const connectionString = database.connectionString;
     pool = dumbo({
-      connectionString,
       driver: pgDumboDriver,
+      connectionString,
       transactionOptions: { allowNestedTransactions: true },
       pooled: false,
     });

--- a/src/packages/emmett-postgresql/src/eventStore/schema/migrations/0_36_0/0_36_0.migration.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/migrations/0_36_0/0_36_0.migration.int.spec.ts
@@ -6,6 +6,7 @@ import {
   type Event,
 } from '@event-driven-io/emmett';
 import { afterEach, beforeEach, describe, it } from 'vitest';
+import { migrations_0_36_0 } from '.';
 import {
   sharedPostgreSQLDatabase,
   type PostgreSQLTestDatabase,
@@ -14,7 +15,6 @@ import {
   getPostgreSQLEventStore,
   type PostgresEventStore,
 } from '../../../postgreSQLEventStore';
-import { migrations_0_36_0 } from '.';
 
 export type ProductItemAdded = Event<
   'ProductItemAdded',
@@ -47,8 +47,8 @@ void describe('Schema migrations tests', () => {
     connectionString = database.connectionString;
 
     pool = dumbo({
-      connectionString,
       driver: pgDumboDriver,
+      connectionString,
       transactionOptions: {
         allowNestedTransactions: true,
       },

--- a/src/packages/emmett-postgresql/src/eventStore/schema/migrations/0_38_7/0_38_7.migration.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/migrations/0_38_7/0_38_7.migration.int.spec.ts
@@ -10,12 +10,6 @@ import {
 import { afterEach, beforeEach, describe, it } from 'vitest';
 import { migrations_0_38_7 } from '.';
 import {
-  appendToStream,
-  readEvents,
-  readSubscriptionCheckpoint,
-  storeSubscriptionCheckpoint,
-} from './legacyApi';
-import {
   sharedPostgreSQLDatabase,
   type PostgreSQLTestDatabase,
 } from '../../../../testing/postgreSQLTestDatabase';
@@ -24,6 +18,12 @@ import {
   type PostgresEventStore,
 } from '../../../postgreSQLEventStore';
 import { migrations_0_36_0 } from '../0_36_0';
+import {
+  appendToStream,
+  readEvents,
+  readSubscriptionCheckpoint,
+  storeSubscriptionCheckpoint,
+} from './legacyApi';
 
 export type ProductItemAdded = Event<
   'ProductItemAdded',
@@ -56,8 +56,8 @@ void describe('Schema migrations tests', () => {
     connectionString = database.connectionString;
 
     pool = dumbo({
-      connectionString,
       driver: pgDumboDriver,
+      connectionString,
       transactionOptions: {
         allowNestedTransactions: true,
       },

--- a/src/packages/emmett-postgresql/src/eventStore/schema/migrations/0_42_0/0_42_0.migration.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/migrations/0_42_0/0_42_0.migration.int.spec.ts
@@ -75,8 +75,8 @@ void describe('Schema migrations tests', () => {
     connectionString = database.connectionString;
 
     pool = dumbo({
-      connectionString,
       driver: pgDumboDriver,
+      connectionString,
       transactionOptions: {
         allowNestedTransactions: true,
       },

--- a/src/packages/emmett-postgresql/src/eventStore/schema/migrations/0_43_0/0_43_0.migration.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/migrations/0_43_0/0_43_0.migration.int.spec.ts
@@ -78,8 +78,8 @@ void describe('Schema migrations tests', () => {
     connectionString = database.connectionString;
 
     pool = dumbo({
-      connectionString,
       driver: pgDumboDriver,
+      connectionString,
       transactionOptions: {
         allowNestedTransactions: true,
       },

--- a/src/packages/emmett-postgresql/src/eventStore/schema/migrations/0_44_0/0_44_0.migration.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/migrations/0_44_0/0_44_0.migration.int.spec.ts
@@ -59,8 +59,8 @@ void describe('Schema migrations tests', () => {
     connectionString = database.connectionString;
 
     pool = dumbo({
-      connectionString,
       driver: pgDumboDriver,
+      connectionString,
       transactionOptions: {
         allowNestedTransactions: true,
       },

--- a/src/packages/emmett-postgresql/src/eventStore/schema/migrations/current/migration.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/migrations/current/migration.int.spec.ts
@@ -72,8 +72,8 @@ void describe('Schema migrations tests', () => {
     connectionString = database.connectionString;
 
     pool = dumbo({
-      connectionString,
       driver: pgDumboDriver,
+      connectionString,
       transactionOptions: {
         allowNestedTransactions: true,
       },

--- a/src/packages/emmett-postgresql/src/eventStore/schema/readMessagesBatch.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/readMessagesBatch.int.spec.ts
@@ -9,11 +9,11 @@ import {
 } from '@event-driven-io/emmett';
 import { v4 as uuid } from 'uuid';
 import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import { createEventStoreSchema } from '.';
 import {
   isolatedPostgreSQLDatabase,
   type PostgreSQLTestDatabase,
 } from '../../testing/postgreSQLTestDatabase';
-import { createEventStoreSchema } from '.';
 import { appentToStreamRaw } from './appendToStream';
 import {
   PostgreSQLEventStoreCheckpoint,
@@ -30,8 +30,8 @@ void describe('reading messages in batches', () => {
     database = await isolatedPostgreSQLDatabase();
     const connectionString = database.connectionString;
     pool = dumbo({
-      connectionString,
       driver: pgDumboDriver,
+      connectionString,
       transactionOptions: {
         allowNestedTransactions: true,
       },

--- a/src/packages/emmett-postgresql/src/eventStore/schema/readStream.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/readStream.int.spec.ts
@@ -13,11 +13,11 @@ import {
 } from '@event-driven-io/emmett';
 import { v4 as uuid } from 'uuid';
 import { afterAll, beforeAll, describe, it } from 'vitest';
+import { createEventStoreSchema, PostgreSQLEventStoreCheckpoint } from '.';
 import {
   sharedPostgreSQLDatabase,
   type PostgreSQLTestDatabase,
 } from '../../testing/postgreSQLTestDatabase';
-import { createEventStoreSchema, PostgreSQLEventStoreCheckpoint } from '.';
 import { PostgreSQLEventStoreDefaultStreamVersion } from '../postgreSQLEventStore';
 import { appendToStream } from './appendToStream';
 import { readStream } from './readStream';
@@ -54,8 +54,8 @@ void describe('readStream', () => {
     database = await sharedPostgreSQLDatabase();
     const connectionString = database.connectionString;
     pool = dumbo({
-      connectionString,
       driver: pgDumboDriver,
+      connectionString,
       transactionOptions: {
         allowNestedTransactions: true,
       },

--- a/src/packages/emmett-postgresql/src/eventStore/schema/storeProcessorCheckpoint.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/storeProcessorCheckpoint.int.spec.ts
@@ -6,11 +6,11 @@ import {
   defaultTag,
 } from '@event-driven-io/emmett';
 import { afterAll, beforeAll, describe, it } from 'vitest';
+import { createEventStoreSchema, PostgreSQLEventStoreCheckpoint } from '.';
 import {
   sharedPostgreSQLDatabase,
   type PostgreSQLTestDatabase,
 } from '../../testing/postgreSQLTestDatabase';
-import { createEventStoreSchema, PostgreSQLEventStoreCheckpoint } from '.';
 import { readProcessorCheckpoint } from './readProcessorCheckpoint';
 import { storeProcessorCheckpoint } from './storeProcessorCheckpoint';
 
@@ -36,8 +36,8 @@ void describe('storeProcessorCheckpoint and readProcessorCheckpoint tests', () =
     database = await sharedPostgreSQLDatabase();
     connectionString = database.connectionString;
     pool = dumbo({
-      connectionString,
       driver: pgDumboDriver,
+      connectionString,
       transactionOptions: {
         allowNestedTransactions: true,
       },

--- a/src/packages/emmett-postgresql/src/eventStore/schema/streamExists.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/streamExists.int.spec.ts
@@ -8,11 +8,11 @@ import {
 } from '@event-driven-io/emmett';
 import { v4 as uuid } from 'uuid';
 import { afterAll, beforeAll, describe, it } from 'vitest';
+import { createEventStoreSchema } from '.';
 import {
   sharedPostgreSQLDatabase,
   type PostgreSQLTestDatabase,
 } from '../../testing/postgreSQLTestDatabase';
-import { createEventStoreSchema } from '.';
 import { appendToStream } from './appendToStream';
 import { streamExists } from './streamExists';
 import { streamsTable } from './typing';
@@ -45,8 +45,8 @@ void describe('streamExists', () => {
     database = await sharedPostgreSQLDatabase();
     const connectionString = database.connectionString;
     pool = dumbo({
-      connectionString,
       driver: pgDumboDriver,
+      connectionString,
       transactionOptions: {
         allowNestedTransactions: true,
       },

--- a/src/packages/emmett-postgresql/src/eventStore/schema/truncateTables.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/truncateTables.int.spec.ts
@@ -8,12 +8,12 @@ import {
 } from '@event-driven-io/emmett';
 import { v4 as uuid } from 'uuid';
 import { afterAll, beforeAll, describe, it } from 'vitest';
+import { createEventStoreSchema } from '.';
 import {
   sharedPostgreSQLDatabase,
   type PostgreSQLTestDatabase,
 } from '../../testing/postgreSQLTestDatabase';
 import { getPostgreSQLEventStore } from '../postgreSQLEventStore';
-import { createEventStoreSchema } from '.';
 import { appendToStream } from './appendToStream';
 import { truncateTables } from './truncateTables';
 import {
@@ -47,8 +47,8 @@ void describe('truncateTables', () => {
     database = await sharedPostgreSQLDatabase();
     connectionString = database.connectionString;
     pool = dumbo({
-      connectionString,
       driver: pgDumboDriver,
+      connectionString,
       transactionOptions: {
         allowNestedTransactions: true,
       },


### PR DESCRIPTION
A follow up to https://github.com/event-driven-io/emmett/pull/388 that didn't fix all calls.

There'll be an additional follow-up that'll do a full refactoring preparing the codebase for multiple drivers.

@dilgerma FYI