### PR TITLE
Ensured that event store wrapper records events in session

### DIFF
--- a/src/packages/emmett/src/testing/wrapEventStore.ts
+++ b/src/packages/emmett/src/testing/wrapEventStore.ts
@@ -1,12 +1,15 @@
-import type {
-  AggregateStreamOptions,
-  AggregateStreamResult,
-  AppendToStreamOptions,
-  AppendToStreamResult,
-  EventStore,
-  EventStoreReadEventMetadata,
-  ReadStreamOptions,
-  ReadStreamResult,
+import {
+  canCreateEventStoreSession,
+  type AggregateStreamOptions,
+  type AggregateStreamResult,
+  type AppendToStreamOptions,
+  type AppendToStreamResult,
+  type EventStore,
+  type EventStoreReadEventMetadata,
+  type EventStoreSession,
+  type EventStoreSessionFactory,
+  type ReadStreamOptions,
+  type ReadStreamResult,
 } from '../eventStore';
 import type { Event, EventMetaDataOf } from '../typing';
 
@@ -25,9 +28,13 @@ export type EventStoreWrapper<Store extends EventStore> = Store & {
 
 export const WrapEventStore = <Store extends EventStore>(
   eventStore: Store,
-): EventStoreWrapper<Store> => {
-  const appendedEvents = new Map<string, TestEventStream>();
+): EventStoreWrapper<Store> =>
+  wrapEventStore(eventStore, new Map<string, TestEventStream>());
 
+const wrapEventStore = <Store extends EventStore>(
+  eventStore: Store,
+  appendedEvents: Map<string, TestEventStream>,
+): EventStoreWrapper<Store> => {
   const wrapped = {
     ...eventStore,
     aggregateStream<State, EventType extends Event>(
@@ -86,5 +93,26 @@ export const WrapEventStore = <Store extends EventStore>(
     },
   };
 
+  if (canCreateEventStoreSession(eventStore))
+    Object.assign(
+      wrapped,
+      sessionsRecordingAppendedEvents(eventStore, appendedEvents),
+    );
+
   return wrapped;
 };
+
+const sessionsRecordingAppendedEvents = <Store extends EventStore>(
+  sessionFactory: EventStoreSessionFactory<Store>,
+  appendedEvents: Map<string, TestEventStream>,
+): EventStoreSessionFactory<Store> => ({
+  withSession: <T = unknown>(
+    callback: (session: EventStoreSession<Store>) => Promise<T>,
+  ): Promise<T> =>
+    sessionFactory.withSession((session) =>
+      callback({
+        ...session,
+        eventStore: wrapEventStore(session.eventStore, appendedEvents),
+      }),
+    ),
+});

--- a/src/packages/emmett/src/testing/wrapEventStore.unit.spec.ts
+++ b/src/packages/emmett/src/testing/wrapEventStore.unit.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it } from 'vitest';
+import { CommandHandler } from '../commandHandling';
+import {
+  getInMemoryEventStore,
+  type EventStore,
+  type EventStoreSessionFactory,
+} from '../eventStore';
+import type { Event } from '../typing';
+import { assertMatches } from './assertions';
+import { WrapEventStore } from './wrapEventStore';
+
+type SomethingHappened = Event<'Did', { something: string }>;
+
+type Entity = { something: string };
+
+const initialState = (): Entity => ({ something: 'Meh' });
+
+const evolve = (_entity: Entity, _event: SomethingHappened): Entity => ({
+  something: 'Nothing',
+});
+
+const handle = CommandHandler<Entity, SomethingHappened>({
+  evolve,
+  initialState,
+});
+
+const event: SomethingHappened = {
+  type: 'Did',
+  data: { something: 'Yes!' },
+};
+
+/**
+ * Mirrors a store that opens a session per command - PostgreSQL does this. The
+ * session yields its own store instance, not the one the caller was holding.
+ */
+const withSessionSupport = <Store extends EventStore>(
+  eventStore: Store,
+): Store & EventStoreSessionFactory<Store> => ({
+  ...eventStore,
+  withSession: (callback) =>
+    callback({ eventStore, close: () => Promise.resolve() }),
+});
+
+void describe('WrapEventStore', () => {
+  void it('records events appended by a command handler', async () => {
+    const eventStore = WrapEventStore(getInMemoryEventStore());
+
+    await handle(eventStore, 'stream-1', () => [event]);
+
+    assertMatches(Array.from(eventStore.appendedEvents.values()), [
+      ['stream-1', [event]],
+    ]);
+  });
+
+  void it('records events appended by a command handler through a session', async () => {
+    const eventStore = WrapEventStore(
+      withSessionSupport(getInMemoryEventStore()),
+    );
+
+    await handle(eventStore, 'stream-2', () => [event]);
+
+    assertMatches(Array.from(eventStore.appendedEvents.values()), [
+      ['stream-2', [event]],
+    ]);
+  });
+});


### PR DESCRIPTION
PostgreSQL and SQLite event stores use sessions to ensure that the same connection is used. The current implementation wasn't handling that correctly. Thanks to this fix, you can use PostgreSQL and SQLite event stores in ApiSpecification integration tests.