### PR TITLE
Aligned the event store driver handling across stores

### DIFF
--- a/src/eslint.config.mjs
+++ b/src/eslint.config.mjs
@@ -108,6 +108,38 @@ export default [
     },
   },
   {
+    files: ['packages/emmett-sqlite/**'],
+    ignores: [
+      'packages/emmett-sqlite/**/*.spec.ts',
+      'packages/emmett-sqlite/src/sqlite3.ts',
+      'packages/emmett-sqlite/src/cloudflare.ts',
+      'packages/emmett-sqlite/src/testing/**',
+    ],
+    rules: {
+      '@typescript-eslint/no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@event-driven-io/dumbo/sqlite3',
+              message:
+                'Take the sqlite3 driver from `src/sqlite3.ts` instead. Importing ' +
+                'the driver module elsewhere ties the package to a single SQLite driver.',
+              allowTypeImports: true,
+            },
+            {
+              name: '@event-driven-io/dumbo/cloudflare',
+              message:
+                'Take the D1 driver from `src/cloudflare.ts` instead. Importing ' +
+                'the driver module elsewhere ties the package to a single SQLite driver.',
+              allowTypeImports: true,
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: ['packages/emmett-postgresql/**'],
     ignores: [
       'packages/emmett-postgresql/**/*.spec.ts',

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -29,7 +29,7 @@
         "mitata": "^1.0.34"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260421.1",
+        "@cloudflare/workers-types": "^5.20260831.1",
         "@eslint/js": "^10.0.1",
         "@faker-js/faker": "^10.4.0",
         "@opentelemetry/api": "^1.9.1",
@@ -64,7 +64,7 @@
         "node": ">=24.12.0"
       },
       "peerDependencies": {
-        "@event-driven-io/pongo": "0.17.0-beta.50",
+        "@event-driven-io/pongo": "0.17.0-beta.52",
         "@types/express": "^5.0.6",
         "@types/node": "^25.6.0",
         "@types/supertest": "^7.2.0",
@@ -507,9 +507,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260702.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
-      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+      "version": "5.20260908.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260908.1.tgz",
+      "integrity": "sha512-cILmYEd/YtL+Hlwytc5n+QVV8F+E5doQOtc6QiBtPb51kK+5fkk909db+G8dxeUsMd2ytJgdpAt/lyciUEobcw==",
       "devOptional": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -1183,14 +1183,14 @@
       "link": true
     },
     "node_modules/@event-driven-io/dumbo": {
-      "version": "0.13.0-beta.50",
-      "resolved": "https://registry.npmjs.org/@event-driven-io/dumbo/-/dumbo-0.13.0-beta.50.tgz",
-      "integrity": "sha512-i+b9uKjXDM/61dGd6FxnlcJWF7KFZSTgy01luD9nw6aHP6ae0z1vkiEB5ytJHKoCDg32sqi17RYn++cCsEGhFg==",
+      "version": "0.13.0-beta.52",
+      "resolved": "https://registry.npmjs.org/@event-driven-io/dumbo/-/dumbo-0.13.0-beta.52.tgz",
+      "integrity": "sha512-K4T1VSRNV1DJgkhQW4jsfxdZlGYX9ps3gv0n61GaHSqdjNEKA4rGhDMHAYYrXJXOUAYqxFyiyBULsUutSFnxsw==",
       "dependencies": {
         "uuid": "^14.0.0"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260421.1",
+        "@cloudflare/workers-types": "^5.20260831.1",
         "@types/pg": "^8.20.0",
         "pg": "^8.20.0",
         "sqlite3": "^6.0.1"
@@ -1251,11 +1251,11 @@
       "link": true
     },
     "node_modules/@event-driven-io/pongo": {
-      "version": "0.17.0-beta.50",
-      "resolved": "https://registry.npmjs.org/@event-driven-io/pongo/-/pongo-0.17.0-beta.50.tgz",
-      "integrity": "sha512-gjIrHGLZOBRSZq2x6aeQrb9MSgk/GQV2yvnArNYBg7AvraDT4ztBYQLQKCxxY958TtVx4BIa8ed/eMaVPdyH/w==",
+      "version": "0.17.0-beta.52",
+      "resolved": "https://registry.npmjs.org/@event-driven-io/pongo/-/pongo-0.17.0-beta.52.tgz",
+      "integrity": "sha512-FgDZCG+TELviuIDcsbtHFHX9RULnMYY2nmoz3Dh3f+TwguOM9dcMrwqe2EyHwnZ7PBBBHS4MDA12AV6bTEtwcw==",
       "dependencies": {
-        "@event-driven-io/dumbo": "0.13.0-beta.50",
+        "@event-driven-io/dumbo": "0.13.0-beta.52",
         "@types/mongodb": "^4.0.7",
         "ansis": "^4.2.0",
         "cli-table3": "^0.6.5",
@@ -1267,7 +1267,7 @@
         "pongo": "dist/cli.js"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260421.1",
+        "@cloudflare/workers-types": "^5.20260831.1",
         "@types/pg": "^8.20.0",
         "pg": "^8.20.0",
         "sqlite3": "^6.0.1"
@@ -13548,7 +13548,7 @@
       "version": "0.43.0-beta.43",
       "dependencies": {
         "@event-driven-io/emmett": "0.43.0-beta.43",
-        "@event-driven-io/pongo": "0.17.0-beta.50"
+        "@event-driven-io/pongo": "0.17.0-beta.52"
       },
       "devDependencies": {
         "@event-driven-io/emmett-testcontainers": "0.43.0-beta.43",
@@ -13575,16 +13575,16 @@
       "version": "0.43.0-beta.43",
       "dependencies": {
         "@event-driven-io/emmett": "0.43.0-beta.43",
-        "@event-driven-io/pongo": "0.17.0-beta.50"
+        "@event-driven-io/pongo": "0.17.0-beta.52"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260421.1",
+        "@cloudflare/workers-types": "^5.20260831.1",
         "@types/node": "^25.6.0",
         "miniflare": "^4.20260420.0",
         "sqlite3": "^6.0.1"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260421.1",
+        "@cloudflare/workers-types": "^5.20260831.1",
         "sqlite3": "^6.0.1"
       },
       "peerDependenciesMeta": {

--- a/src/package.json
+++ b/src/package.json
@@ -87,7 +87,7 @@
     "dist"
   ],
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260421.1",
+    "@cloudflare/workers-types": "^5.20260831.1",
     "@eslint/js": "^10.0.1",
     "@faker-js/faker": "^10.4.0",
     "@opentelemetry/api": "^1.9.1",
@@ -119,7 +119,7 @@
     "vitest": "^4.1.5"
   },
   "peerDependencies": {
-    "@event-driven-io/pongo": "0.17.0-beta.50",
+    "@event-driven-io/pongo": "0.17.0-beta.52",
     "@types/express": "^5.0.6",
     "@types/node": "^25.6.0",
     "@types/supertest": "^7.2.0",

--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBCheckpointer.int.spec.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBCheckpointer.int.spec.ts
@@ -218,7 +218,10 @@ void describe('EventStoreDB processor checkpointer', () => {
       },
     };
 
-    const initial = await firstCheckpointer.read({ processorId }, { client });
+    const initial = await firstCheckpointer.read(
+      { processorId },
+      { session: { client } },
+    );
     const stored = await firstCheckpointer.store(
       {
         processorId,
@@ -226,12 +229,12 @@ void describe('EventStoreDB processor checkpointer', () => {
         message,
         lastCheckpoint: initial.lastCheckpoint,
       },
-      { client },
+      { session: { client } },
     );
 
     assertDeepEqual(stored, { success: true, newCheckpoint: checkpoint });
     assertDeepEqual(
-      await secondCheckpointer.read({ processorId }, { client }),
+      await secondCheckpointer.read({ processorId }, { session: { client } }),
       { lastCheckpoint: checkpoint },
     );
   });

--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBCheckpointer.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBCheckpointer.ts
@@ -52,7 +52,7 @@ type EventStoreDBProcessorCheckpointOptions = {
 };
 
 type EventStoreDBCheckpointerContext = DefaultRecord & {
-  client: EventStoreDBClient;
+  session: { client: EventStoreDBClient };
 };
 
 const getEventStoreDBCheckpointSubscriptionId = ({
@@ -205,7 +205,7 @@ export const eventStoreDBCheckpointer = <
   return {
     read: async (options, context) => {
       const checkpoint = await readEventStoreDBProcessorCheckpoint(
-        context.client,
+        context.session.client,
         options,
       );
 
@@ -222,7 +222,7 @@ export const eventStoreDBCheckpointer = <
 
       if (!previousCheckpoint) {
         previousCheckpoint = await readEventStoreDBProcessorCheckpoint(
-          context.client,
+          context.session.client,
           options,
         );
       }
@@ -231,7 +231,7 @@ export const eventStoreDBCheckpointer = <
         return { success: false, reason: 'MISMATCH' };
 
       const result = await storeEventStoreDBProcessorCheckpoint(
-        context.client,
+        context.session.client,
         {
           ...options,
           newCheckpoint: getCheckpoint(options.message),
@@ -250,7 +250,7 @@ export const eventStoreDBCheckpointer = <
     },
     reset: async (options, context) => {
       const checkpoint = await resetEventStoreDBProcessorCheckpoint(
-        context.client,
+        context.session.client,
         options,
       );
 

--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBEventStoreConsumer.ts
@@ -23,6 +23,7 @@ import {
   eventStoreDBReactor,
   eventStoreDBWorkflowProcessor,
   type EventStoreDBProcessor,
+  type EventStoreDBProcessorHandlerContext,
   type EventStoreDBWorkflowProcessorHandlerContext,
   type EventStoreDBReactorOptions,
   type EventStoreDBWorkflowProcessorOptions,
@@ -166,7 +167,7 @@ export const eventStoreDBEventStoreConsumer = <
   const messageConsumer = consumer<
     ConsumerMessageType,
     EventStoreDBReadEventMetadata,
-    undefined,
+    EventStoreDBProcessorHandlerContext,
     EventStoreDBReactorFactory<ConsumerMessageType>,
     EventStoreDBProjectorFactory<ConsumerMessageType>,
     EventStoreDBWorkflowProcessorFactory<ConsumerMessageType>

--- a/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBProcessor.ts
+++ b/src/packages/emmett-esdb/src/eventStore/consumers/eventStoreDBProcessor.ts
@@ -7,6 +7,7 @@ import type {
   Message,
   MessageHandlerContext,
   MessageProcessingScope,
+  PartialHandlerContext,
   MessageProcessor,
   ReactorOptions,
   ReadEventMetadataWithGlobalPosition,
@@ -30,12 +31,13 @@ import {
 } from '../eventstoreDBEventStore';
 import { eventStoreDBCheckpointer } from './eventStoreDBCheckpointer';
 
-export type EventStoreDBProcessorHandlerContext = MessageHandlerContext<{
-  client: EventStoreDBClient;
-  connection?: {
-    messageStore: EventStoreDBEventStore;
-  };
-}>;
+export type EventStoreDBProcessorHandlerContext = MessageHandlerContext<
+  Record<never, never>,
+  {
+    client: EventStoreDBClient;
+    messageStore?: EventStoreDBEventStore;
+  }
+>;
 
 export type EventStoreDBWorkflowProcessorHandlerContext =
   EventStoreDBProcessorHandlerContext & WorkflowProcessorContext;
@@ -87,13 +89,13 @@ const eventStoreDBProcessingScope = (options: {
     handler: (
       context: EventStoreDBProcessorHandlerContext,
     ) => Result | Promise<Result>,
-    partialContext: Partial<EventStoreDBProcessorHandlerContext>,
+    partialContext: PartialHandlerContext<EventStoreDBProcessorHandlerContext>,
   ) => {
     return handler({
-      client: options.client,
       ...partialContext,
-      connection: {
-        ...partialContext.connection,
+      session: {
+        ...partialContext.session,
+        client: options.client,
         messageStore: getEventStoreDBEventStore(options.client),
       },
       observabilityScope: partialContext?.observabilityScope ?? noopScope,

--- a/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBCheckpointer.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBCheckpointer.ts
@@ -12,14 +12,17 @@ export const mongoDBCheckpointer = <
   MessageType extends Message = Message,
 >(): MongoDBCheckpointer<MessageType> => ({
   read: async (options, context) => {
-    const result = await readProcessorCheckpoint(context.client, options);
+    const result = await readProcessorCheckpoint(
+      context.session.client,
+      options,
+    );
 
     return { lastCheckpoint: result?.lastCheckpoint };
   },
   store: async (options, context) => {
     const newCheckpoint = getCheckpoint(options.message);
 
-    const result = await storeProcessorCheckpoint(context.client, {
+    const result = await storeProcessorCheckpoint(context.session.client, {
       lastStoredCheckpoint: options.lastCheckpoint,
       newCheckpoint,
       processorId: options.processorId,

--- a/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBEventStore.subscription.e2e.spec.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBEventStore.subscription.e2e.spec.ts
@@ -190,7 +190,7 @@ void describe('MongoDBEventStore subscription', () => {
     assertIsNotNull(stream);
     assertEqual(3n, stream.metadata.streamPosition);
 
-    const position = await processor.start({ client });
+    const position = await processor.start({ session: { client } });
 
     assertOk(position);
     assertNotEqual(typeof position, 'string');

--- a/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBEventStoreConsumer.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBEventStoreConsumer.ts
@@ -181,7 +181,7 @@ export const mongoDBEventStoreConsumer = <
     workflowProcessorFactory,
     batchSize: options.pulling?.batchSize,
     batchDeadlineInMs: options.pulling?.batchDeadlineInMs,
-    scope: (handler) => handler({ client }),
+    scope: (handler) => handler({ session: { client } }),
     hooks: {
       onClose: async () => {
         if (isOwnClient) await client.close();

--- a/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBProcessor.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/consumers/mongoDBProcessor.ts
@@ -14,6 +14,7 @@ import {
   type Event,
   type Message,
   type MessageProcessingScope,
+  type PartialHandlerContext,
   type ProjectorOptions,
   type ReactorOptions,
   type SingleMessageHandlerResult,
@@ -40,12 +41,13 @@ type MongoDBConnectionOptions = {
   connectionOptions: MongoDBEventStoreConnectionOptions;
 };
 
-export type MongoDBProcessorHandlerContext = MessageHandlerContext<{
-  client: MongoClient;
-  connection?: {
-    messageStore: MongoDBEventStore;
-  };
-}>;
+export type MongoDBProcessorHandlerContext = MessageHandlerContext<
+  Record<never, never>,
+  {
+    client: MongoClient;
+    messageStore?: MongoDBEventStore;
+  }
+>;
 
 export type MongoDBProcessor<MessageType extends Message = AnyMessage> =
   MessageProcessor<
@@ -107,11 +109,11 @@ const mongoDBProcessingScope = (options: {
     handler: (
       context: MongoDBProcessorHandlerContext,
     ) => Result | Promise<Result>,
-    partialContext: Partial<MongoDBProcessorHandlerContext>,
+    partialContext: PartialHandlerContext<MongoDBProcessorHandlerContext>,
   ) => {
     return handler({
-      client: options.client,
       ...partialContext,
+      session: { ...partialContext.session, client: options.client },
       observabilityScope: partialContext?.observabilityScope ?? noopScope,
     });
   };
@@ -128,13 +130,13 @@ const mongoDBWorkflowProcessingScope = (options: {
     handler: (
       context: MongoDBWorkflowProcessorHandlerContext,
     ) => Result | Promise<Result>,
-    partialContext: Partial<MongoDBWorkflowProcessorHandlerContext>,
+    partialContext: PartialHandlerContext<MongoDBWorkflowProcessorHandlerContext>,
   ) => {
     return handler({
-      client: options.client,
       ...partialContext,
-      connection: {
-        ...partialContext.connection,
+      session: {
+        ...partialContext.session,
+        client: options.client,
         messageStore: getMongoDBEventStore({ client: options.client }),
       },
       observabilityScope: partialContext?.observabilityScope ?? noopScope,

--- a/src/packages/emmett-mongodb/src/eventStore/projections/mongoDBInlineProjection.ts
+++ b/src/packages/emmett-mongodb/src/eventStore/projections/mongoDBInlineProjection.ts
@@ -92,6 +92,7 @@ export const handleInlineProjections = async <
       document: readModels[projection.name] ?? null,
       streamId,
       collection,
+      session: {},
       updates: update,
       observabilityScope: options.observabilityScope,
     });

--- a/src/packages/emmett-postgresql/package.json
+++ b/src/packages/emmett-postgresql/package.json
@@ -88,7 +88,7 @@
   },
   "dependencies": {
     "@event-driven-io/emmett": "0.43.0-beta.43",
-    "@event-driven-io/pongo": "0.17.0-beta.50"
+    "@event-driven-io/pongo": "0.17.0-beta.52"
   },
   "peerDependencies": {
     "@types/pg": "^8.20.0",

--- a/src/packages/emmett-postgresql/src/eventStore/commandHandler.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/commandHandler.int.spec.ts
@@ -5,7 +5,6 @@ import {
   CommandHandler,
 } from '@event-driven-io/emmett';
 import { pongoClient, type PongoClient } from '@event-driven-io/pongo';
-import { pgDriver } from '@event-driven-io/pongo/pg';
 import { afterAll, beforeAll, describe, it } from 'vitest';
 import { v4 as uuid } from 'uuid';
 import {
@@ -48,7 +47,7 @@ void describe('Postgres Projections', () => {
     await eventStore.schema.migrate();
     pongo = pongoClient({
       connectionString,
-      driver: pgDriver,
+      driver: pgEventStoreDriver.pongoDriver,
       connectionOptions: {
         transactionOptions: {
           allowNestedTransactions: true,

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLConsumer.driver.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLConsumer.driver.int.spec.ts
@@ -196,7 +196,7 @@ void describe('Postgres consumer without registered dumbo drivers', () => {
           event.metadata.globalPosition ===
           appendResult.lastEventGlobalPosition,
         eachMessage: async (_event, context) => {
-          await context.connection.messageStore.appendToStream(reactionStream, [
+          await context.session.messageStore.appendToStream(reactionStream, [
             {
               type: 'ShoppingCartConfirmed',
               data: { confirmedAt: new Date() },

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.handling.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.handling.int.spec.ts
@@ -1067,12 +1067,10 @@ void describe('PostgreSQL event store started consumer', () => {
           eachMessage: () => Promise.resolve(),
         });
 
-        const startOptions = {
+        await processor.start({
           execute: pool.execute,
-          connection: { options: { connectionString }, pool },
-        } as Parameters<typeof processor.start>[0];
-
-        await processor.start(startOptions);
+          session: { connectionOptions: { connectionString }, pool },
+        });
 
         // When
         process.emit('SIGTERM');

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.projections.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.projections.int.spec.ts
@@ -11,7 +11,6 @@ import {
   type PongoClient,
   type PongoCollection,
 } from '@event-driven-io/pongo';
-import { pgDriver } from '@event-driven-io/pongo/pg';
 import { v4 as uuid } from 'uuid';
 import { afterAll, beforeAll, describe, it } from 'vitest';
 import {
@@ -52,7 +51,7 @@ void describe('PostgreSQL event store started consumer', () => {
     });
     pongo = pongoClient({
       connectionString,
-      driver: pgDriver,
+      driver: pgEventStoreDriver.pongoDriver,
       connectionOptions: {
         transactionOptions: {
           allowNestedTransactions: true,

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.schema.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.schema.int.spec.ts
@@ -261,7 +261,7 @@ void describe('PostgreSQL event store consumer schema configuration', () => {
           startFrom: 'CURRENT',
           canHandle: ['GuestCheckedIn'],
           eachMessage: async (event, context) => {
-            await context.connection.messageStore.appendToStream(
+            await context.session.messageStore.appendToStream(
               reactionStreamName,
               [
                 {
@@ -325,7 +325,7 @@ void describe('PostgreSQL event store consumer schema configuration', () => {
           startFrom: 'CURRENT',
           canHandle: ['GuestCheckedIn'],
           eachMessage: async (event, context) => {
-            await context.connection.messageStore.appendToStream(
+            await context.session.messageStore.appendToStream(
               reactionStreamName,
               [
                 {

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLEventStoreConsumer.ts
@@ -1,4 +1,4 @@
-import { dumbo, type Dumbo } from '@event-driven-io/dumbo';
+import { dumbo } from '@event-driven-io/dumbo';
 import {
   consumer,
   type AnyCommand,
@@ -11,6 +11,7 @@ import {
   type MessageConsumerOptions,
   type MessageSource,
   type RecordedMessageMetadataWithGlobalPosition,
+  type PartialHandlerContext,
   type WorkflowProcessorContext,
 } from '@event-driven-io/emmett';
 import {
@@ -19,8 +20,10 @@ import {
   type PgEventStoreDriverOptions,
 } from '../../pg';
 import type {
-  AnyEventStoreDriver,
-  InferOptionsFromEventStoreDriver,
+  AnyPostgreSQLEventStoreDriver,
+  InferDumboOptionsFromEventStoreDriver,
+  InferPoolFromEventStoreDriver,
+  PoolOrConnectionOptions,
 } from '../eventStoreDriver';
 import {
   eventStoreDatabaseSchema,
@@ -55,9 +58,8 @@ export type PostgreSQLEventStoreConsumerConfig<
 
 export type PostgreSQLEventStoreConsumerConnectionOptions<
   ConsumerMessageType extends Message = Message,
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 > = {
-  pool?: Dumbo;
   source?: MessageSource<
     NoInfer<ConsumerMessageType>,
     RecordedMessageMetadataWithGlobalPosition
@@ -68,18 +70,18 @@ export type PostgreSQLEventStoreConsumerConnectionOptions<
    */
   connectionString?: string;
   driver?: Driver;
-} & Partial<InferOptionsFromEventStoreDriver<Driver>>;
+} & PoolOrConnectionOptions<Driver>;
 
 export type PostgreSQLEventStoreConsumerOptions<
   ConsumerMessageType extends Message = Message,
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 > = PostgreSQLEventStoreConsumerConfig<ConsumerMessageType> &
   PostgreSQLEventStoreConsumerConnectionOptions<ConsumerMessageType, Driver>;
 
 export type PostgreSQLReactorFactory<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ConsumerMessageType extends AnyMessage = any,
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 > = <MessageType extends ConsumerMessageType = ConsumerMessageType>(
   options: PostgreSQLReactorOptions<MessageType, MessageType, Driver>,
 ) => PostgreSQLProcessor<MessageType, Driver>;
@@ -87,7 +89,7 @@ export type PostgreSQLReactorFactory<
 export type PostgreSQLProjectorFactory<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ConsumerMessageType extends AnyMessage = any,
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 > = <
   EventType extends ConsumerMessageType & AnyEvent = ConsumerMessageType &
     AnyEvent,
@@ -98,7 +100,7 @@ export type PostgreSQLProjectorFactory<
 export type PostgreSQLWorkflowProcessorFactory<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ConsumerMessageType extends AnyMessage = any,
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 > = <
   Input extends ConsumerMessageType,
   State,
@@ -109,21 +111,24 @@ export type PostgreSQLWorkflowProcessorFactory<
     WorkflowProcessorContext,
   StoredMessage extends AnyEvent | AnyCommand = Output,
 >(
-  options: PostgreSQLWorkflowProcessorOptions<
-    Input,
-    State,
-    Output,
-    MetaDataType,
-    HandlerContext,
-    StoredMessage,
-    Driver
+  options: Omit<
+    PostgreSQLWorkflowProcessorOptions<
+      Input,
+      State,
+      Output,
+      MetaDataType,
+      HandlerContext,
+      StoredMessage,
+      Driver
+    >,
+    'messageStore'
   >,
 ) => PostgreSQLProcessor<Input | Output, Driver>;
 
 export type PostgreSQLEventStoreConsumer<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ConsumerMessageType extends AnyMessage = any,
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 > = MessageConsumer<
   ConsumerMessageType,
   PostgreSQLReactorFactory<ConsumerMessageType, Driver>,
@@ -133,7 +138,7 @@ export type PostgreSQLEventStoreConsumer<
 
 export const postgreSQLEventStoreConsumer = <
   ConsumerMessageType extends Message = AnyMessage,
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 >(
   options: PostgreSQLEventStoreConsumerOptions<ConsumerMessageType, Driver>,
 ): PostgreSQLEventStoreConsumer<ConsumerMessageType, Driver> => {
@@ -143,17 +148,16 @@ export const postgreSQLEventStoreConsumer = <
     ...databaseSchema,
   };
   const isOwnPool = !options.pool;
-  const pool =
-    options.pool ??
-    dumbo({
-      serialization: options.serialization,
-      transactionOptions: {
-        allowNestedTransactions: true,
-      },
-      ...(options.driver ?? pgEventStoreDriver).mapToDumboOptions(
-        options as PgEventStoreDriverOptions,
-      ),
-    });
+  const connectionOptions = {
+    serialization: options.serialization,
+    ...(options.driver ?? pgEventStoreDriver).mapToDumboOptions(
+      options as PgEventStoreDriverOptions,
+    ),
+  } as InferDumboOptionsFromEventStoreDriver<Driver>;
+
+  // TODO: Fix this cast when introducing more drivers
+  const pool = (options.pool ??
+    dumbo(connectionOptions)) as InferPoolFromEventStoreDriver<Driver>;
 
   const source: MessageSource<
     ConsumerMessageType,
@@ -167,17 +171,13 @@ export const postgreSQLEventStoreConsumer = <
         databaseSchemaName: databaseSchema.databaseSchemaName,
       });
 
-  const processorContext = {
+  const processorContext: PartialHandlerContext<
+    PostgreSQLProcessorHandlerContext<Driver>
+  > = {
     execute: pool.execute,
     migrationOptions: processorMetadataSchema,
-    connection: {
-      connectionString: options.connectionString,
-      pool,
-      client: undefined as never,
-      transaction: undefined as never,
-      messageStore: undefined as never,
-    },
-  } as unknown as PostgreSQLProcessorHandlerContext<Driver>;
+    session: { pool, connectionOptions },
+  };
 
   const messageConsumer = consumer<
     ConsumerMessageType,
@@ -192,18 +192,21 @@ export const postgreSQLEventStoreConsumer = <
     reactorFactory: (processorOptions) =>
       postgreSQLReactor({
         ...processorOptions,
+        driver: options.driver,
         migrationOptions:
           processorOptions.migrationOptions ?? processorMetadataSchema,
       }),
     projectorFactory: (processorOptions) =>
       postgreSQLProjector({
         ...processorOptions,
+        driver: options.driver,
         migrationOptions:
           processorOptions.migrationOptions ?? processorMetadataSchema,
       }),
     workflowProcessorFactory: (processorOptions) =>
       postgreSQLWorkflowProcessor({
         ...processorOptions,
+        driver: options.driver,
         migrationOptions:
           processorOptions.migrationOptions ?? processorMetadataSchema,
       }),

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLProcessor.pool.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLProcessor.pool.int.spec.ts
@@ -1,0 +1,121 @@
+import { dumbo, type Dumbo } from '@event-driven-io/dumbo';
+import { pgDumboDriver } from '@event-driven-io/dumbo/pg';
+import { assertFalse, assertTrue, type Event } from '@event-driven-io/emmett';
+import { v4 as uuid } from 'uuid';
+import { afterAll, beforeAll, describe, it } from 'vitest';
+import { pgEventStoreDriver } from '../../pg';
+import {
+  isolatedPostgreSQLDatabase,
+  sharedPostgreSQLDatabase,
+  type PostgreSQLTestDatabase,
+} from '../../testing/postgreSQLTestDatabase';
+import {
+  getPostgreSQLEventStore,
+  type PostgresEventStore,
+} from '../postgreSQLEventStore';
+import { postgreSQLEventStoreConsumer } from './postgreSQLEventStoreConsumer';
+
+const withDeadline = { timeout: 60000 };
+
+type GuestCheckedIn = Event<'GuestCheckedIn', { guestId: string }>;
+
+void describe('PostgreSQL processor pool', () => {
+  let consumerDatabase: PostgreSQLTestDatabase;
+  let otherDatabase: PostgreSQLTestDatabase;
+  let eventStore: PostgresEventStore;
+  let otherEventStore: PostgresEventStore;
+
+  beforeAll(async () => {
+    consumerDatabase = await isolatedPostgreSQLDatabase();
+    otherDatabase = await sharedPostgreSQLDatabase();
+
+    eventStore = getPostgreSQLEventStore({
+      driver: pgEventStoreDriver,
+      connectionString: consumerDatabase.connectionString,
+    });
+    await eventStore.schema.migrate();
+
+    otherEventStore = getPostgreSQLEventStore({
+      driver: pgEventStoreDriver,
+      connectionString: otherDatabase.connectionString,
+    });
+    await otherEventStore.schema.migrate();
+  });
+
+  afterAll(async () => {
+    try {
+      await eventStore?.close();
+      await otherEventStore?.close();
+      await consumerDatabase?.close();
+      await otherDatabase?.close();
+    } catch (error) {
+      console.log(error);
+    }
+  });
+
+  const poolSeenBy = async (
+    processorConnectionString?: string,
+  ): Promise<{ consumerPool: Dumbo; seenPool: Dumbo | undefined }> => {
+    const consumerPool = dumbo({
+      driver: pgDumboDriver,
+      connectionString: consumerDatabase.connectionString,
+      transactionOptions: { allowNestedTransactions: true },
+    });
+
+    let seenPool: Dumbo | undefined;
+
+    const consumer = postgreSQLEventStoreConsumer<GuestCheckedIn>({
+      driver: pgEventStoreDriver,
+      pool: consumerPool,
+      stopWhen: { noMessagesLeft: true },
+    });
+
+    consumer.reactor<GuestCheckedIn>({
+      processorId: uuid(),
+      startFrom: 'BEGINNING',
+      canHandle: ['GuestCheckedIn'],
+      connectionOptions: processorConnectionString
+        ? { connectionString: processorConnectionString }
+        : undefined,
+      eachMessage: (_message, context) => {
+        seenPool = context.session.pool;
+      },
+    });
+
+    await eventStore.appendToStream(`guestStay-${uuid()}`, [
+      { type: 'GuestCheckedIn', data: { guestId: uuid() } },
+    ]);
+
+    try {
+      await consumer.start();
+    } finally {
+      await consumer.close();
+      await consumerPool.close();
+    }
+
+    return { consumerPool, seenPool };
+  };
+
+  void it(
+    'uses the consumer pool when the processor has no connection options',
+    withDeadline,
+    async () => {
+      const { consumerPool, seenPool } = await poolSeenBy();
+
+      assertTrue(seenPool === consumerPool);
+    },
+  );
+
+  void it(
+    'opens its own pool when the processor has connection options',
+    withDeadline,
+    async () => {
+      const { consumerPool, seenPool } = await poolSeenBy(
+        otherDatabase.connectionString,
+      );
+
+      assertTrue(seenPool !== undefined);
+      assertFalse(seenPool === consumerPool);
+    },
+  );
+});

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLProcessor.transactions.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLProcessor.transactions.int.spec.ts
@@ -75,7 +75,7 @@ void describe('PostgreSQL processor transaction handling', () => {
           event.metadata.globalPosition ===
           appendResult.lastEventGlobalPosition,
         eachMessage: async (event, context) => {
-          await context.connection.messageStore.appendToStream(reactionStream, [
+          await context.session.messageStore.appendToStream(reactionStream, [
             { type: 'GuestCheckedOut', data: { guestId: event.data.guestId } },
           ]);
 

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLProcessor.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/postgreSQLProcessor.ts
@@ -1,5 +1,6 @@
 import {
   dumbo,
+  type AnyDatabaseTransaction,
   type DatabaseDriverType,
   type SQLExecutor,
 } from '@event-driven-io/dumbo';
@@ -22,6 +23,7 @@ import type {
   Message,
   MessageHandlerContext,
   MessageProcessingScope,
+  PartialHandlerContext,
   MessageProcessor,
   ProcessorHooks,
   ProcessorLock,
@@ -65,37 +67,42 @@ import {
   storeProcessorCheckpoint,
   type EventStoreSchemaMigrationOptions,
 } from '../schema';
-import { pgEventStoreDriver, type PgEventStoreDriver } from '../../pg';
+import {
+  pgEventStoreDriver,
+  type PgEventStoreDriver,
+  type PgEventStoreDriverOptions,
+} from '../../pg';
 import type {
-  AnyEventStoreDriver,
-  InferDbClientFromEventStoreDriver,
+  AnyPostgreSQLEventStoreDriver,
+  InferDumboConnectionFromEventStoreDriver,
   InferDumboOptionsFromEventStoreDriver,
   InferPoolFromEventStoreDriver,
   InferTransactionFromEventStoreDriver,
 } from '../eventStoreDriver';
 
 export type PostgreSQLProcessorHandlerContext<
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 > = MessageHandlerContext<
   {
     partition: string;
     execute: SQLExecutor;
     driverType: DatabaseDriverType;
-    connection: {
-      client: InferDbClientFromEventStoreDriver<Driver>;
-      transaction: InferTransactionFromEventStoreDriver<Driver>;
-      pool: InferPoolFromEventStoreDriver<Driver>;
-      messageStore: PostgresEventStore;
-      options: InferDumboOptionsFromEventStoreDriver<Driver>;
-    };
+    driver?: Driver;
   } &
     // TODO: Reconsider if it should be for all processors
-    EventStoreSchemaMigrationOptions
+    EventStoreSchemaMigrationOptions,
+  {
+    connection: InferDumboConnectionFromEventStoreDriver<Driver>;
+    transaction: InferTransactionFromEventStoreDriver<Driver>;
+    pool: InferPoolFromEventStoreDriver<Driver>;
+    messageStore: PostgresEventStore;
+    connectionOptions?: InferDumboOptionsFromEventStoreDriver<Driver>;
+  }
 >;
 
 export type PostgreSQLProcessor<
   MessageType extends Message = AnyMessage,
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 > = MessageProcessor<
   MessageType,
   ReadEventMetadataWithGlobalPosition,
@@ -104,7 +111,7 @@ export type PostgreSQLProcessor<
 
 export type PostgreSQLProcessorEachMessageHandler<
   MessageType extends Message = Message,
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 > = SingleRecordedMessageHandlerWithContext<
   MessageType,
   ReadEventMetadataWithGlobalPosition,
@@ -113,7 +120,7 @@ export type PostgreSQLProcessorEachMessageHandler<
 
 export type PostgreSQLProcessorEachBatchHandler<
   MessageType extends Message = Message,
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 > = BatchRecordedMessageHandlerWithContext<
   MessageType,
   ReadEventMetadataWithGlobalPosition,
@@ -175,13 +182,20 @@ type PostgreSQLProcessorNotPooledOptions =
       pooled?: false;
     };
 
-export type PostgreSQLProcessorConnectionOptions = {
-  connectionString: string;
-} & (PostgreSQLProcessorPooledOptions | PostgreSQLProcessorNotPooledOptions);
+export type PostgreSQLProcessorConnectionOptions =
+  | ({
+      connectionString: string;
+    } & (
+      PostgreSQLProcessorPooledOptions | PostgreSQLProcessorNotPooledOptions
+    ))
+  | {
+      connectionString?: undefined;
+      dumbo: PgPool;
+    };
 
 export type PostgreSQLCheckpointer<
   MessageType extends AnyMessage = AnyMessage,
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 > = Checkpointer<
   MessageType,
   ReadEventMetadataWithGlobalPosition,
@@ -190,7 +204,7 @@ export type PostgreSQLCheckpointer<
 
 export const postgreSQLCheckpointer = <
   MessageType extends Message = Message,
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 >(): PostgreSQLCheckpointer<MessageType, Driver> => ({
   read: async (options, context) => {
     const result = await readProcessorCheckpoint(context.execute, {
@@ -219,14 +233,14 @@ export const postgreSQLCheckpointer = <
 });
 
 type PostgreSQLConnectionOptions<
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 > = {
   connectionOptions?: PostgreSQLProcessorConnectionOptions;
   driver?: Driver;
 } & JSONSerializationOptions;
 
 type PostgreSQLProcessorOptionsBase<
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 > = PostgreSQLConnectionOptions<Driver> & {
   lock?: {
     /** Defaults to the PostgreSQL processor lock backed by the message store */
@@ -239,7 +253,7 @@ type PostgreSQLProcessorOptionsBase<
 export type PostgreSQLReactorOptions<
   MessageType extends Message = Message,
   MessagePayloadType extends AnyMessage = MessageType,
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 > = ReactorOptions<
   MessageType,
   ReadEventMetadataWithGlobalPosition,
@@ -251,7 +265,7 @@ export type PostgreSQLReactorOptions<
 export type PostgreSQLProjectorOptions<
   EventType extends AnyEvent = AnyEvent,
   EventPayloadType extends Event = EventType,
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 > = ProjectorOptions<
   EventType,
   ReadEventMetadataWithGlobalPosition,
@@ -268,7 +282,7 @@ export type PostgreSQLWorkflowProcessorOptions<
   MetaDataType extends AnyRecordedMessageMetadata = AnyRecordedMessageMetadata,
   HandlerContext extends WorkflowProcessorContext = WorkflowProcessorContext,
   StoredMessage extends AnyEvent | AnyCommand = Output,
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 > = WorkflowProcessorOptions<
   Input,
   State,
@@ -280,16 +294,16 @@ export type PostgreSQLWorkflowProcessorOptions<
   PostgreSQLProcessorOptionsBase<Driver>;
 
 const postgreSQLProcessingScope = <
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 >(options: {
-  pool: PgPool | null;
-  connectionString: string | null;
+  pool: InferPoolFromEventStoreDriver<Driver> | null;
+  connectionOptions: InferDumboOptionsFromEventStoreDriver<Driver> | null;
   driver?: Driver;
   processorId: string;
   partition: string;
   migrationOptions?: EventStoreSchemaMigrationOptions['migrationOptions'];
 }): MessageProcessingScope<PostgreSQLProcessorHandlerContext<Driver>> => {
-  const processorConnectionString = options.connectionString;
+  const processorConnectionOptions = options.connectionOptions;
 
   const processorPool = options.pool;
 
@@ -299,50 +313,48 @@ const postgreSQLProcessingScope = <
     handler: (
       context: PostgreSQLProcessorHandlerContext<Driver>,
     ) => Result | Promise<Result>,
-    partialContext: Partial<PostgreSQLProcessorHandlerContext<Driver>>,
+    partialContext: PartialHandlerContext<
+      PostgreSQLProcessorHandlerContext<Driver>
+    >,
   ) => {
-    const connection = partialContext?.connection;
-    /**
-     * `getProcessorPool` is still pg specific, so the connection string it
-     * carries is read back out of the driver's own pool options.
-     */
-    const connectionString: string | null | undefined =
-      processorConnectionString ??
-      (connection?.options as { connectionString?: string } | undefined)
-        ?.connectionString;
+    const session = partialContext?.session;
 
-    const pool: PgPool | null =
-      ((!processorConnectionString ||
-      connectionString == processorConnectionString
-        ? connection?.pool
-        : processorPool) as PgPool | null) ?? processorPool;
+    const { pool, connectionOptions } = processorPool
+      ? {
+          pool: processorPool,
+          connectionOptions: processorConnectionOptions ?? undefined,
+        }
+      : { pool: session?.pool, connectionOptions: session?.connectionOptions };
 
     if (!pool)
       throw new EmmettError(
         `PostgreSQL processor '${options.processorId}' is missing a connection pool. Ensure that you passed connection options through options`,
       );
 
-    return pool.withTransaction(async (transaction) => {
-      const client = await transaction.connection.open();
-      /**
-       * The context type follows the driver, while `getProcessorPool` still
-       * builds a pg pool. The two only meet through this cast until the pool
-       * plumbing is driver-generic too.
-       */
+    return pool.withTransaction(async (transaction: AnyDatabaseTransaction) => {
+      const connection =
+        transaction.connection as InferDumboConnectionFromEventStoreDriver<Driver>;
+
       return handler({
         ...partialContext,
         partition: options.partition,
         execute: transaction.execute,
         driverType: pool.driverType,
-        connection: {
-          connectionString,
+        driver:
+          options.driver ??
+          partialContext?.driver ??
+          (pgEventStoreDriver as unknown as Driver),
+        session: {
+          ...partialContext?.session,
           pool,
-          client,
-          transaction: transaction,
+          connectionOptions,
+          connection,
+          transaction:
+            transaction as InferTransactionFromEventStoreDriver<Driver>,
           messageStore: getPostgreSQLEventStore({
             driver: options.driver ?? pgEventStoreDriver,
             connectionOptions: {
-              connection: transaction.connection as PgPoolClientConnection,
+              connection: connection as unknown as PgPoolClientConnection,
             },
             schema: {
               autoMigration: 'None',
@@ -352,7 +364,7 @@ const postgreSQLProcessingScope = <
         },
         migrationOptions: options.migrationOptions,
         observabilityScope: partialContext?.observabilityScope ?? noopScope,
-      } as unknown as PostgreSQLProcessorHandlerContext<Driver>);
+      });
     });
   };
 
@@ -360,7 +372,7 @@ const postgreSQLProcessingScope = <
 };
 
 const getProcessorPool = <
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 >(
   options: PostgreSQLConnectionOptions<Driver>,
 ) => {
@@ -372,25 +384,27 @@ const getProcessorPool = <
       ? (poolOptions.connectionString ?? null)
       : null;
 
-  const processorPool =
+  const connectionOptions = processorConnectionString
+    ? ({
+        serialization: options.serialization,
+        ...(options.driver ?? pgEventStoreDriver).mapToDumboOptions({
+          connectionString: processorConnectionString,
+          connectionOptions: poolOptions,
+        } as PgEventStoreDriverOptions),
+      } as InferDumboOptionsFromEventStoreDriver<Driver>)
+    : null;
+
+  const processorPool = (
     'dumbo' in poolOptions
-      ? (poolOptions.dumbo as PgPool)
-      : processorConnectionString
-        ? (dumbo({
-            ...poolOptions,
-            serialization: options.serialization,
-            transactionOptions: {
-              allowNestedTransactions: true,
-            },
-            ...(options.driver ?? pgEventStoreDriver).mapToDumboOptions({
-              connectionString: processorConnectionString,
-            }),
-          }) as PgPool)
-        : null;
+      ? poolOptions.dumbo
+      : connectionOptions
+        ? dumbo(connectionOptions)
+        : null
+  ) as InferPoolFromEventStoreDriver<Driver> | null;
 
   return {
     pool: processorPool,
-    connectionString: processorConnectionString,
+    connectionOptions,
     close:
       processorPool != null && !('dumbo' in poolOptions)
         ? processorPool.close
@@ -399,7 +413,7 @@ const getProcessorPool = <
 };
 
 const toProcessorLockOptions = <
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 >(
   processorLock: PostgreSQLProcessorLock,
   lock: PostgreSQLProcessorOptionsBase<Driver>['lock'],
@@ -412,7 +426,7 @@ const toProcessorLockOptions = <
 export const postgreSQLProjector = <
   EventType extends Event = Event,
   EventPayloadType extends Event = EventType,
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 >(
   options: PostgreSQLProjectorOptions<EventType, EventPayloadType, Driver>,
 ): PostgreSQLProcessor<EventType, Driver> => {
@@ -426,7 +440,7 @@ export const postgreSQLProjector = <
     lock,
   } = options;
 
-  const { pool, connectionString, close } = getProcessorPool(options);
+  const { pool, connectionOptions, close } = getProcessorPool(options);
 
   const processorLock = postgreSQLProcessorLock({
     databaseSchemaName: options.migrationOptions?.databaseSchemaName,
@@ -490,7 +504,7 @@ export const postgreSQLProjector = <
     lock: toProcessorLockOptions(processorLock, lock),
     processingScope: postgreSQLProcessingScope<Driver>({
       pool,
-      connectionString,
+      connectionOptions,
       driver: options.driver,
       processorId,
       partition,
@@ -510,7 +524,7 @@ export const postgreSQLWorkflowProcessor = <
   State,
   Output extends AnyEvent | AnyCommand,
   MetaDataType extends AnyRecordedMessageMetadata = AnyRecordedMessageMetadata,
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
   HandlerContext extends PostgreSQLProcessorHandlerContext<Driver> &
     WorkflowProcessorContext = PostgreSQLProcessorHandlerContext<Driver> &
     WorkflowProcessorContext,
@@ -537,7 +551,7 @@ export const postgreSQLWorkflowProcessor = <
     lock,
   } = options;
 
-  const { pool, connectionString, close } = getProcessorPool(options);
+  const { pool, connectionOptions, close } = getProcessorPool(options);
 
   const processorLock = postgreSQLProcessorLock({
     databaseSchemaName: options.migrationOptions?.databaseSchemaName,
@@ -552,11 +566,8 @@ export const postgreSQLWorkflowProcessor = <
   const hooks: ProcessorHooks<HandlerContext> = {
     ...(options.hooks ?? {}),
     onClose: close
-      ? async (
-          context: PostgreSQLProcessorHandlerContext<AnyEventStoreDriver>,
-        ) => {
-          if (options.hooks?.onClose)
-            await options.hooks?.onClose(context as HandlerContext);
+      ? async (context: HandlerContext) => {
+          if (options.hooks?.onClose) await options.hooks?.onClose(context);
           if (close) await close();
         }
       : options.hooks?.onClose,
@@ -572,7 +583,7 @@ export const postgreSQLWorkflowProcessor = <
     lock: toProcessorLockOptions(processorLock, lock),
     processingScope: postgreSQLProcessingScope<Driver>({
       pool,
-      connectionString,
+      connectionOptions,
       driver: options.driver,
       processorId,
       partition,
@@ -592,7 +603,7 @@ export const postgreSQLWorkflowProcessor = <
 export const postgreSQLReactor = <
   MessageType extends AnyMessage = AnyMessage,
   MessagePayloadType extends AnyMessage = MessageType,
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 >(
   options: PostgreSQLReactorOptions<MessageType, MessagePayloadType, Driver>,
 ): PostgreSQLProcessor<MessageType, Driver> => {
@@ -604,7 +615,7 @@ export const postgreSQLReactor = <
     lock,
   } = options;
 
-  const { pool, connectionString, close } = getProcessorPool(options);
+  const { pool, connectionOptions, close } = getProcessorPool(options);
 
   const processorLock = postgreSQLProcessorLock({
     databaseSchemaName: options.migrationOptions?.databaseSchemaName,
@@ -636,7 +647,7 @@ export const postgreSQLReactor = <
     lock: toProcessorLockOptions(processorLock, lock),
     processingScope: postgreSQLProcessingScope<Driver>({
       pool,
-      connectionString,
+      connectionOptions,
       driver: options.driver,
       processorId,
       partition,

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/rebuildPostgreSQLProjections.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/rebuildPostgreSQLProjections.int.spec.ts
@@ -22,7 +22,6 @@ import {
   type PongoCollection,
   type PongoDb,
 } from '@event-driven-io/pongo';
-import { pgDriver } from '@event-driven-io/pongo/pg';
 import { v4 as uuid } from 'uuid';
 import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
 import {
@@ -75,7 +74,7 @@ void describe('Rebuilding PostgreSQL Projections', () => {
     });
     pongo = pongoClient({
       connectionString,
-      driver: pgDriver,
+      driver: pgEventStoreDriver.pongoDriver,
       connectionOptions: {
         transactionOptions: {
           allowNestedTransactions: true,

--- a/src/packages/emmett-postgresql/src/eventStore/consumers/rebuildPostgreSQLProjections.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/consumers/rebuildPostgreSQLProjections.ts
@@ -6,7 +6,7 @@ import {
   type ReadEventMetadataWithGlobalPosition,
 } from '@event-driven-io/emmett';
 import type { PgEventStoreDriver } from '../../pg';
-import type { AnyEventStoreDriver } from '../eventStoreDriver';
+import type { AnyPostgreSQLEventStoreDriver } from '../eventStoreDriver';
 import type { PostgreSQLProjectionDefinition } from '../projections';
 import type { LockAcquisitionPolicy } from '../projections/locks';
 import {
@@ -24,36 +24,41 @@ const defaultRebuildLockPolicy: LockAcquisitionPolicy = {
   maxTimeout: 5000,
 };
 
+export type RebuildPostgreSQLProjectionsOptions<
+  EventType extends AnyEvent = AnyEvent,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
+> = Omit<
+  PostgreSQLEventStoreConsumerConfig<EventType>,
+  'stopWhen' | 'processors'
+> &
+  PostgreSQLEventStoreConsumerConnectionOptions<EventType, Driver> & {
+    lock?: {
+      acquisitionPolicy?: LockAcquisitionPolicy;
+      timeoutSeconds?: number;
+    };
+  } & (
+    | {
+        projections: (
+          | ProjectorOptions<
+              EventType,
+              ReadEventMetadataWithGlobalPosition,
+              PostgreSQLProcessorHandlerContext<Driver>
+            >
+          | PostgreSQLProjectionDefinition<EventType, EventType, Driver>
+        )[];
+      }
+    | ProjectorOptions<
+        EventType,
+        ReadEventMetadataWithGlobalPosition,
+        PostgreSQLProcessorHandlerContext<Driver>
+      >
+  );
+
 export const rebuildPostgreSQLProjections = <
   EventType extends AnyEvent = AnyEvent,
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 >(
-  options: Omit<
-    PostgreSQLEventStoreConsumerConfig<EventType>,
-    'stopWhen' | 'processors'
-  > &
-    PostgreSQLEventStoreConsumerConnectionOptions<EventType, Driver> & {
-      lock?: {
-        acquisitionPolicy?: LockAcquisitionPolicy;
-        timeoutSeconds?: number;
-      };
-    } & (
-      | {
-          projections: (
-            | ProjectorOptions<
-                EventType,
-                ReadEventMetadataWithGlobalPosition,
-                PostgreSQLProcessorHandlerContext<Driver>
-              >
-            | PostgreSQLProjectionDefinition<EventType, EventType, Driver>
-          )[];
-        }
-      | ProjectorOptions<
-          EventType,
-          ReadEventMetadataWithGlobalPosition,
-          PostgreSQLProcessorHandlerContext<Driver>
-        >
-    ),
+  options: RebuildPostgreSQLProjectionsOptions<EventType, Driver>,
 ): PostgreSQLEventStoreConsumer<EventType, Driver> => {
   const consumer = postgreSQLEventStoreConsumer<EventType, Driver>({
     ...options,

--- a/src/packages/emmett-postgresql/src/eventStore/eventStoreDriver.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/eventStoreDriver.ts
@@ -1,5 +1,10 @@
+import { EmmettError } from '@event-driven-io/emmett';
+import type { AnyPongoDriver } from '@event-driven-io/pongo';
+import type { PostgreSQLDriverType } from '@event-driven-io/dumbo/pg';
 import type {
   AnyDumboDatabaseDriver,
+  Connection,
+  Dumbo,
   DumboDatabaseDriver,
   ExtractDumboDatabaseDriverOptions,
   ExtractDumboTypeFromDriver,
@@ -13,10 +18,37 @@ export interface EventStoreDriver<
 > {
   driverType: DatabaseDriver['driverType'];
   dumboDriver: DatabaseDriver;
+  pongoDriver?: AnyPongoDriver;
   mapToDumboOptions(
-    driverOptions: DriverOptions,
+    options: DriverOptions,
   ): ExtractDumboDatabaseDriverOptions<DatabaseDriver>;
 }
+
+export const eventStoreDriverOf = <
+  Driver extends AnyPostgreSQLEventStoreDriver = AnyPostgreSQLEventStoreDriver,
+>(
+  driver: Driver | undefined,
+): Driver => {
+  if (!driver)
+    throw new EmmettError(
+      `The handler context carries no event store driver. Ensure that you passed it to getPostgreSQLEventStore.`,
+    );
+
+  return driver;
+};
+
+export const pongoDriverOf = (
+  driver: AnyPostgreSQLEventStoreDriver | undefined,
+): AnyPongoDriver => {
+  const pongoDriver = eventStoreDriverOf(driver).pongoDriver;
+
+  if (!pongoDriver)
+    throw new EmmettError(
+      `Pongo projections need a Pongo driver on the event store driver. Ensure that the driver you passed to getPostgreSQLEventStore defines 'pongoDriver'.`,
+    );
+
+  return pongoDriver;
+};
 
 export type EventStoreDriverOptions<
   Driver extends AnyEventStoreDriver = AnyEventStoreDriver,
@@ -33,7 +65,37 @@ export type AnyEventStoreDriver = EventStoreDriver<
   AnyEventStoreDriverOptions
 >;
 
-export type InferOptionsFromEventStoreDriver<C extends AnyEventStoreDriver> =
+/**
+ * Mirrors `AnySQLiteConnection`, which Dumbo ships and its PostgreSQL side does
+ * not. Move to Dumbo's own once it has one.
+ */
+export type AnyPostgreSQLConnection = Connection<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  any,
+  PostgreSQLDriverType,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  any
+>;
+
+/**
+ * Any driver this package can actually talk to. Constraining on it keeps
+ * `context.session.connection` a PostgreSQL connection, whichever PostgreSQL
+ * driver you picked.
+ */
+export type AnyPostgreSQLEventStoreDriver = Omit<
+  EventStoreDriver<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    DumboDatabaseDriver<AnyPostgreSQLConnection, any>,
+    AnyEventStoreDriverOptions
+  >,
+  'driverType'
+> & { driverType: PostgreSQLDriverType };
+
+export type InferOptionsFromEventStoreDriver<
+  C extends AnyPostgreSQLEventStoreDriver,
+> =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   C extends EventStoreDriver<any, infer DO> ? DO : never;
 
@@ -43,11 +105,11 @@ export type InferOptionsFromEventStoreDriver<C extends AnyEventStoreDriver> =
  * without one exposes whatever it does have.
  */
 export type InferDumboOptionsFromEventStoreDriver<
-  C extends AnyEventStoreDriver,
+  C extends AnyPostgreSQLEventStoreDriver,
 > = ExtractDumboDatabaseDriverOptions<C['dumboDriver']>;
 
 export type InferDumboConnectionFromEventStoreDriver<
-  Driver extends AnyEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver,
 > =
   Driver['dumboDriver'] extends DumboDatabaseDriver<
     infer ConnectionType,
@@ -59,17 +121,24 @@ export type InferDumboConnectionFromEventStoreDriver<
     ? ConnectionType
     : never;
 
-export type InferPoolFromEventStoreDriver<Driver extends AnyEventStoreDriver> =
-  ExtractDumboTypeFromDriver<Driver['dumboDriver']>;
+export type InferPoolFromEventStoreDriver<
+  Driver extends AnyPostgreSQLEventStoreDriver,
+> = ExtractDumboTypeFromDriver<Driver['dumboDriver']>;
 
 export type InferDbClientFromEventStoreDriver<
-  Driver extends AnyEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver,
 > = InferDbClientFromConnection<
   InferDumboConnectionFromEventStoreDriver<Driver>
 >;
 
 export type InferTransactionFromEventStoreDriver<
-  Driver extends AnyEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver,
 > = InferTransactionFromConnection<
   InferDumboConnectionFromEventStoreDriver<Driver>
 >;
+
+export type PoolOrConnectionOptions<
+  Driver extends AnyPostgreSQLEventStoreDriver = AnyPostgreSQLEventStoreDriver,
+> =
+  | ({ pool?: undefined } & InferOptionsFromEventStoreDriver<Driver>)
+  | ({ pool: Dumbo } & Partial<InferOptionsFromEventStoreDriver<Driver>>);

--- a/src/packages/emmett-postgresql/src/eventStore/eventStoreDriver.unit.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/eventStoreDriver.unit.spec.ts
@@ -1,22 +1,29 @@
 import type {
   Connection,
   ConnectionPool,
+  Dumbo,
   DatabaseTransaction,
   DumboDatabaseDriver,
 } from '@event-driven-io/dumbo';
 import type {
   PgClientConnection,
-  PgClientOrPoolClient,
   PgPool,
   PgPoolClientConnection,
   PgPoolOptions,
   PgTransactionOptions,
 } from '@event-driven-io/dumbo/pg';
-import { assertTrue } from '@event-driven-io/emmett';
+import { assertThrows, assertTrue, EmmettError } from '@event-driven-io/emmett';
+import { pgDriver as pgPongoDriver } from '@event-driven-io/pongo/pg';
 import { describe, it } from 'vitest';
-import type { PgEventStoreDriver } from '../pg';
+import { pgEventStoreDriver, type PgEventStoreDriver } from '../pg';
 import type { PostgreSQLProcessorHandlerContext } from './consumers/postgreSQLProcessor';
-import type { EventStoreDriver } from './eventStoreDriver';
+import {
+  eventStoreDriverOf,
+  pongoDriverOf,
+  type AnyPostgreSQLEventStoreDriver,
+  type EventStoreDriver,
+  type PoolOrConnectionOptions,
+} from './eventStoreDriver';
 import type { PostgreSQLProjectionHandlerContext } from './projections/postgreSQLProjection';
 
 type Equals<Left, Right> =
@@ -46,27 +53,27 @@ type FakeEventStoreDriver = EventStoreDriver<
   { connectionOptions?: { url: string } | undefined }
 >;
 
-type ProcessorConnection<Driver extends EventStoreDriver> =
-  PostgreSQLProcessorHandlerContext<Driver>['connection'];
+type ProcessorSession<Driver extends AnyPostgreSQLEventStoreDriver> =
+  PostgreSQLProcessorHandlerContext<Driver>['session'];
 
-type ProjectionConnection<Driver extends EventStoreDriver> =
-  PostgreSQLProjectionHandlerContext<Driver>['connection'];
+type ProjectionSession<Driver extends AnyPostgreSQLEventStoreDriver> =
+  PostgreSQLProjectionHandlerContext<Driver>['session'];
 
-void describe('Handler context connection typing', () => {
+void describe('Handler context session typing', () => {
   void describe('when no driver is given', () => {
     void it('falls back to the pg driver', () => {
       assertTypesEqual<
         Equals<
-          ProcessorConnection<PgEventStoreDriver>['client'],
-          PgClientOrPoolClient
+          ProcessorSession<PgEventStoreDriver>['connection'],
+          PgClientConnection | PgPoolClientConnection
         >
       >();
       assertTypesEqual<
-        Equals<ProcessorConnection<PgEventStoreDriver>['pool'], PgPool>
+        Equals<ProcessorSession<PgEventStoreDriver>['pool'], PgPool>
       >();
       assertTypesEqual<
         Equals<
-          ProcessorConnection<PgEventStoreDriver>['transaction'],
+          ProcessorSession<PgEventStoreDriver>['transaction'],
           | DatabaseTransaction<PgPoolClientConnection, PgTransactionOptions>
           | DatabaseTransaction<PgClientConnection, PgTransactionOptions>
         >
@@ -74,8 +81,8 @@ void describe('Handler context connection typing', () => {
 
       assertTypesEqual<
         Equals<
-          ProcessorConnection<PgEventStoreDriver>['options'],
-          PgPoolOptions
+          ProcessorSession<PgEventStoreDriver>['connectionOptions'],
+          PgPoolOptions | undefined
         >
       >();
 
@@ -84,12 +91,18 @@ void describe('Handler context connection typing', () => {
   });
 
   void describe('when another driver is given', () => {
-    void it('derives the client from that driver', () => {
+    void it('derives the connection from that driver', () => {
       assertTypesEqual<
-        Equals<ProcessorConnection<FakeEventStoreDriver>['client'], FakeClient>
+        Equals<
+          ProcessorSession<FakeEventStoreDriver>['connection'],
+          FakeConnection
+        >
       >();
       assertTypesEqual<
-        Equals<ProjectionConnection<FakeEventStoreDriver>['client'], FakeClient>
+        Equals<
+          ProjectionSession<FakeEventStoreDriver>['connection'],
+          FakeConnection
+        >
       >();
 
       assertTrue(true);
@@ -98,7 +111,7 @@ void describe('Handler context connection typing', () => {
     void it('derives the transaction from that driver', () => {
       assertTypesEqual<
         Equals<
-          ProcessorConnection<FakeEventStoreDriver>['transaction'],
+          ProcessorSession<FakeEventStoreDriver>['transaction'],
           DatabaseTransaction<FakeConnection>
         >
       >();
@@ -109,8 +122,8 @@ void describe('Handler context connection typing', () => {
     void it('derives the pool options from that driver', () => {
       assertTypesEqual<
         Equals<
-          ProcessorConnection<FakeEventStoreDriver>['options'],
-          { url: string }
+          ProcessorSession<FakeEventStoreDriver>['connectionOptions'],
+          { url: string } | undefined
         >
       >();
 
@@ -120,12 +133,92 @@ void describe('Handler context connection typing', () => {
     void it('derives the pool from that driver', () => {
       assertTypesEqual<
         Equals<
-          ProcessorConnection<FakeEventStoreDriver>['pool'],
+          ProcessorSession<FakeEventStoreDriver>['pool'],
           ConnectionPool<FakeConnection>
         >
       >();
 
       assertTrue(true);
     });
+  });
+
+  void describe('driver family', () => {
+    void it('accepts every driver this package ships', () => {
+      assertTypesEqual<
+        PgEventStoreDriver extends AnyPostgreSQLEventStoreDriver ? true : false
+      >();
+
+      assertTrue(true);
+    });
+
+    void it('rejects a driver that is not a PostgreSQL one', () => {
+      type NotPostgreSQL = {
+        driverType: 'SQLite:sqlite3';
+        dumboDriver: never;
+        mapToDumboOptions: () => never;
+      };
+
+      assertTypesEqual<
+        NotPostgreSQL extends AnyPostgreSQLEventStoreDriver ? false : true
+      >();
+
+      assertTrue(true);
+    });
+  });
+});
+
+void describe('pongoDriverOf', () => {
+  void it('returns the Pongo driver the event store driver names', () => {
+    assertTrue(pongoDriverOf(pgEventStoreDriver) === pgPongoDriver);
+  });
+
+  void it('fails when the event store driver names no Pongo driver', () => {
+    const { pongoDriver: _, ...withoutPongoDriver } = pgEventStoreDriver;
+
+    assertThrows(
+      () => pongoDriverOf(withoutPongoDriver),
+      (error) => error instanceof EmmettError,
+    );
+  });
+});
+
+void describe('eventStoreDriverOf', () => {
+  void it('returns the driver the context was given', () => {
+    assertTrue(eventStoreDriverOf(pgEventStoreDriver) === pgEventStoreDriver);
+  });
+
+  void it('fails when the context carries no driver', () => {
+    assertThrows(
+      () => eventStoreDriverOf(undefined),
+      (error) => error instanceof EmmettError,
+    );
+  });
+});
+
+void describe('PoolOrConnectionOptions', () => {
+  void it('needs the driver options when no pool is given', () => {
+    assertTypesEqual<
+      {
+        connectionString: string;
+      } extends PoolOrConnectionOptions<PgEventStoreDriver>
+        ? true
+        : false
+    >();
+    assertTypesEqual<
+      // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+      {} extends PoolOrConnectionOptions<PgEventStoreDriver> ? false : true
+    >();
+
+    assertTrue(true);
+  });
+
+  void it('makes the driver options optional when a pool is given', () => {
+    assertTypesEqual<
+      { pool: Dumbo } extends PoolOrConnectionOptions<PgEventStoreDriver>
+        ? true
+        : false
+    >();
+
+    assertTrue(true);
   });
 });

--- a/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.deprecated.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.deprecated.int.spec.ts
@@ -135,7 +135,7 @@ void describe('Postgres event store built through the deprecated positional form
       hooks: {
         onAfterSchemaCreated: (context) => {
           seenConnectionString =
-            context.connection.options.connectionString ?? null;
+            context.session.connectionOptions?.connectionString ?? null;
         },
       },
     });

--- a/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.e2e.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.e2e.spec.ts
@@ -14,7 +14,6 @@ import {
   type ReadEvent,
 } from '@event-driven-io/emmett';
 import { pongoClient, type PongoClient } from '@event-driven-io/pongo';
-import { pgDriver } from '@event-driven-io/pongo/pg';
 import pg from 'pg';
 import { v4 as uuid } from 'uuid';
 import {
@@ -59,7 +58,7 @@ void describe('EventStoreDBEventStore', () => {
     connectionString = database.connectionString;
     pongo = pongoClient({
       connectionString,
-      driver: pgDriver,
+      driver: pgEventStoreDriver.pongoDriver,
       connectionOptions: {
         transactionOptions: {
           allowNestedTransactions: true,
@@ -269,6 +268,38 @@ void describe('EventStoreDBEventStore', () => {
     );
 
     assertEqual(3, handledEventsInCustomProjection.length);
+  });
+
+  void it('should allow events to be processed in the onBeforeCommit hook', async () => {
+    const savedEvents: ReadEvent[] = [];
+    const hookedStore = getPostgreSQLEventStore({
+      driver: pgEventStoreDriver,
+      connectionString,
+      schema: { autoMigration: 'None' },
+      hooks: {
+        onBeforeCommit: (messages): void => {
+          savedEvents.push(...messages);
+        },
+      },
+    });
+
+    try {
+      await hookedStore.appendToStream<ShoppingCartEvent>(
+        `shopping_cart-${uuid()}`,
+        [
+          {
+            type: 'ProductItemAdded',
+            data: { productItem },
+            metadata: { clientId },
+          },
+        ],
+      );
+
+      assertEqual(savedEvents.length, 1);
+      assertEqual(savedEvents[0]!.type, 'ProductItemAdded');
+    } finally {
+      await hookedStore.close();
+    }
   });
 
   void it('should record observability while appending', async () => {

--- a/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/postgreSQLEventStore.ts
@@ -4,18 +4,19 @@ import {
   fromDatabaseDriverType,
   getFormatter,
   JSONSerializer,
-  type Dumbo,
   type MigrationStyle,
   type RunSQLMigrationsResult,
 } from '@event-driven-io/dumbo';
 import type {
   PgClientConnection,
+  PgConnection,
   PgDriverType,
   PgPool,
   PgPoolClientConnection,
   PgPoolOptions,
+  PgTransaction,
 } from '@event-driven-io/dumbo/pg';
-import { pgEventStoreDriver } from '../pg';
+import { pgEventStoreDriver, type PgEventStoreDriver } from '../pg';
 import {
   assertExpectedVersionMatchesCurrent,
   downcastRecordedMessages,
@@ -40,6 +41,7 @@ import {
   type JSONSerializationOptions,
   type Message,
   type ProjectionRegistration,
+  type BeforeEventStoreCommitHandler,
   type ReadEvent,
   type ReadEventMetadataWithGlobalPosition,
   type ReadStreamOptions,
@@ -72,8 +74,8 @@ import {
 } from './schema';
 import { truncateTables } from './schema/truncateTables';
 import type {
-  AnyEventStoreDriver,
-  InferOptionsFromEventStoreDriver,
+  AnyPostgreSQLEventStoreDriver,
+  PoolOrConnectionOptions,
 } from './eventStoreDriver';
 
 export interface PostgresEventStore
@@ -182,7 +184,60 @@ type PostgresEventStoreNotPooledOptions =
 export type PostgresEventStoreConnectionOptions =
   PostgresEventStorePooledOptions | PostgresEventStoreNotPooledOptions;
 
-type PostgresEventStoreCommonOptions = {
+export type PostgresEventStoreOptions<
+  Driver extends AnyPostgreSQLEventStoreDriver = AnyPostgreSQLEventStoreDriver,
+> = {
+  driver: Driver;
+  projections?: ProjectionRegistration<
+    'inline',
+    PostgresReadEventMetadata,
+    PostgreSQLProjectionHandlerContext<Driver>
+  >[];
+  observability?: EmmettObservabilityConfig;
+  schema?: { autoMigration?: MigrationStyle } & EventStoreDatabaseSchemaOptions;
+  hooks?: {
+    /**
+     * This hook will be called **BEFORE** event store schema is created
+     */
+    onBeforeSchemaCreated?: (
+      context: PostgreSQLProjectionHandlerContext<Driver>,
+    ) => Promise<void> | void;
+    /**
+     * This hook will be called **BEFORE** events were stored in the event store.
+     * @type {BeforeEventStoreCommitHandler<PostgresEventStore, HandlerContext>}
+     */
+    onBeforeCommit?: BeforeEventStoreCommitHandler<
+      PostgresEventStore,
+      {
+        connection: PgConnection;
+        transaction: PgTransaction;
+      }
+    >;
+    /**
+     * This hook will be called **AFTER** event store schema was created but before transaction commits
+     */
+    onAfterSchemaCreated?: (
+      context: PostgreSQLProjectionHandlerContext<Driver>,
+    ) => Promise<void> | void;
+  };
+} & PoolOrConnectionOptions<Driver> &
+  JSONSerializationOptions;
+
+/**
+ * @deprecated use `PostgresEventStoreOptions` instead; this alias is removed in
+ * the next major.
+ */
+export type PostgresEventStoreDriverOptions<
+  Driver extends AnyPostgreSQLEventStoreDriver = AnyPostgreSQLEventStoreDriver,
+> = PostgresEventStoreOptions<Driver>;
+
+/**
+ * Options for the `getPostgreSQLEventStore(connectionString, options)` form.
+ *
+ * @deprecated pass an options object carrying `driver` instead; this form is
+ * removed in the next major.
+ */
+export type PostgresEventStoreConnectionStringOptions = {
   projections?: ProjectionRegistration<
     'inline',
     PostgresReadEventMetadata,
@@ -198,39 +253,31 @@ type PostgresEventStoreCommonOptions = {
       context: PostgreSQLProjectionHandlerContext,
     ) => Promise<void> | void;
     /**
+     * This hook will be called **BEFORE** events were stored in the event store.
+     * @type {BeforeEventStoreCommitHandler<PostgresEventStore, HandlerContext>}
+     */
+    onBeforeCommit?: BeforeEventStoreCommitHandler<
+      PostgresEventStore,
+      {
+        connection: PgConnection;
+        transaction: PgTransaction;
+      }
+    >;
+    /**
      * This hook will be called **AFTER** event store schema was created but before transaction commits
      */
     onAfterSchemaCreated?: (
       context: PostgreSQLProjectionHandlerContext,
     ) => Promise<void> | void;
   };
+  connectionOptions?: PostgresEventStoreConnectionOptions;
 } & JSONSerializationOptions;
 
-/**
- * Options for the `getPostgreSQLEventStore(connectionString, options)` form.
- *
- * @deprecated pass an options object carrying `driver` instead; this form is
- * removed in the next major.
- */
-export type PostgresEventStoreOptions = PostgresEventStoreCommonOptions & {
-  connectionOptions?: PostgresEventStoreConnectionOptions;
-};
-
-/**
- * Options for the `getPostgreSQLEventStore(options)` form. Connection details
- * arrive flattened, through the driver's own option shape.
- */
-export type PostgresEventStoreDriverOptions<
-  Driver extends AnyEventStoreDriver = AnyEventStoreDriver,
-> = PostgresEventStoreCommonOptions & {
-  driver: Driver;
-  pool?: Dumbo;
-} & InferOptionsFromEventStoreDriver<Driver>;
-
-export const defaultPostgreSQLOptions: PostgresEventStoreOptions = {
-  projections: [],
-  schema: { autoMigration: 'CreateOrUpdate' },
-};
+export const defaultPostgreSQLOptions: PostgresEventStoreConnectionStringOptions =
+  {
+    projections: [],
+    schema: { autoMigration: 'CreateOrUpdate' },
+  };
 
 export const PostgreSQLEventStoreDefaultStreamVersion = 0n;
 
@@ -240,30 +287,30 @@ export const PostgreSQLEventStoreDefaultStreamVersion = 0n;
  */
 export function getPostgreSQLEventStore(
   connectionString: string,
-  options?: PostgresEventStoreOptions,
+  options?: PostgresEventStoreConnectionStringOptions,
 ): PostgresEventStore;
 export function getPostgreSQLEventStore<
-  Driver extends AnyEventStoreDriver = AnyEventStoreDriver,
->(options: PostgresEventStoreDriverOptions<Driver>): PostgresEventStore;
+  Driver extends AnyPostgreSQLEventStoreDriver = AnyPostgreSQLEventStoreDriver,
+>(options: PostgresEventStoreOptions<Driver>): PostgresEventStore;
 export function getPostgreSQLEventStore(
-  connectionStringOrOptions: string | PostgresEventStoreDriverOptions,
-  maybeOptions: PostgresEventStoreOptions = defaultPostgreSQLOptions,
+  connectionStringOrOptions: string | PostgresEventStoreOptions,
+  maybeOptions: PostgresEventStoreConnectionStringOptions = defaultPostgreSQLOptions,
 ): PostgresEventStore {
-  const driverOptions =
+  const optionsWithDriver =
     typeof connectionStringOrOptions === 'string'
       ? undefined
       : connectionStringOrOptions;
 
-  const options: PostgresEventStoreOptions = driverOptions
-    ? (driverOptions as PostgresEventStoreCommonOptions)
-    : maybeOptions;
+  const options: PostgresEventStoreOptions = optionsWithDriver
+    ? optionsWithDriver
+    : (maybeOptions as PostgresEventStoreOptions);
 
   const poolOptions = {
     connectionString:
       typeof connectionStringOrOptions === 'string'
         ? connectionStringOrOptions
         : '',
-    ...(driverOptions ? {} : (maybeOptions.connectionOptions ?? {})),
+    ...(optionsWithDriver ? {} : (maybeOptions.connectionOptions ?? {})),
   };
   /**
    * Built even when a pool is supplied, so the handler context always carries
@@ -271,8 +318,8 @@ export function getPostgreSQLEventStore(
    */
   // TODO: Fix this cast when introducing more drivers
   const dumboOptions = (
-    driverOptions
-      ? driverOptions.driver.mapToDumboOptions(driverOptions)
+    optionsWithDriver
+      ? optionsWithDriver.driver.mapToDumboOptions(optionsWithDriver)
       : pgEventStoreDriver.mapToDumboOptions({
           connectionString: poolOptions.connectionString,
           connectionOptions: poolOptions,
@@ -280,14 +327,24 @@ export function getPostgreSQLEventStore(
   ) as PgPoolOptions;
 
   // TODO: Fix this cast when introducing more drivers
+  const eventStoreDriver = (optionsWithDriver?.driver ??
+    pgEventStoreDriver) as PgEventStoreDriver;
+
+  // TODO: Fix this cast when introducing more drivers
   const pool = (
-    driverOptions
-      ? (driverOptions.pool ??
+    optionsWithDriver
+      ? (optionsWithDriver.pool ??
         dumbo({ serialization: options.serialization, ...dumboOptions }))
       : 'dumbo' in poolOptions
         ? poolOptions.dumbo
         : dumbo({ serialization: options.serialization, ...dumboOptions })
   ) as PgPool;
+
+  const session = {
+    pool,
+    driver: eventStoreDriver,
+    connectionOptions: dumboOptions,
+  };
 
   let migrateSchema: Promise<RunSQLMigrationsResult> | undefined = undefined;
 
@@ -314,10 +371,9 @@ export function getPostgreSQLEventStore(
       };
 
       // TODO: Fix this cast when introducing more drivers
-      const migration = createEventStoreSchema(
-        dumboOptions,
-        pool,
-        {
+      const migration = createEventStoreSchema({
+        ...session,
+        hooks: {
           onBeforeSchemaCreated: async (context) => {
             if (options.hooks?.onBeforeSchemaCreated) {
               await options.hooks.onBeforeSchemaCreated(context);
@@ -343,8 +399,8 @@ export function getPostgreSQLEventStore(
             }
           },
         },
-        schemaMigrationOptions,
-      );
+        schema: schemaMigrationOptions,
+      });
 
       if (migrationOptions?.dryRun) {
         return migration;
@@ -388,30 +444,42 @@ export function getPostgreSQLEventStore(
       readOptions?.observability,
     );
 
+  const onBeforeCommitHook = options.hooks?.onBeforeCommit;
+
   const beforeCommitHook = (
     streamName: string,
     appendScope: ObservabilityScope,
   ): AppendToStreamBeforeCommitHook | undefined =>
-    inlineProjections.length > 0
-      ? async (events, { transaction }) =>
-          collector.instrumentInlineProjection(
-            streamName,
-            appendScope,
-            async (observabilityScope) =>
-              handleProjections({
-                projections: inlineProjections,
-                // TODO: Add proper handling of global data
-                // Currently it's not available as append doesn't return array of global position but just the last one
-                events: events as ReadEvent<Event, PostgresReadEventMetadata>[],
-                ...(await transactionToPostgreSQLProjectionHandlerContext(
-                  dumboOptions,
-                  pool,
-                  transaction,
-                )),
-                migrationOptions: databaseSchema,
-                observabilityScope,
-              }),
-          )
+    inlineProjections.length > 0 || onBeforeCommitHook
+      ? async (events, context) => {
+          if (inlineProjections.length > 0)
+            await collector.instrumentInlineProjection(
+              streamName,
+              appendScope,
+              async (observabilityScope) =>
+                handleProjections({
+                  projections: inlineProjections,
+                  // TODO: Add proper handling of global data
+                  // Currently it's not available as append doesn't return array of global position but just the last one
+                  events: events as ReadEvent<
+                    Event,
+                    PostgresReadEventMetadata
+                  >[],
+                  ...transactionToPostgreSQLProjectionHandlerContext(
+                    session,
+                    context.transaction,
+                  ),
+                  migrationOptions: databaseSchema,
+                  observabilityScope,
+                }),
+            );
+
+          if (onBeforeCommitHook)
+            await onBeforeCommitHook(
+              events as ReadEvent<Event, PostgresReadEventMetadata>[],
+              context,
+            );
+        }
       : undefined;
 
   const eventStoreSchemaDescription = (): string =>
@@ -439,9 +507,8 @@ export function getPostgreSQLEventStore(
 
             if (truncateOptions?.truncateProjections) {
               const projectionContext =
-                await transactionToPostgreSQLProjectionHandlerContext(
-                  dumboOptions,
-                  pool,
+                transactionToPostgreSQLProjectionHandlerContext(
+                  session,
                   transaction,
                 );
               for (const projection of options?.projections ?? []) {
@@ -611,7 +678,7 @@ export function getPostgreSQLEventStore(
       callback: (session: EventStoreSession<PostgresEventStore>) => Promise<T>,
     ): Promise<T> {
       return await pool.withConnection(async (connection) => {
-        const storeOptions: PostgresEventStoreOptions = {
+        const storeOptions: PostgresEventStoreConnectionStringOptions = {
           ...options,
           connectionOptions: {
             connection: connection,
@@ -622,12 +689,12 @@ export function getPostgreSQLEventStore(
           },
         };
 
-        const eventStore = driverOptions
+        const eventStore = optionsWithDriver
           ? getPostgreSQLEventStore({
-              ...driverOptions,
+              ...optionsWithDriver,
               pool: dumbo({
                 serialization: options.serialization,
-                ...driverOptions.driver.mapToDumboOptions(driverOptions),
+                ...dumboOptions,
                 connection,
               }),
               schema: {

--- a/src/packages/emmett-postgresql/src/eventStore/projections/locks/postgreSQLProcessorLock.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/locks/postgreSQLProcessorLock.int.spec.ts
@@ -37,7 +37,7 @@ void describe('tryAcquireProcessorLock', () => {
         allowNestedTransactions: true,
       },
     });
-    await createEventStoreSchema({ connectionString }, pool);
+    await createEventStoreSchema({ pool });
   });
 
   afterAll(async () => {

--- a/src/packages/emmett-postgresql/src/eventStore/projections/locks/postgreSQLProjectionLock.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/locks/postgreSQLProjectionLock.int.spec.ts
@@ -35,7 +35,7 @@ void describe('tryAcquireProjectionLock', () => {
         allowNestedTransactions: true,
       },
     });
-    await createEventStoreSchema({ connectionString }, pool);
+    await createEventStoreSchema({ pool });
   });
 
   afterAll(async () => {

--- a/src/packages/emmett-postgresql/src/eventStore/projections/management/projectionRegistration.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/management/projectionRegistration.int.spec.ts
@@ -40,7 +40,7 @@ void describe('projectionRegistration', () => {
         allowNestedTransactions: true,
       },
     });
-    await createEventStoreSchema({ connectionString }, pool);
+    await createEventStoreSchema({ pool });
   });
 
   afterAll(async () => {

--- a/src/packages/emmett-postgresql/src/eventStore/projections/pongo/pongoProjection.transaction.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/pongo/pongoProjection.transaction.int.spec.ts
@@ -7,7 +7,6 @@ import {
   type Event,
 } from '@event-driven-io/emmett';
 import { pongoClient } from '@event-driven-io/pongo';
-import { pgDriver } from '@event-driven-io/pongo/pg';
 import { v4 as uuid } from 'uuid';
 import { afterAll, beforeAll, describe, it } from 'vitest';
 import { pgEventStoreDriver } from '../../../pg';
@@ -125,7 +124,10 @@ void describe('Pongo projection sharing the event store transaction', () => {
     });
 
   const summaryIn = async (collectionName: string, streamName: string) => {
-    const pongo = pongoClient({ connectionString, driver: pgDriver });
+    const pongo = pongoClient({
+      connectionString,
+      driver: pgEventStoreDriver.pongoDriver,
+    });
 
     try {
       return await pongo

--- a/src/packages/emmett-postgresql/src/eventStore/projections/pongo/pongoProjectionSpec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/pongo/pongoProjectionSpec.ts
@@ -16,9 +16,9 @@ import {
   type PongoFilter,
   type WithId,
 } from '@event-driven-io/pongo';
-import { pgDriver } from '@event-driven-io/pongo/pg';
 import type { PostgreSQLProjectionAssert } from '..';
-import { pgEventStoreDriver } from '../../../pg';
+import type { PgEventStoreDriver } from '../../../pg';
+import { eventStoreDriverOf, pongoDriverOf } from '../../eventStoreDriver';
 
 export type PongoAssertOptions<
   Doc extends PongoDocument = PongoDocument,
@@ -36,11 +36,13 @@ const withCollection = <
   handle: (collection: PongoCollection<Doc>) => Promise<void>,
   options: {
     pool: Dumbo;
+    driver: PgEventStoreDriver;
     migrationOptions?: EventStoreDatabaseSchemaOptions | undefined;
   } & PongoAssertOptions<Doc, DocumentPayload>,
 ) => {
   const {
     pool,
+    driver,
     inDatabase,
     inCollection,
     collectionOptions,
@@ -50,10 +52,10 @@ const withCollection = <
   return pool.withConnection(async (connection) => {
     const pongo = pongoClient({
       pool: dumbo({
-        driver: pgEventStoreDriver.dumboDriver,
+        driver: eventStoreDriverOf(driver).dumboDriver,
         connection: connection as PgConnection,
       }),
-      driver: pgDriver,
+      driver: pongoDriverOf(driver),
       defaultSchemaName: migrationOptions?.projectionsDatabaseSchemaName,
       migrationTable: migrationOptions?.migrationTable,
     });

--- a/src/packages/emmett-postgresql/src/eventStore/projections/pongo/pongoProjections.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/pongo/pongoProjections.ts
@@ -1,4 +1,3 @@
-import { dumbo } from '@event-driven-io/dumbo';
 import {
   reduceAsync,
   type CanHandle,
@@ -14,14 +13,13 @@ import {
   type PongoDBCollectionOptions,
   type PongoDocument,
 } from '@event-driven-io/pongo';
-import { pgDriver } from '@event-driven-io/pongo/pg';
 import {
   postgreSQLProjection,
   type PostgreSQLProjectionDefinition,
   type PostgreSQLProjectionHandlerContext,
 } from '..';
 import type { PostgresReadEventMetadata } from '../../postgreSQLEventStore';
-import { pgEventStoreDriver } from '../../../pg';
+import { pongoDriverOf } from '../../eventStoreDriver';
 
 export type PongoProjectionHandlerContext =
   PostgreSQLProjectionHandlerContext & {
@@ -114,16 +112,11 @@ export const pongoProjection = <
     canHandle,
     eventsOptions,
     handle: async (events, context) => {
-      const {
-        connection: { transaction },
-      } = context;
+      const { connection } = context.session;
       const pongo = pongoClient({
-        pool: dumbo({
-          driver: pgEventStoreDriver.dumboDriver,
-          connection: transaction.connection,
-        }),
-        driver: pgDriver,
+        driver: pongoDriverOf(context.driver),
         ...pongoSchemaOptions(context),
+        connectionOptions: { connection },
         schema: { autoMigration: 'None' },
       });
       try {
@@ -137,16 +130,11 @@ export const pongoProjection = <
     },
     truncate: truncate
       ? async (context) => {
-          const {
-            connection: { transaction },
-          } = context;
+          const { connection } = context.session;
           const pongo = pongoClient({
-            pool: dumbo({
-              driver: pgEventStoreDriver.dumboDriver,
-              connection: transaction.connection,
-            }),
-            driver: pgDriver,
+            driver: pongoDriverOf(context.driver),
             ...pongoSchemaOptions(context),
+            connectionOptions: { connection },
           });
           try {
             await truncate({
@@ -160,16 +148,11 @@ export const pongoProjection = <
       : undefined,
     init: init
       ? async (options) => {
-          const {
-            connection: { transaction },
-          } = options.context;
+          const { connection } = options.context.session;
           const pongo = pongoClient({
-            pool: dumbo({
-              driver: pgEventStoreDriver.dumboDriver,
-              connection: transaction.connection,
-            }),
-            driver: pgDriver,
+            driver: pongoDriverOf(options.context.driver),
             ...pongoSchemaOptions(options.context),
+            connectionOptions: { connection },
           });
           try {
             await init({
@@ -300,16 +283,11 @@ export const pongoMultiStreamProjection = <
     },
     canHandle,
     truncate: async (context) => {
-      const {
-        connection: { transaction },
-      } = context;
+      const { connection } = context.session;
       const pongo = pongoClient({
-        pool: dumbo({
-          driver: pgEventStoreDriver.dumboDriver,
-          connection: transaction.connection,
-        }),
-        driver: pgDriver,
+        driver: pongoDriverOf(context.driver),
         ...pongoSchemaOptions(context),
+        connectionOptions: { connection },
       });
 
       try {

--- a/src/packages/emmett-postgresql/src/eventStore/projections/pongo/postgreSQLPongoProjection.schema.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/pongo/postgreSQLPongoProjection.schema.int.spec.ts
@@ -9,7 +9,6 @@ import {
   type Event,
 } from '@event-driven-io/emmett';
 import { pongoClient, type PongoCollection } from '@event-driven-io/pongo';
-import { pgDriver } from '@event-driven-io/pongo/pg';
 import { v4 as uuid } from 'uuid';
 import { afterAll, beforeAll, describe, it } from 'vitest';
 import {
@@ -520,7 +519,7 @@ void describe('PostgreSQL Pongo projection schema configuration', () => {
   ): Promise<Result> => {
     const pongo = pongoClient({
       connectionString,
-      driver: pgDriver,
+      driver: pgEventStoreDriver.pongoDriver,
       defaultSchemaName: databaseSchemaName,
       connectionOptions: {
         transactionOptions: { allowNestedTransactions: true },

--- a/src/packages/emmett-postgresql/src/eventStore/projections/postgreSQLProjection.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/postgreSQLProjection.ts
@@ -21,8 +21,8 @@ import {
 } from '@event-driven-io/emmett';
 import type { PgEventStoreDriver } from '../../pg';
 import type {
-  AnyEventStoreDriver,
-  InferDbClientFromEventStoreDriver,
+  AnyPostgreSQLEventStoreDriver,
+  InferDumboConnectionFromEventStoreDriver,
   InferDumboOptionsFromEventStoreDriver,
   InferPoolFromEventStoreDriver,
   InferTransactionFromEventStoreDriver,
@@ -34,38 +34,42 @@ import { postgreSQLProjectionLock } from './locks';
 import { registerProjection } from './management';
 
 export type PostgreSQLProjectionHandlerContext<
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 > = ProjectionHandlerContext<
   {
     execute: SQLExecutor;
     driverType: DatabaseDriverType;
-    connection: {
-      client: InferDbClientFromEventStoreDriver<Driver>;
-      transaction: InferTransactionFromEventStoreDriver<Driver>;
-      pool: InferPoolFromEventStoreDriver<Driver> & Dumbo;
-      options: InferDumboOptionsFromEventStoreDriver<Driver>;
-    };
+    driver?: Driver;
   } &
     // TODO: This should be only for Init options
     // Make init options type configurable for projections
-    EventStoreSchemaMigrationOptions
+    EventStoreSchemaMigrationOptions,
+  {
+    connection: InferDumboConnectionFromEventStoreDriver<Driver>;
+    transaction: InferTransactionFromEventStoreDriver<Driver>;
+    pool: InferPoolFromEventStoreDriver<Driver>;
+    connectionOptions?: InferDumboOptionsFromEventStoreDriver<Driver>;
+  }
 >;
 
-export const transactionToPostgreSQLProjectionHandlerContext = async <
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+export const transactionToPostgreSQLProjectionHandlerContext = <
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 >(
-  dumboOptions: InferDumboOptionsFromEventStoreDriver<Driver>,
-  pool: Dumbo,
+  session: {
+    pool: Dumbo;
+    driver?: Driver;
+    connectionOptions?: InferDumboOptionsFromEventStoreDriver<Driver>;
+  },
   transaction: AnyDatabaseTransaction,
-): Promise<PostgreSQLProjectionHandlerContext<Driver>> =>
+): PostgreSQLProjectionHandlerContext<Driver> =>
   ({
     execute: transaction.execute,
-    driverType: pool.driverType,
-    connection: {
-      client: await (transaction.connection as AnyConnection).open(),
+    driverType: session.pool.driverType,
+    driver: session.driver,
+    session: {
+      ...session,
+      connection: transaction.connection as AnyConnection,
       transaction: transaction,
-      pool,
-      options: dumboOptions,
     },
     observabilityScope: noopScope,
   }) as PostgreSQLProjectionHandlerContext<Driver>;
@@ -74,7 +78,7 @@ export type PostgreSQLProjectionHandler<
   EventType extends Event = Event,
   EventMetaDataType extends PostgresReadEventMetadata =
     PostgresReadEventMetadata,
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 > = ProjectionHandler<
   EventType,
   EventMetaDataType,
@@ -84,7 +88,7 @@ export type PostgreSQLProjectionHandler<
 export type PostgreSQLProjectionDefinition<
   EventType extends Event = Event,
   EventPayloadType extends Event = EventType,
-  Driver extends AnyEventStoreDriver = PgEventStoreDriver,
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
 > = ProjectionDefinition<
   EventType,
   PostgresReadEventMetadata,
@@ -106,11 +110,10 @@ export const handleProjections = async <EventType extends Event = Event>(
   const {
     projections: allProjections,
     events,
-    connection: { pool, transaction, options: dumboOptions },
+    session,
     partition = defaultTag,
   } = options;
-
-  const client = await transaction.connection.open();
+  const { transaction } = session;
 
   for (const projection of allProjections) {
     const filteredEvents = events.filter(({ type }) =>
@@ -135,12 +138,8 @@ export const handleProjections = async <EventType extends Event = Event>(
 
     await projection.handle(filteredEvents, {
       driverType: options.driverType,
-      connection: {
-        pool,
-        client,
-        transaction,
-        options: dumboOptions,
-      },
+      driver: options.driver,
+      session,
       execute: transaction.execute,
       migrationOptions: options.migrationOptions,
       observabilityScope: options.observabilityScope,

--- a/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjectionSpec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/projections/postgresProjectionSpec.ts
@@ -6,7 +6,7 @@ import {
   type SQL,
 } from '@event-driven-io/dumbo';
 import type { PgPool, PgPoolOptions } from '@event-driven-io/dumbo/pg';
-import { pgEventStoreDriver } from '../../pg';
+import { pgEventStoreDriver, type PgEventStoreDriver } from '../../pg';
 import {
   assertFails,
   AssertionError,
@@ -63,6 +63,7 @@ export type PostgreSQLProjectionSpec<EventType extends Event> = (
 
 export type PostgreSQLProjectionAssert = (options: {
   pool: Dumbo;
+  driver: PgEventStoreDriver;
   connectionString: string;
   migrationOptions?: EventStoreDatabaseSchemaOptions | undefined;
 }) => Promise<void | boolean>;
@@ -115,11 +116,14 @@ export const PostgreSQLProjectionSpec = {
               version: projection.version ?? 1,
               status: 'active',
               context: {
-                ...(await transactionToPostgreSQLProjectionHandlerContext(
-                  dumboOptions,
-                  pool,
+                ...transactionToPostgreSQLProjectionHandlerContext(
+                  {
+                    pool,
+                    driver: pgEventStoreDriver,
+                    connectionOptions: dumboOptions,
+                  },
                   transaction,
-                )),
+                ),
                 migrationOptions,
               },
             });
@@ -176,11 +180,14 @@ export const PostgreSQLProjectionSpec = {
                 await handleProjections<EventType>({
                   events: allEvents,
                   projections: [projection],
-                  ...(await transactionToPostgreSQLProjectionHandlerContext(
-                    dumboOptions,
-                    pool,
+                  ...transactionToPostgreSQLProjectionHandlerContext(
+                    {
+                      pool,
+                      driver: pgEventStoreDriver,
+                      connectionOptions: dumboOptions,
+                    },
                     transaction,
-                  )),
+                  ),
                   migrationOptions,
                 });
               });
@@ -197,6 +204,7 @@ export const PostgreSQLProjectionSpec = {
 
                   const succeeded = await assert({
                     pool,
+                    driver: pgEventStoreDriver,
                     connectionString: connectionString!,
                     migrationOptions,
                   });

--- a/src/packages/emmett-postgresql/src/eventStore/schema/appendToStream.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/appendToStream.int.spec.ts
@@ -62,7 +62,7 @@ void describe('appendEvent', () => {
       },
     });
 
-    await createEventStoreSchema({ connectionString }, pool);
+    await createEventStoreSchema({ pool });
   });
 
   afterAll(async () => {

--- a/src/packages/emmett-postgresql/src/eventStore/schema/appendToStream.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/appendToStream.ts
@@ -167,6 +167,7 @@ type AppendToStreamResult =
 export type AppendToStreamBeforeCommitHook = (
   messages: RecordedMessage[],
   context: {
+    connection: PgConnection;
     transaction: PgTransaction;
   },
 ) => Promise<void>;
@@ -262,7 +263,10 @@ export const appendToStream = (
       });
 
       if (options?.beforeCommitHook)
-        await options.beforeCommitHook(messagesToAppend, { transaction });
+        await options.beforeCommitHook(messagesToAppend, {
+          connection,
+          transaction,
+        });
 
       return {
         success: true,

--- a/src/packages/emmett-postgresql/src/eventStore/schema/createEventStoreSchema.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/createEventStoreSchema.int.spec.ts
@@ -49,7 +49,7 @@ void describe('createEventStoreSchema', () => {
         allowNestedTransactions: true,
       },
     });
-    await createEventStoreSchema({ connectionString }, pool);
+    await createEventStoreSchema({ pool });
   });
 
   afterAll(async () => {
@@ -230,8 +230,11 @@ void describe('createEventStoreSchema with configured database schemas', () => {
   });
 
   void it('creates the event store objects in the schema configured by the user', async () => {
-    await createEventStoreSchema({ connectionString }, pool, undefined, {
-      databaseSchemaName: 'events',
+    await createEventStoreSchema({
+      pool,
+      schema: {
+        databaseSchemaName: 'events',
+      },
     });
 
     assertTrue(await schemaExists(pool.execute, 'events'));
@@ -263,11 +266,14 @@ void describe('createEventStoreSchema with configured database schemas', () => {
   });
 
   void it('uses the migration table schema and name configured by the user', async () => {
-    await createEventStoreSchema({ connectionString }, pool, undefined, {
-      databaseSchemaName: 'store',
-      migrationTable: {
-        schemaName: 'infrastructure',
-        tableName: 'emmett_migrations',
+    await createEventStoreSchema({
+      pool,
+      schema: {
+        databaseSchemaName: 'store',
+        migrationTable: {
+          schemaName: 'infrastructure',
+          tableName: 'emmett_migrations',
+        },
       },
     });
 
@@ -348,10 +354,9 @@ void describe('createEventStoreSchema with configured database schemas', () => {
     let afterMigrationTableSchemaName: string | undefined;
     let afterProjectionsDatabaseSchemaName: string | undefined;
 
-    await createEventStoreSchema(
-      { connectionString },
+    await createEventStoreSchema({
       pool,
-      {
+      hooks: {
         onBeforeSchemaCreated: (context) => {
           beforeMigrationTableSchemaName =
             context.migrationOptions?.migrationTable?.schemaName;
@@ -365,13 +370,13 @@ void describe('createEventStoreSchema with configured database schemas', () => {
             context.migrationOptions?.projectionsDatabaseSchemaName;
         },
       },
-      {
+      schema: {
         databaseSchemaName: eventSchemaName,
         migrationTable: {
           tableName: 'custom_migrations',
         },
       },
-    );
+    });
 
     assertEqual(beforeMigrationTableSchemaName, eventSchemaName);
     assertEqual(beforeProjectionsDatabaseSchemaName, eventSchemaName);

--- a/src/packages/emmett-postgresql/src/eventStore/schema/index.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/index.ts
@@ -1,12 +1,19 @@
 import {
   runSQLMigrations,
+  type Dumbo,
   type RunSQLMigrationsResult,
 } from '@event-driven-io/dumbo';
-import type { PgPool, PgTransaction } from '@event-driven-io/dumbo/pg';
 import type { JSONSerializationOptions } from '@event-driven-io/emmett';
 import type { PostgresEventStoreOptions } from '../postgreSQLEventStore';
-import { transactionToPostgreSQLProjectionHandlerContext } from '../projections';
-import type { PgPoolOptions } from '@event-driven-io/dumbo/pg';
+import {
+  transactionToPostgreSQLProjectionHandlerContext,
+  type PostgreSQLProjectionHandlerContext,
+} from '../projections';
+import type { PgEventStoreDriver } from '../../pg';
+import type {
+  AnyPostgreSQLEventStoreDriver,
+  InferDumboOptionsFromEventStoreDriver,
+} from '../eventStoreDriver';
 import {
   eventStoreDatabaseSchema,
   type EventStoreDatabaseSchemaOptions,
@@ -41,22 +48,24 @@ export type EventStoreSchemaMigrationOptions = {
   migrationOptions?: CreateEventStoreSchemaOptions;
 };
 
-export const createEventStoreSchema = (
-  dumboOptions: PgPoolOptions,
-  pool: PgPool,
-  hooks?: PostgresEventStoreOptions['hooks'],
-  options?: CreateEventStoreSchemaOptions,
-): Promise<RunSQLMigrationsResult> => {
-  return pool.withTransaction(async (tx: PgTransaction) => {
-    const context = await transactionToPostgreSQLProjectionHandlerContext(
-      dumboOptions,
-      pool,
-      tx,
-    );
-
+export const createEventStoreSchema = <
+  Driver extends AnyPostgreSQLEventStoreDriver = PgEventStoreDriver,
+>({
+  hooks,
+  schema: options,
+  ...session
+}: {
+  pool: Dumbo;
+  driver?: Driver;
+  connectionOptions?: InferDumboOptionsFromEventStoreDriver<Driver>;
+  hooks?: PostgresEventStoreOptions<Driver>['hooks'];
+  schema?: CreateEventStoreSchemaOptions;
+}): Promise<RunSQLMigrationsResult> =>
+  session.pool.withTransaction<RunSQLMigrationsResult>(async (tx) => {
+    const { pool } = session;
     const databaseSchema = eventStoreDatabaseSchema(options);
-    const schemaContext = {
-      ...context,
+    const schemaContext: PostgreSQLProjectionHandlerContext<Driver> = {
+      ...transactionToPostgreSQLProjectionHandlerContext(session, tx),
       migrationOptions: {
         ...options,
         ...databaseSchema,
@@ -80,6 +89,6 @@ export const createEventStoreSchema = (
     if (hooks?.onAfterSchemaCreated) {
       await hooks.onAfterSchemaCreated(schemaContext);
     }
+
     return result;
   });
-};

--- a/src/packages/emmett-postgresql/src/eventStore/schema/messagesPollIndex.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/messagesPollIndex.int.spec.ts
@@ -40,7 +40,7 @@ void describe('emt_messages consumer poll index', () => {
       pooled: false,
     });
 
-    await createEventStoreSchema({ connectionString }, pool);
+    await createEventStoreSchema({ pool });
     await seedMessages(defaultTag, 0);
     await pool.execute.command(SQL`ANALYZE emt_messages`);
   });

--- a/src/packages/emmett-postgresql/src/eventStore/schema/readMessagesBatch.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/readMessagesBatch.int.spec.ts
@@ -38,7 +38,7 @@ void describe('reading messages in batches', () => {
       pooled: false,
     });
 
-    await createEventStoreSchema({ connectionString }, pool);
+    await createEventStoreSchema({ pool });
   });
 
   beforeEach(async () => {

--- a/src/packages/emmett-postgresql/src/eventStore/schema/readStream.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/readStream.int.spec.ts
@@ -61,7 +61,7 @@ void describe('readStream', () => {
       },
     });
 
-    await createEventStoreSchema({ connectionString }, pool);
+    await createEventStoreSchema({ pool });
   });
 
   afterAll(async () => {

--- a/src/packages/emmett-postgresql/src/eventStore/schema/storeProcessorCheckpoint.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/storeProcessorCheckpoint.int.spec.ts
@@ -42,7 +42,7 @@ void describe('storeProcessorCheckpoint and readProcessorCheckpoint tests', () =
         allowNestedTransactions: true,
       },
     });
-    await createEventStoreSchema({ connectionString }, pool);
+    await createEventStoreSchema({ pool });
 
     await pool.execute.command(SQL`SELECT emt_add_partition('partition-2')`);
   });

--- a/src/packages/emmett-postgresql/src/eventStore/schema/streamExists.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/streamExists.int.spec.ts
@@ -52,7 +52,7 @@ void describe('streamExists', () => {
       },
     });
 
-    await createEventStoreSchema({ connectionString }, pool);
+    await createEventStoreSchema({ pool });
   });
 
   afterAll(async () => {

--- a/src/packages/emmett-postgresql/src/eventStore/schema/truncateTables.int.spec.ts
+++ b/src/packages/emmett-postgresql/src/eventStore/schema/truncateTables.int.spec.ts
@@ -55,7 +55,7 @@ void describe('truncateTables', () => {
       },
     });
 
-    await createEventStoreSchema({ connectionString }, pool);
+    await createEventStoreSchema({ pool });
   });
 
   afterAll(async () => {
@@ -209,11 +209,17 @@ void describe('truncateTables', () => {
     const resetSchemaName = schemaName('reset_sequences');
     const otherSchemaName = schemaName('other_reset_sequences');
 
-    await createEventStoreSchema({ connectionString }, pool, undefined, {
-      databaseSchemaName: resetSchemaName,
+    await createEventStoreSchema({
+      pool,
+      schema: {
+        databaseSchemaName: resetSchemaName,
+      },
     });
-    await createEventStoreSchema({ connectionString }, pool, undefined, {
-      databaseSchemaName: otherSchemaName,
+    await createEventStoreSchema({
+      pool,
+      schema: {
+        databaseSchemaName: otherSchemaName,
+      },
     });
 
     const events = [createTestEvent()];
@@ -279,11 +285,17 @@ void describe('truncateTables', () => {
     const truncatedSchemaName = schemaName('events');
     const otherSchemaName = schemaName('other_events');
 
-    await createEventStoreSchema({ connectionString }, pool, undefined, {
-      databaseSchemaName: truncatedSchemaName,
+    await createEventStoreSchema({
+      pool,
+      schema: {
+        databaseSchemaName: truncatedSchemaName,
+      },
     });
-    await createEventStoreSchema({ connectionString }, pool, undefined, {
-      databaseSchemaName: otherSchemaName,
+    await createEventStoreSchema({
+      pool,
+      schema: {
+        databaseSchemaName: otherSchemaName,
+      },
     });
 
     const events = [createTestEvent()];

--- a/src/packages/emmett-postgresql/src/pg.ts
+++ b/src/packages/emmett-postgresql/src/pg.ts
@@ -1,24 +1,24 @@
 import type { PgPoolOptions } from '@event-driven-io/dumbo/pg';
 import { pgDumboDriver } from '@event-driven-io/dumbo/pg';
+import { pgDriver as pgPongoDriver } from '@event-driven-io/pongo/pg';
 import type { PostgresEventStoreDriverOptions } from './eventStore';
 import type { EventStoreDriver } from './eventStore/eventStoreDriver';
 
-export const pgEventStoreDriver: EventStoreDriver<
-  typeof pgDumboDriver,
-  PgEventStoreDriverOptions
-> = {
+export const pgEventStoreDriver = {
   driverType: pgDumboDriver.driverType,
   dumboDriver: pgDumboDriver,
-  mapToDumboOptions: (driverOptions) =>
+  pongoDriver: pgPongoDriver,
+  mapToDumboOptions: (options) =>
     ({
       driver: pgDumboDriver,
-      connectionString: driverOptions.connectionString,
-      ...driverOptions.connectionOptions,
+      connectionString: options.connectionString,
+      ...options.connectionOptions,
       transactionOptions: {
         allowNestedTransactions: true,
+        ...options.connectionOptions?.transactionOptions,
       },
     }) as unknown as PgPoolOptions,
-};
+} satisfies EventStoreDriver<typeof pgDumboDriver, PgEventStoreDriverOptions>;
 
 export type PgEventStoreDriver = typeof pgEventStoreDriver;
 

--- a/src/packages/emmett-postgresql/src/pg.unit.spec.ts
+++ b/src/packages/emmett-postgresql/src/pg.unit.spec.ts
@@ -1,6 +1,7 @@
 import type { PgPoolOptions } from '@event-driven-io/dumbo/pg';
 import { pgDumboDriver } from '@event-driven-io/dumbo/pg';
 import { assertEqual } from '@event-driven-io/emmett';
+import { pgDriver as pgPongoDriver } from '@event-driven-io/pongo/pg';
 import { describe, it } from 'vitest';
 import { pgEventStoreDriver, type PgEventStoreDriverOptions } from './pg';
 
@@ -38,6 +39,10 @@ void describe('pgEventStoreDriver', () => {
     assertEqual('emmett_other', options.database);
   });
 
+  void it('carries the Pongo driver its projections need', () => {
+    assertEqual<unknown>(pgPongoDriver, pgEventStoreDriver.pongoDriver);
+  });
+
   void it('carries the driver for every supported option shape', () => {
     const shapes: PgEventStoreDriverOptions[] = [
       { connectionString },
@@ -65,5 +70,16 @@ void describe('pgEventStoreDriver', () => {
       pgEventStoreDriver.mapToDumboOptions({ connectionString })
         .transactionOptions?.allowNestedTransactions,
     );
+  });
+
+  void it('keeps the transaction options the caller set explicitly', () => {
+    const { transactionOptions } = pgEventStoreDriver.mapToDumboOptions({
+      connectionString,
+      connectionOptions: {
+        transactionOptions: { allowNestedTransactions: false },
+      },
+    });
+
+    assertEqual(false, transactionOptions?.allowNestedTransactions);
   });
 });

--- a/src/packages/emmett-sqlite/package.json
+++ b/src/packages/emmett-sqlite/package.json
@@ -93,10 +93,10 @@
   ],
   "dependencies": {
     "@event-driven-io/emmett": "0.43.0-beta.43",
-    "@event-driven-io/pongo": "0.17.0-beta.50"
+    "@event-driven-io/pongo": "0.17.0-beta.52"
   },
   "peerDependencies": {
-    "@cloudflare/workers-types": "^4.20260421.1",
+    "@cloudflare/workers-types": "^5.20260831.1",
     "sqlite3": "^6.0.1"
   },
   "peerDependenciesMeta": {
@@ -108,7 +108,7 @@
     }
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260421.1",
+    "@cloudflare/workers-types": "^5.20260831.1",
     "miniflare": "^4.20260420.0",
     "@types/node": "^25.6.0",
     "sqlite3": "^6.0.1"

--- a/src/packages/emmett-sqlite/src/cloudflare.ts
+++ b/src/packages/emmett-sqlite/src/cloudflare.ts
@@ -3,25 +3,25 @@ import {
   d1DumboDriver,
   type D1PoolOptions,
 } from '@event-driven-io/dumbo/cloudflare';
+import { pongoDriver as d1PongoDriver } from '@event-driven-io/pongo/cloudflare';
 import type { SQLiteEventStoreOptions } from './eventStore';
 import type { EventStoreDriver } from './eventStore/eventStoreDriver';
 
-export const d1EventStoreDriver: EventStoreDriver<
-  typeof d1DumboDriver,
-  D1EventStoreDriverOptions
-> = {
+export const d1EventStoreDriver = {
   driverType: d1DumboDriver.driverType,
   dumboDriver: d1DumboDriver,
-  mapToDumboOptions: (driverOptions) => ({
+  pongoDriver: d1PongoDriver,
+  mapToDumboOptions: (options) => ({
     driver: d1DumboDriver,
-    database: driverOptions.database,
-    ...driverOptions.connectionOptions,
+    database: options.database,
+    ...options.connectionOptions,
     transactionOptions: {
       allowNestedTransactions: true,
       mode: 'session_based',
+      ...options.connectionOptions?.transactionOptions,
     },
   }),
-};
+} satisfies EventStoreDriver<typeof d1DumboDriver, D1EventStoreDriverOptions>;
 
 export type D1EventStoreDriver = typeof d1EventStoreDriver;
 

--- a/src/packages/emmett-sqlite/src/cloudflare.unit.spec.ts
+++ b/src/packages/emmett-sqlite/src/cloudflare.unit.spec.ts
@@ -1,0 +1,50 @@
+import type { D1Database } from '@cloudflare/workers-types';
+import { d1DumboDriver } from '@event-driven-io/dumbo/cloudflare';
+import { assertEqual } from '@event-driven-io/emmett';
+import { pongoDriver as d1PongoDriver } from '@event-driven-io/pongo/cloudflare';
+import { describe, it } from 'vitest';
+import { d1EventStoreDriver } from './cloudflare';
+
+const database = {} as D1Database;
+
+void describe('d1EventStoreDriver', () => {
+  void it('names the same driver type as the dumbo driver it wraps', () => {
+    assertEqual(d1DumboDriver.driverType, d1EventStoreDriver.driverType);
+    assertEqual(d1DumboDriver, d1EventStoreDriver.dumboDriver);
+  });
+
+  void it('carries the Pongo driver its projections need', () => {
+    assertEqual<unknown>(d1PongoDriver, d1EventStoreDriver.pongoDriver);
+  });
+
+  void it('carries the driver and the database it was given', () => {
+    const options = d1EventStoreDriver.mapToDumboOptions({ database });
+
+    assertEqual<unknown>(
+      d1DumboDriver,
+      (options as { driver?: unknown }).driver,
+    );
+    assertEqual(database, options.database);
+  });
+
+  void it('runs D1 transactions in session mode, nested calls allowed', () => {
+    const { transactionOptions } = d1EventStoreDriver.mapToDumboOptions({
+      database,
+    });
+
+    assertEqual(true, transactionOptions?.allowNestedTransactions);
+    assertEqual('session_based', transactionOptions?.mode);
+  });
+
+  void it('keeps the transaction options the caller set explicitly', () => {
+    const { transactionOptions } = d1EventStoreDriver.mapToDumboOptions({
+      database,
+      connectionOptions: {
+        transactionOptions: { allowNestedTransactions: false, mode: 'strict' },
+      },
+    });
+
+    assertEqual(false, transactionOptions?.allowNestedTransactions);
+    assertEqual('strict', transactionOptions?.mode);
+  });
+});

--- a/src/packages/emmett-sqlite/src/eslintRules.unit.spec.ts
+++ b/src/packages/emmett-sqlite/src/eslintRules.unit.spec.ts
@@ -1,0 +1,124 @@
+import { assertEqual, assertOk, assertTrue } from '@event-driven-io/emmett';
+import { Linter } from 'eslint';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { describe, it } from 'vitest';
+
+type RestrictedImportPath = {
+  name: string;
+  message?: string;
+  allowTypeImports?: boolean;
+};
+
+type EslintConfigEntry = {
+  files?: ReadonlyArray<string>;
+  ignores?: ReadonlyArray<string>;
+  rules?: Record<string, unknown>;
+};
+
+const sqliteImportFiles = ['packages/emmett-sqlite/**'];
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../..',
+);
+
+const restrictedImportsFor = async (
+  files: ReadonlyArray<string>,
+): Promise<{
+  paths: ReadonlyArray<RestrictedImportPath>;
+  ignores: ReadonlyArray<string>;
+}> => {
+  const config = (await import(
+    pathToFileURL(path.join(repoRoot, 'eslint.config.mjs')).href
+  )) as { default: unknown };
+
+  const entry = (config.default as EslintConfigEntry[]).find(
+    (candidate) =>
+      Array.isArray(candidate.files) &&
+      candidate.files.length === files.length &&
+      candidate.files.every((file, index) => file === files[index]) &&
+      candidate.rules?.['@typescript-eslint/no-restricted-imports'] !==
+        undefined,
+  );
+  assertOk(entry, `Expected ESLint config for ${files.join(', ')}`);
+
+  const rule = entry.rules?.['@typescript-eslint/no-restricted-imports'];
+  assertTrue(
+    Array.isArray(rule),
+    'Expected @typescript-eslint/no-restricted-imports rule',
+  );
+  assertEqual((rule as unknown[])[0], 'error');
+
+  return {
+    paths: ((rule as unknown[])[1] as { paths: RestrictedImportPath[] }).paths,
+    ignores: entry.ignores ?? [],
+  };
+};
+
+const lintWithRestrictedImports = (
+  code: string,
+  paths: ReadonlyArray<RestrictedImportPath>,
+) =>
+  new Linter().verify(code, {
+    languageOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        { paths: paths.map(({ name, message }) => ({ name, message })) },
+      ],
+    },
+  });
+
+void describe('Emmett ESLint dumbo SQLite import restrictions', () => {
+  void it('restricts both SQLite driver modules', async () => {
+    const { paths } = await restrictedImportsFor(sqliteImportFiles);
+
+    for (const name of [
+      '@event-driven-io/dumbo/sqlite3',
+      '@event-driven-io/dumbo/cloudflare',
+    ]) {
+      const restricted = paths.find((candidate) => candidate.name === name);
+
+      assertOk(
+        restricted,
+        `Expected '${name}' to be restricted. Got: ${JSON.stringify(paths)}`,
+      );
+      assertTrue(
+        restricted.allowTypeImports === true,
+        `Expected type-only imports of '${name}' to stay allowed`,
+      );
+    }
+  });
+
+  void it('exempts the driver seams, the testing helpers and the specs', async () => {
+    const { ignores } = await restrictedImportsFor(sqliteImportFiles);
+
+    for (const exempt of [
+      'packages/emmett-sqlite/**/*.spec.ts',
+      'packages/emmett-sqlite/src/sqlite3.ts',
+      'packages/emmett-sqlite/src/cloudflare.ts',
+      'packages/emmett-sqlite/src/testing/**',
+    ])
+      assertTrue(
+        ignores.includes(exempt),
+        `Expected '${exempt}' to be exempt. Got: ${JSON.stringify(ignores)}`,
+      );
+  });
+
+  void it('rejects a value import of either driver module', async () => {
+    const { paths } = await restrictedImportsFor(sqliteImportFiles);
+
+    for (const code of [
+      `import { sqlite3DumboDriver } from '@event-driven-io/dumbo/sqlite3';\n`,
+      `import { d1DumboDriver } from '@event-driven-io/dumbo/cloudflare';\n`,
+    ]) {
+      const messages = lintWithRestrictedImports(code, paths);
+
+      assertTrue(
+        messages.some(({ ruleId }) => ruleId === 'no-restricted-imports'),
+        `Expected a restricted import violation. Got: ${JSON.stringify(messages)}`,
+      );
+    }
+  });
+});

--- a/src/packages/emmett-sqlite/src/eventStore/SQLiteEventStore.registry.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/SQLiteEventStore.registry.int.spec.ts
@@ -1,0 +1,87 @@
+import { assertEqual, assertTrue } from '@event-driven-io/emmett';
+import { v4 as uuid } from 'uuid';
+import { afterAll, beforeAll, describe, it } from 'vitest';
+import { sqlite3EventStoreDriver } from '../sqlite3';
+import { clearRegisteredDumboDrivers } from '../testing/dumboDriverIsolation';
+import type {
+  PricedProductItem,
+  ShoppingCartEvent,
+} from '../testing/shoppingCart.domain';
+import { deleteSQLiteDatabaseFiles } from '../testing/sqliteTestDatabase';
+import { getSQLiteEventStore, type SQLiteEventStore } from './SQLiteEventStore';
+
+void describe('SQLite event store without registered dumbo drivers', () => {
+  let fileName: string;
+  let restoreDumboDrivers: () => void;
+
+  const productItem: PricedProductItem = {
+    productId: '123',
+    quantity: 10,
+    price: 3,
+  };
+
+  const migrateAppendAndRead = async (eventStore: SQLiteEventStore) => {
+    await eventStore.schema.migrate();
+
+    const shoppingCartId = `shopping_cart-${uuid()}`;
+
+    const appended = await eventStore.appendToStream<ShoppingCartEvent>(
+      shoppingCartId,
+      [
+        { type: 'ProductItemAdded', data: { productItem } },
+        { type: 'DiscountApplied', data: { percent: 10, couponId: uuid() } },
+      ],
+    );
+
+    assertEqual(2n, appended.nextExpectedStreamVersion);
+    assertEqual(true, appended.createdNewStream);
+
+    const { events, currentStreamVersion, streamExists } =
+      await eventStore.readStream<ShoppingCartEvent>(shoppingCartId);
+
+    assertTrue(streamExists);
+    assertEqual(2n, currentStreamVersion);
+    assertEqual(2, events.length);
+    assertEqual('ProductItemAdded', events[0]!.type);
+    assertEqual('DiscountApplied', events[1]!.type);
+  };
+
+  beforeAll(() => {
+    fileName = `./test-registry-${uuid()}.db`;
+    restoreDumboDrivers = clearRegisteredDumboDrivers();
+  });
+
+  afterAll(() => {
+    restoreDumboDrivers?.();
+    deleteSQLiteDatabaseFiles(fileName);
+  });
+
+  void it('builds its own pool from the driver it was given', async () => {
+    const eventStore = getSQLiteEventStore({
+      driver: sqlite3EventStoreDriver,
+      fileName,
+      schema: { autoMigration: 'None' },
+    });
+
+    try {
+      await migrateAppendAndRead(eventStore);
+    } finally {
+      await eventStore.close();
+    }
+  });
+
+  void it('connects from driver connection options alone', async () => {
+    const eventStore = getSQLiteEventStore({
+      driver: sqlite3EventStoreDriver,
+      fileName,
+      schema: { autoMigration: 'None' },
+      connectionOptions: { singleton: true },
+    });
+
+    try {
+      await migrateAppendAndRead(eventStore);
+    } finally {
+      await eventStore.close();
+    }
+  });
+});

--- a/src/packages/emmett-sqlite/src/eventStore/SQLiteEventStore.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/SQLiteEventStore.ts
@@ -2,6 +2,7 @@ import {
   dumbo,
   fromDatabaseDriverType,
   getFormatter,
+  type AnyDatabaseTransaction,
   type Dumbo,
   type RunSQLMigrationsResult,
 } from '@event-driven-io/dumbo';
@@ -43,11 +44,13 @@ import {
   type SQLiteEventStoreConsumerConfig,
 } from './consumers';
 import type {
-  AnyEventStoreDriver,
-  InferOptionsFromEventStoreDriver,
+  AnySQLiteEventStoreDriver,
+  InferDumboOptionsFromEventStoreDriver,
+  PoolOrConnectionOptions,
 } from './eventStoreDriver';
 import {
   handleProjections,
+  transactionToSQLiteProjectionHandlerContext,
   type SQLiteProjectionHandlerContext,
 } from './projections';
 import {
@@ -110,13 +113,14 @@ export type SQLiteReadEvent<EventType extends Event = Event> = ReadEvent<
 >;
 
 export type SQLiteEventStoreOptions<
-  EventStoreDriver extends AnyEventStoreDriver = AnyEventStoreDriver,
+  EventStoreDriver extends AnySQLiteEventStoreDriver =
+    AnySQLiteEventStoreDriver,
 > = {
   driver: EventStoreDriver;
   projections?: ProjectionRegistration<
     'inline',
     SQLiteReadEventMetadata,
-    SQLiteProjectionHandlerContext
+    SQLiteProjectionHandlerContext<EventStoreDriver>
   >[];
   observability?: EmmettObservabilityConfig;
   schema?: {
@@ -127,7 +131,7 @@ export type SQLiteEventStoreOptions<
      * This hook will be called **BEFORE** event store schema is created
      */
     onBeforeSchemaCreated?: (
-      context: SQLiteProjectionHandlerContext,
+      context: SQLiteProjectionHandlerContext<EventStoreDriver>,
     ) => Promise<void> | void;
     /**
      * This hook will be called **BEFORE** events were stored in the event store.
@@ -135,20 +139,23 @@ export type SQLiteEventStoreOptions<
      */
     onBeforeCommit?: BeforeEventStoreCommitHandler<
       SQLiteEventStore,
-      { connection: AnySQLiteConnection }
+      {
+        connection: AnySQLiteConnection;
+        transaction: AnyDatabaseTransaction;
+      }
     >;
     /**
      * This hook will be called **AFTER** event store schema was created
      */
     onAfterSchemaCreated?: (
-      context: SQLiteProjectionHandlerContext,
+      context: SQLiteProjectionHandlerContext<EventStoreDriver>,
     ) => Promise<void> | void;
   };
-} & { pool?: Dumbo } & InferOptionsFromEventStoreDriver<EventStoreDriver> &
+} & PoolOrConnectionOptions<EventStoreDriver> &
   JSONSerializationOptions;
 
 export const getSQLiteEventStore = <
-  Driver extends AnyEventStoreDriver = AnyEventStoreDriver,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
 >(
   options: SQLiteEventStoreOptions<Driver>,
 ): SQLiteEventStore => {
@@ -158,16 +165,18 @@ export const getSQLiteEventStore = <
 
   const databaseSchema = eventStoreDatabaseSchema(options.schema);
 
-  const pool =
-    options.pool ??
-    dumbo({
-      serialization: options.serialization,
-      transactionOptions: {
-        allowNestedTransactions: true,
-        mode: 'session_based',
-      },
-      ...options.driver.mapToDumboOptions(options),
-    });
+  const dumboOptions = {
+    serialization: options.serialization,
+    ...options.driver.mapToDumboOptions(options),
+  } as InferDumboOptionsFromEventStoreDriver<Driver>;
+
+  const pool: Dumbo = options.pool ?? dumbo(dumboOptions);
+
+  const session = {
+    pool,
+    driver: options.driver,
+    connectionOptions: dumboOptions,
+  };
   let migrateSchema: Promise<RunSQLMigrationsResult> | undefined = undefined;
 
   const inlineProjections = (options.projections ?? [])
@@ -197,10 +206,13 @@ export const getSQLiteEventStore = <
         ...eventStoreDatabaseSchema(migrationSchemaOptions),
       };
 
-      const migration = createEventStoreSchema(
-        pool,
-        {
-          onBeforeSchemaCreated: async (context) => {
+      const migration = createEventStoreSchema({
+        ...session,
+        hooks: {
+          onBeforeSchemaCreated: async (untypedContext) => {
+            // TODO: Fix this cast when the pool plumbing is driver-generic
+            const context =
+              untypedContext as SQLiteProjectionHandlerContext<Driver>;
             for (const projection of inlineProjections) {
               if (projection.init) {
                 await projection.init({
@@ -215,14 +227,18 @@ export const getSQLiteEventStore = <
               await options.hooks.onBeforeSchemaCreated(context);
             }
           },
-          onAfterSchemaCreated: async (context) => {
+          onAfterSchemaCreated: async (untypedContext) => {
+            // TODO: Fix this cast when the pool plumbing is driver-generic
+            const context =
+              untypedContext as SQLiteProjectionHandlerContext<Driver>;
+
             if (options.hooks?.onAfterSchemaCreated) {
               await options.hooks.onAfterSchemaCreated(context);
             }
           },
         },
-        schemaMigrationOptions,
-      );
+        schema: schemaMigrationOptions,
+      });
 
       if (migrationOptions?.dryRun) {
         return migration;
@@ -380,9 +396,10 @@ export const getSQLiteEventStore = <
                         handleProjections({
                           projections: inlineProjections,
                           events: messages,
-                          execute: context.connection.execute,
-                          connection: context.connection,
-                          driverType: options.driver.driverType,
+                          ...transactionToSQLiteProjectionHandlerContext(
+                            session,
+                            context.transaction,
+                          ),
                           migrationOptions: databaseSchema,
                           observabilityScope,
                         }),
@@ -445,14 +462,9 @@ export const getSQLiteEventStore = <
         const sessionStore = getSQLiteEventStore({
           ...options,
           pool: dumbo({
-            ...options.driver.mapToDumboOptions(options),
+            ...dumboOptions,
             connection,
-            serialization: options.serialization,
           }),
-          transactionOptions: {
-            allowNestedTransactions: true,
-            mode: 'session_based',
-          },
           schema: {
             ...options.schema,
             autoMigration: 'None',
@@ -485,11 +497,11 @@ export const getSQLiteEventStore = <
             });
 
             if (truncateOptions?.truncateProjections) {
-              const projectionContext = {
-                execute: transaction.execute,
-                connection: transaction.connection as AnySQLiteConnection,
-                driverType: options.driver.driverType,
-              };
+              const projectionContext =
+                transactionToSQLiteProjectionHandlerContext(
+                  session,
+                  transaction,
+                );
 
               for (const projection of options?.projections ?? []) {
                 if (projection.projection.truncate)

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/index.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/index.ts
@@ -1,3 +1,4 @@
 export * from './messageSource';
+export * from './rebuildSQLiteProjections';
 export * from './sqliteEventStoreConsumer';
 export * from './sqliteProcessor';

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/rebuildSQLiteProjections.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/rebuildSQLiteProjections.int.spec.ts
@@ -1,0 +1,254 @@
+import { sqlite3Pool, type SQLitePool } from '@event-driven-io/dumbo/sqlite3';
+import {
+  assertDeepEqual,
+  projections,
+  type ReadEvent,
+} from '@event-driven-io/emmett';
+import {
+  pongoClient,
+  type PongoClient,
+  type PongoCollection,
+} from '@event-driven-io/pongo';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { v4 as uuid } from 'uuid';
+import { afterEach, beforeEach, describe, it } from 'vitest';
+import { sqlite3EventStoreDriver } from '../../sqlite3';
+import type {
+  ProductItemAdded,
+  ShoppingCartConfirmed,
+} from '../../testing/shoppingCart.domain';
+import { deleteSQLiteDatabaseFiles } from '../../testing/sqliteTestDatabase';
+import { pongoDriverOf } from '../eventStoreDriver';
+import { pongoSingleStreamProjection } from '../projections';
+import {
+  getSQLiteEventStore,
+  type SQLiteEventStore,
+} from '../SQLiteEventStore';
+import { rebuildSQLiteProjections } from './rebuildSQLiteProjections';
+
+const withDeadline = { timeout: 30000 };
+
+void describe('Rebuilding SQLite projections', () => {
+  const testDatabasePath = path.dirname(fileURLToPath(import.meta.url));
+  const fileName = path.resolve(testDatabasePath, 'rebuild.test.db');
+  const productItem = { price: 10, productId: uuid(), quantity: 10 };
+  const confirmedAt = new Date();
+  const events: ShoppingCartSummaryEvent[] = [
+    { type: 'ProductItemAdded', data: { productItem } },
+    { type: 'ShoppingCartConfirmed', data: { confirmedAt } },
+  ];
+
+  let pool: SQLitePool;
+  let eventStore: SQLiteEventStore;
+  let pongo: PongoClient;
+  let summaries: PongoCollection<ShoppingCartSummary>;
+  let otherSummaries: PongoCollection<ShoppingCartSummary>;
+
+  beforeEach(() => {
+    pool = sqlite3Pool({
+      fileName,
+      transactionOptions: { allowNestedTransactions: true },
+    });
+    eventStore = getSQLiteEventStore({
+      driver: sqlite3EventStoreDriver,
+      schema: { autoMigration: 'CreateOrUpdate' },
+      fileName,
+      pool,
+      projections: projections.inline([
+        shoppingCartsSummaryProjection,
+        otherShoppingCartsSummaryProjection,
+      ]),
+    });
+    pongo = pongoClient({
+      driver: pongoDriverOf(sqlite3EventStoreDriver),
+      connectionOptions: {
+        fileName,
+        transactionOptions: { allowNestedTransactions: true },
+      },
+    });
+    summaries = pongo.db().collection(shoppingCartsSummaryCollectionName);
+    otherSummaries = pongo
+      .db()
+      .collection(otherShoppingCartsSummaryCollectionName);
+  });
+
+  afterEach(async () => {
+    await pongo.close();
+    await eventStore.close();
+    await pool.close();
+    deleteSQLiteDatabaseFiles(fileName);
+  });
+
+  void it('rebuilds a single inline projection', withDeadline, async () => {
+    // Given
+    const streamName = `shopping_cart-shoppingCart:${uuid()}`;
+    await eventStore.appendToStream(streamName, events);
+
+    assertDeepEqual(await summaries.findOne({ _id: streamName }), {
+      _id: streamName,
+      status: 'confirmed',
+      _version: 1n,
+      productItemsCount: productItem.quantity,
+    });
+
+    // When
+    const consumer = rebuildSQLiteProjections({
+      driver: sqlite3EventStoreDriver,
+      fileName,
+      projection: shoppingCartsSummaryProjectionNew,
+    });
+
+    try {
+      await consumer.start();
+
+      // Then
+      assertDeepEqual(await summaries.findOne({ _id: streamName }), {
+        _id: streamName,
+        status: 'confirmed',
+        _version: 1n,
+        productItemsCount: productItem.quantity * v2QuantityMultiplier,
+      });
+    } finally {
+      await consumer.close();
+    }
+  });
+
+  void it('rebuilds multiple inline projections', withDeadline, async () => {
+    // Given
+    const streamName = `shopping_cart-shoppingCart:${uuid()}`;
+    const otherStreamName = `shopping_cart-shoppingCart:${uuid()}`;
+
+    await eventStore.appendToStream(streamName, events);
+    await eventStore.appendToStream(otherStreamName, events);
+
+    assertDeepEqual(
+      await summaries.findOne({ _id: streamName }),
+      await otherSummaries.findOne({ _id: streamName }),
+    );
+
+    // When
+    const consumer = rebuildSQLiteProjections({
+      driver: sqlite3EventStoreDriver,
+      fileName,
+      projections: [
+        shoppingCartsSummaryProjectionNew,
+        otherShoppingCartsSummaryProjectionNew,
+      ],
+    });
+
+    try {
+      await consumer.start();
+
+      // Then
+      for (const collection of [summaries, otherSummaries]) {
+        for (const stream of [streamName, otherStreamName]) {
+          assertDeepEqual(await collection.findOne({ _id: stream }), {
+            _id: stream,
+            status: 'confirmed',
+            _version: 1n,
+            productItemsCount: productItem.quantity * v2QuantityMultiplier,
+          });
+        }
+      }
+    } finally {
+      await consumer.close();
+    }
+  });
+
+  void it(
+    'leaves no documents behind for streams that were rebuilt',
+    withDeadline,
+    async () => {
+      // Given
+      const streamNames = [
+        `shopping_cart-shoppingCart:${uuid()}`,
+        `shopping_cart-shoppingCart:${uuid()}`,
+      ];
+
+      for (const streamName of streamNames)
+        await eventStore.appendToStream(streamName, events);
+
+      // When
+      const consumer = rebuildSQLiteProjections({
+        driver: sqlite3EventStoreDriver,
+        fileName,
+        projection: shoppingCartsSummaryProjectionNew,
+      });
+
+      try {
+        await consumer.start();
+
+        // Then
+        const documents = await summaries.find({});
+
+        assertDeepEqual(documents.length, streamNames.length);
+      } finally {
+        await consumer.close();
+      }
+    },
+  );
+});
+
+type ShoppingCartSummary = {
+  _id?: string;
+  productItemsCount: number;
+  status: string;
+};
+
+type ShoppingCartSummaryEvent = ProductItemAdded | ShoppingCartConfirmed;
+
+const shoppingCartsSummaryCollectionName = 'shoppingCartsSummary';
+const otherShoppingCartsSummaryCollectionName = 'otherShoppingCartsSummary';
+
+const v2QuantityMultiplier = 2;
+
+const productItemQuantity = (
+  document: ShoppingCartSummary,
+  { type, data }: ReadEvent<ShoppingCartSummaryEvent>,
+  multiplier: number,
+): ShoppingCartSummary => {
+  switch (type) {
+    case 'ProductItemAdded':
+      return {
+        ...document,
+        productItemsCount:
+          document.productItemsCount + data.productItem.quantity * multiplier,
+      };
+    case 'ShoppingCartConfirmed':
+      return { ...document, status: 'confirmed' };
+    default:
+      return document;
+  }
+};
+
+const summaryProjection = (collectionName: string, multiplier: number) =>
+  pongoSingleStreamProjection({
+    collectionName,
+    canHandle: ['ProductItemAdded', 'ShoppingCartConfirmed'],
+    evolve: (
+      document: ShoppingCartSummary,
+      event: ReadEvent<ShoppingCartSummaryEvent>,
+    ) => productItemQuantity(document, event, multiplier),
+    initialState: () => ({ status: 'pending', productItemsCount: 0 }),
+  });
+
+const shoppingCartsSummaryProjection = summaryProjection(
+  shoppingCartsSummaryCollectionName,
+  1,
+);
+
+const shoppingCartsSummaryProjectionNew = summaryProjection(
+  shoppingCartsSummaryCollectionName,
+  v2QuantityMultiplier,
+);
+
+const otherShoppingCartsSummaryProjection = summaryProjection(
+  otherShoppingCartsSummaryCollectionName,
+  1,
+);
+
+const otherShoppingCartsSummaryProjectionNew = summaryProjection(
+  otherShoppingCartsSummaryCollectionName,
+  v2QuantityMultiplier,
+);

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/rebuildSQLiteProjections.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/rebuildSQLiteProjections.ts
@@ -1,0 +1,88 @@
+import {
+  getProjectorId,
+  unknownTag,
+  type AnyEvent,
+  type ProjectorOptions,
+  type ReadEventMetadataWithGlobalPosition,
+} from '@event-driven-io/emmett';
+import type { AnySQLiteEventStoreDriver } from '../eventStoreDriver';
+import type { SQLiteProjectionDefinition } from '../projections';
+import {
+  sqliteEventStoreConsumer,
+  type SQLiteEventStoreConsumer,
+  type SQLiteEventStoreConsumerConfig,
+  type SQLiteEventStoreConsumerConnectionOptions,
+} from './sqliteEventStoreConsumer';
+import type { SQLiteProcessorHandlerContext } from './sqliteProcessor';
+
+export type RebuildSQLiteProjectionsOptions<
+  EventType extends AnyEvent = AnyEvent,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
+> = Omit<SQLiteEventStoreConsumerConfig<EventType>, 'stopWhen' | 'processors'> &
+  SQLiteEventStoreConsumerConnectionOptions<EventType, Driver> &
+  (
+    | {
+        projections: (
+          | ProjectorOptions<
+              EventType,
+              ReadEventMetadataWithGlobalPosition,
+              SQLiteProcessorHandlerContext<Driver>
+            >
+          | SQLiteProjectionDefinition<EventType, EventType, Driver>
+        )[];
+      }
+    | ProjectorOptions<
+        EventType,
+        ReadEventMetadataWithGlobalPosition,
+        SQLiteProcessorHandlerContext<Driver>
+      >
+  );
+
+export const rebuildSQLiteProjections = <
+  EventType extends AnyEvent = AnyEvent,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
+>(
+  options: RebuildSQLiteProjectionsOptions<EventType, Driver>,
+): SQLiteEventStoreConsumer<EventType, Driver> => {
+  const consumer = sqliteEventStoreConsumer<EventType, Driver>({
+    ...options,
+    stopWhen: { noMessagesLeft: true },
+  });
+
+  const projections: (Omit<
+    ProjectorOptions<
+      EventType,
+      ReadEventMetadataWithGlobalPosition,
+      SQLiteProcessorHandlerContext<Driver>
+    >,
+    'processorId'
+  > & { processorId?: string })[] =
+    'projections' in options
+      ? options.projections.map((p) =>
+          'projection' in p
+            ? {
+                truncateOnStart: true,
+                processorId: getProjectorId({
+                  projectionName: p.projection.name ?? unknownTag,
+                }),
+                ...p,
+              }
+            : {
+                projection: p,
+                processorId: getProjectorId({
+                  projectionName: p.name ?? unknownTag,
+                }),
+                truncateOnStart: true,
+              },
+        )
+      : [options];
+
+  for (const projectionDefinition of projections) {
+    consumer.projector({
+      ...projectionDefinition,
+      truncateOnStart: projectionDefinition.truncateOnStart ?? true,
+    });
+  }
+
+  return consumer;
+};

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/rebuildSQLiteProjections.unit.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/rebuildSQLiteProjections.unit.spec.ts
@@ -1,0 +1,258 @@
+import { assertEqual, assertOk } from '@event-driven-io/emmett';
+import { v7 as uuid } from 'uuid';
+import { describe, it } from 'vitest';
+import { sqlite3EventStoreDriver } from '../../sqlite3';
+import { rebuildSQLiteProjections } from './rebuildSQLiteProjections';
+
+const connectionOptions = {
+  driver: sqlite3EventStoreDriver,
+  fileName: ':memory:',
+};
+
+const dummyProjection = (name: string) => ({
+  name,
+  canHandle: [],
+  handle: () => Promise.resolve(),
+});
+
+void describe('rebuildSQLiteProjections', () => {
+  void describe('single projection via projection option', () => {
+    void it('should create consumer with single processor', () => {
+      // Given
+      const projectionName = `projection_${uuid()}`;
+
+      // When
+      const consumer = rebuildSQLiteProjections({
+        ...connectionOptions,
+        projection: dummyProjection(projectionName),
+      });
+
+      // Then
+      assertEqual(consumer.processors.length, 1);
+    });
+
+    void it('should generate processorId from projection name', () => {
+      // Given
+      const projectionName = `projection_${uuid()}`;
+
+      // When
+      const consumer = rebuildSQLiteProjections({
+        ...connectionOptions,
+        projection: dummyProjection(projectionName),
+      });
+
+      // Then
+      assertEqual(
+        consumer.processors[0]!.id,
+        `emt:processor:projector:${projectionName}`,
+      );
+    });
+
+    void it('should set processor type to projector', () => {
+      // Given
+      const projectionName = `projection_${uuid()}`;
+
+      // When
+      const consumer = rebuildSQLiteProjections({
+        ...connectionOptions,
+        projection: dummyProjection(projectionName),
+      });
+
+      // Then
+      assertEqual(consumer.processors[0]!.type, 'projector');
+    });
+  });
+
+  void describe('multiple projections via projections option', () => {
+    void it('should create consumer with multiple processors for projection definitions', () => {
+      // Given
+      const projection1Name = `projection1_${uuid()}`;
+      const projection2Name = `projection2_${uuid()}`;
+
+      // When
+      const consumer = rebuildSQLiteProjections({
+        ...connectionOptions,
+        projections: [
+          dummyProjection(projection1Name),
+          dummyProjection(projection2Name),
+        ],
+      });
+
+      // Then
+      assertEqual(consumer.processors.length, 2);
+      assertEqual(
+        consumer.processors[0]!.id,
+        `emt:processor:projector:${projection1Name}`,
+      );
+      assertEqual(
+        consumer.processors[1]!.id,
+        `emt:processor:projector:${projection2Name}`,
+      );
+    });
+
+    void it('should create consumer with multiple processors for projector options', () => {
+      // Given
+      const projection1Name = `projection1_${uuid()}`;
+      const projection2Name = `projection2_${uuid()}`;
+
+      // When
+      const consumer = rebuildSQLiteProjections({
+        ...connectionOptions,
+        projections: [
+          { projection: dummyProjection(projection1Name) },
+          { projection: dummyProjection(projection2Name) },
+        ],
+      });
+
+      // Then
+      assertEqual(consumer.processors.length, 2);
+      assertEqual(
+        consumer.processors[0]!.id,
+        `emt:processor:projector:${projection1Name}`,
+      );
+      assertEqual(
+        consumer.processors[1]!.id,
+        `emt:processor:projector:${projection2Name}`,
+      );
+    });
+
+    void it('should handle mixed projection definitions and projector options', () => {
+      // Given
+      const projection1Name = `projection1_${uuid()}`;
+      const projection2Name = `projection2_${uuid()}`;
+
+      // When
+      const consumer = rebuildSQLiteProjections({
+        ...connectionOptions,
+        projections: [
+          dummyProjection(projection1Name),
+          { projection: dummyProjection(projection2Name) },
+        ],
+      });
+
+      // Then
+      assertEqual(consumer.processors.length, 2);
+      assertEqual(
+        consumer.processors[0]!.id,
+        `emt:processor:projector:${projection1Name}`,
+      );
+      assertEqual(
+        consumer.processors[1]!.id,
+        `emt:processor:projector:${projection2Name}`,
+      );
+    });
+  });
+
+  void describe('custom processorId', () => {
+    void it('should use custom processorId when provided in projector options', () => {
+      // Given
+      const projectionName = `projection_${uuid()}`;
+      const customProcessorId = `custom:processor:${uuid()}`;
+
+      // When
+      const consumer = rebuildSQLiteProjections({
+        ...connectionOptions,
+        projections: [
+          {
+            processorId: customProcessorId,
+            projection: dummyProjection(projectionName),
+          },
+        ],
+      });
+
+      // Then
+      assertEqual(consumer.processors[0]!.id, customProcessorId);
+    });
+  });
+
+  void describe('consumer configuration', () => {
+    void it('should expose projector method on consumer', () => {
+      // Given
+      const projectionName = `projection_${uuid()}`;
+
+      // When
+      const consumer = rebuildSQLiteProjections({
+        ...connectionOptions,
+        projection: dummyProjection(projectionName),
+      });
+
+      // Then
+      assertOk(typeof consumer.projector === 'function');
+    });
+
+    void it('should expose reactor method on consumer', () => {
+      // Given
+      const projectionName = `projection_${uuid()}`;
+
+      // When
+      const consumer = rebuildSQLiteProjections({
+        ...connectionOptions,
+        projection: dummyProjection(projectionName),
+      });
+
+      // Then
+      assertOk(typeof consumer.reactor === 'function');
+    });
+
+    void it('should generate unique consumerId', () => {
+      // Given
+      const projectionName = `projection_${uuid()}`;
+
+      // When
+      const consumer1 = rebuildSQLiteProjections({
+        ...connectionOptions,
+        projection: dummyProjection(projectionName),
+      });
+
+      const consumer2 = rebuildSQLiteProjections({
+        ...connectionOptions,
+        projection: dummyProjection(projectionName),
+      });
+
+      // Then
+      assertOk(
+        typeof consumer1.consumerId === 'string' &&
+          consumer1.consumerId.length > 0,
+      );
+      assertOk(consumer1.consumerId !== consumer2.consumerId);
+    });
+
+    void it('should use provided consumerId', () => {
+      // Given
+      const projectionName = `projection_${uuid()}`;
+      const customConsumerId = `consumer_${uuid()}`;
+
+      // When
+      const consumer = rebuildSQLiteProjections({
+        ...connectionOptions,
+        consumerId: customConsumerId,
+        projection: dummyProjection(projectionName),
+      });
+
+      // Then
+      assertEqual(consumer.consumerId, customConsumerId);
+    });
+  });
+
+  void describe('processor instance uniqueness', () => {
+    void it('should generate unique instanceId for each processor', () => {
+      // Given
+      const projection1Name = `projection_${uuid()}`;
+      const projection2Name = `projection_${uuid()}`;
+
+      // When
+      const consumer = rebuildSQLiteProjections({
+        ...connectionOptions,
+        projections: [
+          dummyProjection(projection1Name),
+          dummyProjection(projection2Name),
+        ],
+      });
+
+      // Then
+      const instanceId1 = consumer.processors[0]!.instanceId;
+      const instanceId2 = consumer.processors[1]!.instanceId;
+      assertOk(instanceId1 !== instanceId2);
+    });
+  });
+});

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteCheckpointer.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteCheckpointer.ts
@@ -4,19 +4,23 @@ import {
   type ReadEventMetadataWithGlobalPosition,
   getCheckpoint,
 } from '@event-driven-io/emmett';
+import type { AnySQLiteEventStoreDriver } from '../eventStoreDriver';
 import { readProcessorCheckpoint, storeProcessorCheckpoint } from '../schema';
 import type { SQLiteProcessorHandlerContext } from './sqliteProcessor';
 
-export type SQLiteCheckpointer<MessageType extends AnyMessage = AnyMessage> =
-  Checkpointer<
-    MessageType,
-    ReadEventMetadataWithGlobalPosition,
-    SQLiteProcessorHandlerContext
-  >;
+export type SQLiteCheckpointer<
+  MessageType extends AnyMessage = AnyMessage,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
+> = Checkpointer<
+  MessageType,
+  ReadEventMetadataWithGlobalPosition,
+  SQLiteProcessorHandlerContext<Driver>
+>;
 
 export const sqliteCheckpointer = <
   MessageType extends Message = Message,
->(): SQLiteCheckpointer<MessageType> => ({
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
+>(): SQLiteCheckpointer<MessageType, Driver> => ({
   read: async (options, context) => {
     const result = await readProcessorCheckpoint(context.execute, {
       ...options,

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.awaiters.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.awaiters.int.spec.ts
@@ -53,9 +53,9 @@ void describe('waiting for a SQLite consumer to catch up in a test', () => {
       transactionOptions: { allowNestedTransactions: true },
     });
     eventStore = getSQLiteEventStore({ ...config, pool });
-    return createEventStoreSchema(
-      sqlite3Pool({ fileName, serializer: JSONSerializer }),
-    );
+    return createEventStoreSchema({
+      pool: sqlite3Pool({ fileName, serializer: JSONSerializer }),
+    });
   });
 
   afterEach(async () => {

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.handling.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.handling.int.spec.ts
@@ -16,6 +16,7 @@ import { v4 as uuid } from 'uuid';
 import { afterEach, beforeEach, describe, it } from 'vitest';
 import {
   sqlite3EventStoreDriver,
+  type SQLite3EventStoreDriver,
   type SQLite3EventStoreOptions,
 } from '../../sqlite3';
 import { deleteSQLiteDatabaseFiles } from '../../testing/sqliteTestDatabase';
@@ -68,9 +69,9 @@ void describe('SQLite event store started consumer', () => {
     });
 
     eventStore = getSQLiteEventStore({ ...config, pool });
-    return createEventStoreSchema(
-      sqlite3Pool({ fileName, serializer: JSONSerializer }),
-    );
+    return createEventStoreSchema({
+      pool: sqlite3Pool({ fileName, serializer: JSONSerializer }),
+    });
   });
 
   afterEach(async () => {
@@ -1002,7 +1003,11 @@ void describe('SQLite event store started consumer', () => {
 
         let result: GuestStayEvent[] = [];
 
-        const processorOptions: SQLiteReactorOptions<GuestStayEvent> = {
+        const processorOptions: SQLiteReactorOptions<
+          GuestStayEvent,
+          GuestStayEvent,
+          SQLite3EventStoreDriver
+        > = {
           processorId: uuid(),
           startFrom: 'CURRENT',
           stopAfter: (event) => event.metadata.globalPosition === startPosition,

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.inMemory.projections.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.inMemory.projections.int.spec.ts
@@ -57,9 +57,9 @@ void describe('SQLite event store started consumer', () => {
       pool,
     });
     summaries = database.collection(shoppingCartsSummaryCollectionName);
-    await createEventStoreSchema(
-      sqlite3Pool({ fileName, serializer: JSONSerializer }),
-    );
+    await createEventStoreSchema({
+      pool: sqlite3Pool({ fileName, serializer: JSONSerializer }),
+    });
   });
 
   afterEach(async () => {

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.int.spec.ts
@@ -49,7 +49,9 @@ void describe('SQLite event store consumer', () => {
       singleton: true,
       connection,
     });
-    await createEventStoreSchema(pool);
+    await createEventStoreSchema({
+      pool,
+    });
   });
 
   afterEach(() => connection.close());

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.projections.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.projections.int.spec.ts
@@ -14,7 +14,10 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { v4 as uuid } from 'uuid';
 import { afterEach, beforeEach, describe, it } from 'vitest';
-import { sqlite3EventStoreDriver } from '../../sqlite3';
+import {
+  sqlite3EventStoreDriver,
+  type SQLite3EventStoreDriver,
+} from '../../sqlite3';
 import type {
   ProductItemAdded,
   ShoppingCartConfirmed,
@@ -28,6 +31,7 @@ import {
 import { pongoSingleStreamProjection } from '../projections';
 import { sqliteEventStoreConsumer } from './sqliteEventStoreConsumer';
 import type { SQLiteProjectorOptions } from './sqliteProcessor';
+import { pongoDriverOf } from '../eventStoreDriver';
 
 const withDeadline = { timeout: 30000 };
 
@@ -51,9 +55,9 @@ void describe('SQLite event store started consumer', () => {
       fileName,
       pool,
     });
-    await createEventStoreSchema(
-      sqlite3Pool({ fileName, serializer: JSONSerializer }),
-    );
+    await createEventStoreSchema({
+      pool: sqlite3Pool({ fileName, serializer: JSONSerializer }),
+    });
   });
 
   afterEach(async () => {
@@ -292,14 +296,16 @@ void describe('SQLite event store started consumer', () => {
             { type: 'ProductItemAdded', data: { productItem } },
           ] as ShoppingCartSummaryEvent[]);
 
-        const processorOptions: SQLiteProjectorOptions<ShoppingCartSummaryEvent> =
-          {
-            processorId: uuid(),
-            projection: shoppingCartsSummaryProjection,
-            startFrom: 'CURRENT',
-            stopAfter: (event) =>
-              event.metadata.globalPosition === startPosition,
-          };
+        const processorOptions: SQLiteProjectorOptions<
+          ShoppingCartSummaryEvent,
+          ShoppingCartSummaryEvent,
+          SQLite3EventStoreDriver
+        > = {
+          processorId: uuid(),
+          projection: shoppingCartsSummaryProjection,
+          startFrom: 'CURRENT',
+          stopAfter: (event) => event.metadata.globalPosition === startPosition,
+        };
 
         const consumer = sqliteEventStoreConsumer({
           driver: sqlite3EventStoreDriver,
@@ -383,9 +389,7 @@ void describe('SQLite event store started consumer', () => {
 
   const summaryFor = (streamName: string) =>
     pool.withConnection(async (connection) => {
-      const driver = (await pongoDriverRegistry.tryResolve(
-        connection.driverType,
-      ))!;
+      const driver = pongoDriverOf(sqlite3EventStoreDriver);
       const pongo = pongoClient({ driver, connectionOptions: { connection } });
       try {
         return await pongo

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.schema.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.schema.int.spec.ts
@@ -33,6 +33,7 @@ import { messagesTable, processorsTable } from '../schema/typing';
 import { pongoClient } from '@event-driven-io/pongo';
 import { pongoSingleStreamProjection } from '../projections';
 import { sqliteEventStoreConsumer } from './sqliteEventStoreConsumer';
+import { pongoDriverOf } from '../eventStoreDriver';
 
 const withDeadline = { timeout: 30000 };
 
@@ -331,9 +332,7 @@ void describe('SQLite event store consumer schema configuration', () => {
     streamName: string,
   ) =>
     pool.withConnection(async (connection) => {
-      const driver = (await pongoDriverRegistry.tryResolve(
-        connection.driverType,
-      ))!;
+      const driver = pongoDriverOf(sqlite3EventStoreDriver);
       const pongo = pongoClient({
         driver,
         connectionOptions: { connection },

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.ts
@@ -1,5 +1,4 @@
-import { dumbo, type Dumbo } from '@event-driven-io/dumbo';
-import { sqliteAmbientConnectionPool } from '@event-driven-io/dumbo/sqlite';
+import { dumbo } from '@event-driven-io/dumbo';
 import {
   consumer,
   type AnyCommand,
@@ -15,14 +14,15 @@ import {
   type WorkflowProcessorContext,
 } from '@event-driven-io/emmett';
 import type {
-  AnyEventStoreDriver,
-  InferOptionsFromEventStoreDriver,
+  AnySQLiteEventStoreDriver,
+  InferDumboOptionsFromEventStoreDriver,
+  PoolOrConnectionOptions,
+  InferPoolFromEventStoreDriver,
 } from '../eventStoreDriver';
 import {
   eventStoreDatabaseSchema,
   type EventStoreDatabaseSchemaOptions,
 } from '../schema';
-import { getSQLiteEventStore } from '../SQLiteEventStore';
 import { sqliteMessageSource } from './messageSource';
 import {
   sqliteProjector,
@@ -48,48 +48,55 @@ export type SQLiteEventStoreConsumerConfig<
     pullingFrequencyInMs?: number;
   };
   schema?: EventStoreDatabaseSchemaOptions;
-};
+} & JSONSerializationOptions;
 
-export type SQLiteEventStoreConsumerOptions<
+export type SQLiteEventStoreConsumerConnectionOptions<
   ConsumerMessageType extends Message = Message,
-  Driver extends AnyEventStoreDriver = AnyEventStoreDriver,
-> = SQLiteEventStoreConsumerConfig<ConsumerMessageType> & {
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
+> = {
   driver: Driver;
-  pool?: Dumbo;
   source?: MessageSource<
     ConsumerMessageType,
     ReadEventMetadataWithGlobalPosition
   >;
-} & InferOptionsFromEventStoreDriver<Driver> &
-  JSONSerializationOptions;
+} & PoolOrConnectionOptions<Driver>;
+
+export type SQLiteEventStoreConsumerOptions<
+  ConsumerMessageType extends Message = Message,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
+> = SQLiteEventStoreConsumerConfig<ConsumerMessageType> &
+  SQLiteEventStoreConsumerConnectionOptions<ConsumerMessageType, Driver>;
 
 export type SQLiteReactorFactory<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ConsumerMessageType extends AnyMessage = any,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
 > = <MessageType extends ConsumerMessageType = ConsumerMessageType>(
-  options: SQLiteReactorOptions<MessageType>,
-) => SQLiteProcessor<MessageType>;
+  options: SQLiteReactorOptions<MessageType, MessageType, Driver>,
+) => SQLiteProcessor<MessageType, Driver>;
 
 export type SQLiteProjectorFactory<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ConsumerMessageType extends AnyMessage = any,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
 > = <
   EventType extends ConsumerMessageType & AnyEvent = ConsumerMessageType &
     AnyEvent,
 >(
-  options: SQLiteProjectorOptions<EventType>,
-) => SQLiteProcessor<EventType>;
+  options: SQLiteProjectorOptions<EventType, EventType, Driver>,
+) => SQLiteProcessor<EventType, Driver>;
 
 export type SQLiteWorkflowProcessorFactory<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ConsumerMessageType extends AnyMessage = any,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
 > = <
   Input extends ConsumerMessageType,
   State,
   Output extends ConsumerMessageType,
   MetaDataType extends AnyRecordedMessageMetadata = AnyRecordedMessageMetadata,
-  HandlerContext extends SQLiteProcessorHandlerContext &
-    WorkflowProcessorContext = SQLiteProcessorHandlerContext &
+  HandlerContext extends SQLiteProcessorHandlerContext<Driver> &
+    WorkflowProcessorContext = SQLiteProcessorHandlerContext<Driver> &
     WorkflowProcessorContext,
   StoredMessage extends AnyEvent | AnyCommand = Output,
 >(
@@ -104,40 +111,37 @@ export type SQLiteWorkflowProcessorFactory<
     >,
     'messageStore'
   >,
-) => SQLiteProcessor<Input | Output>;
+) => SQLiteProcessor<Input | Output, Driver>;
 
 export type SQLiteEventStoreConsumer<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ConsumerMessageType extends AnyMessage = any,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
 > = MessageConsumer<
   ConsumerMessageType,
-  SQLiteReactorFactory<ConsumerMessageType>,
-  SQLiteProjectorFactory<ConsumerMessageType>,
-  SQLiteWorkflowProcessorFactory<ConsumerMessageType>
+  SQLiteReactorFactory<ConsumerMessageType, Driver>,
+  SQLiteProjectorFactory<ConsumerMessageType, Driver>,
+  SQLiteWorkflowProcessorFactory<ConsumerMessageType, Driver>
 >;
 
 export const sqliteEventStoreConsumer = <
   ConsumerMessageType extends Message = AnyMessage,
-  Driver extends AnyEventStoreDriver = AnyEventStoreDriver,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
 >(
   options: SQLiteEventStoreConsumerOptions<ConsumerMessageType, Driver>,
-): SQLiteEventStoreConsumer<ConsumerMessageType> => {
+): SQLiteEventStoreConsumer<ConsumerMessageType, Driver> => {
   const databaseSchema = eventStoreDatabaseSchema(options.schema);
   const processorMetadataSchema = {
     ...options.schema,
     ...databaseSchema,
   };
   const isOwnPool = !options.pool;
-  const pool =
-    options.pool ??
-    dumbo({
-      serialization: options.serialization,
-      transactionOptions: {
-        allowNestedTransactions: true,
-        mode: 'session_based',
-      },
-      ...options.driver.mapToDumboOptions(options),
-    });
+  const dumboOptions = {
+    serialization: options.serialization,
+    ...options.driver.mapToDumboOptions(options),
+  } as InferDumboOptionsFromEventStoreDriver<Driver>;
+
+  const pool = options.pool ?? dumbo(dumboOptions);
 
   const source = options.source
     ? { ...options.source, close: () => Promise.resolve() }
@@ -154,38 +158,32 @@ export const sqliteEventStoreConsumer = <
   > = (processorOptions) =>
     sqliteWorkflowProcessor({
       ...processorOptions,
+      driver: options.driver,
       migrationOptions:
         processorOptions.migrationOptions ?? processorMetadataSchema,
-      messageStore: (connection) =>
-        getSQLiteEventStore({
-          ...options,
-          pool: sqliteAmbientConnectionPool({
-            driverType: options.driver.driverType,
-            connection,
-          }),
-          schema: { autoMigration: 'None', ...databaseSchema },
-        }),
     });
 
   const messageConsumer = consumer<
     ConsumerMessageType,
     ReadEventMetadataWithGlobalPosition,
-    SQLiteProcessorHandlerContext,
-    SQLiteReactorFactory<ConsumerMessageType>,
-    SQLiteProjectorFactory<ConsumerMessageType>,
-    SQLiteWorkflowProcessorFactory<ConsumerMessageType>
+    SQLiteProcessorHandlerContext<Driver>,
+    SQLiteReactorFactory<ConsumerMessageType, Driver>,
+    SQLiteProjectorFactory<ConsumerMessageType, Driver>,
+    SQLiteWorkflowProcessorFactory<ConsumerMessageType, Driver>
   >({
     ...options,
     source,
     reactorFactory: (processorOptions) =>
       sqliteReactor({
         ...processorOptions,
+        driver: options.driver,
         migrationOptions:
           processorOptions.migrationOptions ?? processorMetadataSchema,
       }),
     projectorFactory: (processorOptions) =>
       sqliteProjector({
         ...processorOptions,
+        driver: options.driver,
         migrationOptions:
           processorOptions.migrationOptions ?? processorMetadataSchema,
       }),
@@ -193,12 +191,14 @@ export const sqliteEventStoreConsumer = <
     batchSize: options.pulling?.batchSize,
     batchDeadlineInMs: options.pulling?.batchDeadlineInMs,
     scope: (handler) =>
-      pool.withConnection((connection) =>
-        handler({
-          connection,
-          execute: connection.execute,
-        }),
-      ),
+      handler({
+        // TODO: Fix this cast when the pool plumbing is driver-generic
+        session: {
+          pool: pool as InferPoolFromEventStoreDriver<Driver>,
+          connectionOptions: dumboOptions,
+        },
+        execute: pool.execute,
+      }),
     until:
       options.until ??
       (options.stopWhen?.noMessagesLeft === true

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.workflow.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteEventStoreConsumer.workflow.int.spec.ts
@@ -74,9 +74,9 @@ void describe('SQLite event store workflow processor', () => {
 
   beforeEach(() => {
     eventStore = getSQLiteEventStore(config);
-    return createEventStoreSchema(
-      sqlite3Pool({ fileName, serializer: JSONSerializer }),
-    );
+    return createEventStoreSchema({
+      pool: sqlite3Pool({ fileName, serializer: JSONSerializer }),
+    });
   });
 
   afterEach(async () => {

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteProcessor.pool.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteProcessor.pool.int.spec.ts
@@ -1,0 +1,175 @@
+import { dumbo, type Dumbo } from '@event-driven-io/dumbo';
+import { sqlite3DumboDriver } from '@event-driven-io/dumbo/sqlite3';
+import {
+  assertEqual,
+  assertFalse,
+  assertTrue,
+  type Event,
+} from '@event-driven-io/emmett';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { v4 as uuid } from 'uuid';
+import { afterEach, beforeEach, describe, it } from 'vitest';
+import {
+  sqlite3EventStoreDriver,
+  type SQLite3EventStoreDriver,
+} from '../../sqlite3';
+import { deleteSQLiteDatabaseFiles } from '../../testing/sqliteTestDatabase';
+import {
+  getSQLiteEventStore,
+  type SQLiteEventStore,
+} from '../SQLiteEventStore';
+import { sqliteEventStoreConsumer } from './sqliteEventStoreConsumer';
+
+const withDeadline = { timeout: 30000 };
+
+type GuestCheckedIn = Event<'GuestCheckedIn', { guestId: string }>;
+
+void describe('SQLite processor pool', () => {
+  const testDatabasePath = path.dirname(fileURLToPath(import.meta.url));
+  const fileName = path.resolve(testDatabasePath, 'processorPool.test.db');
+  const otherFileName = path.resolve(
+    testDatabasePath,
+    'processorPool.other.test.db',
+  );
+
+  let eventStore: SQLiteEventStore;
+  let otherEventStore: SQLiteEventStore;
+
+  beforeEach(async () => {
+    eventStore = getSQLiteEventStore({
+      driver: sqlite3EventStoreDriver,
+      fileName,
+    });
+    await eventStore.schema.migrate();
+
+    otherEventStore = getSQLiteEventStore({
+      driver: sqlite3EventStoreDriver,
+      fileName: otherFileName,
+    });
+    await otherEventStore.schema.migrate();
+  });
+
+  afterEach(async () => {
+    await eventStore.close();
+    await otherEventStore.close();
+    deleteSQLiteDatabaseFiles(fileName);
+    deleteSQLiteDatabaseFiles(otherFileName);
+  });
+
+  const poolSeenBy = async (
+    processorFileName?: string,
+  ): Promise<{
+    consumerPool: Dumbo;
+    seenPool: Dumbo | undefined;
+    handled: number;
+  }> => {
+    const consumerPool = dumbo({
+      driver: sqlite3DumboDriver,
+      fileName,
+      transactionOptions: { allowNestedTransactions: true },
+    });
+
+    let seenPool: Dumbo | undefined;
+    let handled = 0;
+
+    const consumer = sqliteEventStoreConsumer<
+      GuestCheckedIn,
+      SQLite3EventStoreDriver
+    >({
+      driver: sqlite3EventStoreDriver,
+      pool: consumerPool,
+      stopWhen: { noMessagesLeft: true },
+    });
+
+    consumer.reactor<GuestCheckedIn>({
+      processorId: uuid(),
+      startFrom: 'BEGINNING',
+      canHandle: ['GuestCheckedIn'],
+      connectionOptions: processorFileName
+        ? { fileName: processorFileName }
+        : undefined,
+      eachMessage: (_message, context) => {
+        seenPool = context.session.pool;
+        handled++;
+      },
+    });
+
+    await eventStore.appendToStream(`guestStay-${uuid()}`, [
+      { type: 'GuestCheckedIn', data: { guestId: uuid() } },
+    ]);
+
+    try {
+      await consumer.start();
+    } finally {
+      await consumer.close();
+      await consumerPool.close();
+    }
+
+    return { consumerPool, seenPool, handled };
+  };
+
+  void it(
+    'uses the consumer pool when the processor has no connection options',
+    withDeadline,
+    async () => {
+      const { consumerPool, seenPool, handled } = await poolSeenBy();
+
+      assertEqual(handled, 1);
+      assertTrue(seenPool === consumerPool);
+    },
+  );
+
+  void it(
+    'opens its own pool when the processor has connection options',
+    withDeadline,
+    async () => {
+      const { consumerPool, seenPool, handled } =
+        await poolSeenBy(otherFileName);
+
+      assertEqual(handled, 1);
+      assertTrue(seenPool !== undefined);
+      assertFalse(seenPool === consumerPool);
+    },
+  );
+
+  void it(
+    'handles messages on a file based database without pinning a connection',
+    withDeadline,
+    async () => {
+      const guestIds = [uuid(), uuid(), uuid()];
+      const handled: string[] = [];
+
+      const consumer = sqliteEventStoreConsumer<
+        GuestCheckedIn,
+        SQLite3EventStoreDriver
+      >({
+        driver: sqlite3EventStoreDriver,
+        fileName,
+        stopWhen: { noMessagesLeft: true },
+      });
+
+      consumer.reactor<GuestCheckedIn>({
+        processorId: uuid(),
+        startFrom: 'BEGINNING',
+        canHandle: ['GuestCheckedIn'],
+        eachMessage: (message) => {
+          handled.push(message.data.guestId);
+        },
+      });
+
+      for (const guestId of guestIds)
+        await eventStore.appendToStream(`guestStay-${guestId}`, [
+          { type: 'GuestCheckedIn', data: { guestId } },
+        ]);
+
+      try {
+        await consumer.start();
+      } finally {
+        await consumer.close();
+      }
+
+      assertEqual(handled.length, guestIds.length);
+    },
+  );
+});

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteProcessor.transactions.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteProcessor.transactions.int.spec.ts
@@ -2,7 +2,7 @@ import { JSONSerializer } from '@event-driven-io/dumbo';
 import { sqlite3Pool } from '@event-driven-io/dumbo/sqlite3';
 import {
   assertEqual,
-  assertFalse,
+  assertTrue,
   workflowStreamName,
 } from '@event-driven-io/emmett';
 import path from 'path';
@@ -43,9 +43,9 @@ void describe('SQLite processor transaction handling', () => {
 
   beforeEach(() => {
     eventStore = getSQLiteEventStore(config);
-    return createEventStoreSchema(
-      sqlite3Pool({ fileName, serializer: JSONSerializer }),
-    );
+    return createEventStoreSchema({
+      pool: sqlite3Pool({ fileName, serializer: JSONSerializer }),
+    });
   });
 
   afterEach(async () => {
@@ -54,7 +54,7 @@ void describe('SQLite processor transaction handling', () => {
   });
 
   void it(
-    'does not leak the workflow message store onto connections of other processors',
+    'gives every processor a message store bound to its own transaction',
     withDeadline,
     async () => {
       // Given
@@ -93,16 +93,19 @@ void describe('SQLite processor transaction handling', () => {
           message.data.groupCheckoutId === groupCheckoutId,
       });
 
-      const reactorConnectionsWithMessageStore: boolean[] = [];
+      const reactionStream = `reaction-${groupCheckoutId}`;
+      const reactorMessageStores: boolean[] = [];
 
       consumer.reactor({
         processorId: `reactor-${groupCheckoutId}`,
         canHandle: ['GroupCheckoutInitiated'],
         stopAfter: (message) => message.type === 'GroupCheckoutInitiated',
-        eachMessage: (_message, context) => {
-          reactorConnectionsWithMessageStore.push(
-            'messageStore' in context.connection,
-          );
+        eachMessage: async (_message, context) => {
+          reactorMessageStores.push('messageStore' in context.session);
+
+          await context.session.messageStore.appendToStream(reactionStream, [
+            { type: 'GuestCheckedOut', data: { guestId: groupCheckoutId } },
+          ]);
         },
       });
 
@@ -128,8 +131,12 @@ void describe('SQLite processor transaction handling', () => {
       }
 
       // Then
-      assertEqual(1, reactorConnectionsWithMessageStore.length);
-      assertFalse(reactorConnectionsWithMessageStore[0]!);
+      assertEqual(1, reactorMessageStores.length);
+      assertTrue(reactorMessageStores[0]!);
+
+      const reaction = await eventStore.readStream(reactionStream);
+      assertEqual(1, reaction.events.length);
+      assertEqual('GuestCheckedOut', reaction.events[0]!.type);
 
       const { events } = await eventStore.readStream(
         workflowStreamName({

--- a/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteProcessor.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/consumers/sqliteProcessor.ts
@@ -1,8 +1,11 @@
-import type { DatabaseDriverType, SQLExecutor } from '@event-driven-io/dumbo';
-import type {
-  AnySQLiteConnection,
-  SQLiteTransaction,
-} from '@event-driven-io/dumbo/sqlite';
+import {
+  dumbo,
+  type AnyDatabaseTransaction,
+  type DatabaseDriverType,
+  type SQLExecutor,
+} from '@event-driven-io/dumbo';
+import type { AnySQLiteConnection } from '@event-driven-io/dumbo/sqlite';
+import { sqliteAmbientConnectionPool } from '@event-driven-io/dumbo/sqlite';
 import type {
   AnyCommand,
   AnyEvent,
@@ -11,9 +14,11 @@ import type {
   BatchRecordedMessageHandlerWithContext,
   Checkpointer,
   CurrentMessageProcessorPosition,
+  JSONSerializationOptions,
   Message,
   MessageHandlerContext,
   MessageProcessingScope,
+  PartialHandlerContext,
   MessageProcessor,
   ProcessorHooks,
   ProjectorOptions,
@@ -39,77 +44,117 @@ import {
   type Event,
   type ReadEvent,
 } from '@event-driven-io/emmett';
+import { eventStoreDriverOf } from '../eventStoreDriver';
+import type {
+  AnySQLiteEventStoreDriver,
+  InferDumboConnectionFromEventStoreDriver,
+  InferDumboOptionsFromEventStoreDriver,
+  InferOptionsFromEventStoreDriver,
+  InferPoolFromEventStoreDriver,
+  InferTransactionFromEventStoreDriver,
+} from '../eventStoreDriver';
 import type { EventStoreSchemaMigrationOptions } from '../schema';
+import {
+  getSQLiteEventStore,
+  type SQLiteEventStore,
+} from '../SQLiteEventStore';
 import { sqliteCheckpointer } from './sqliteCheckpointer';
 
 export type SQLiteProcessorEventsBatch<EventType extends Event = Event> = {
   messages: ReadEvent<EventType, ReadEventMetadataWithGlobalPosition>[];
 };
 
-export type SQLiteProcessorHandlerContext = MessageHandlerContext<
+export type SQLiteProcessorHandlerContext<
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
+> = MessageHandlerContext<
   {
+    partition: string;
     execute: SQLExecutor;
-    connection: AnySQLiteConnection;
     driverType: DatabaseDriverType;
+    driver?: Driver;
   } &
     // TODO: Reconsider if it should be for all processors
-    EventStoreSchemaMigrationOptions
+    EventStoreSchemaMigrationOptions,
+  {
+    connection: InferDumboConnectionFromEventStoreDriver<Driver>;
+    transaction: InferTransactionFromEventStoreDriver<Driver>;
+    pool: InferPoolFromEventStoreDriver<Driver>;
+    messageStore: SQLiteEventStore;
+    connectionOptions?: InferDumboOptionsFromEventStoreDriver<Driver>;
+  }
 >;
 
-export type SQLiteProcessor<MessageType extends Message = AnyMessage> =
-  MessageProcessor<
-    MessageType,
-    ReadEventMetadataWithGlobalPosition,
-    SQLiteProcessorHandlerContext
-  >;
+export type SQLiteProcessor<
+  MessageType extends Message = AnyMessage,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
+> = MessageProcessor<
+  MessageType,
+  ReadEventMetadataWithGlobalPosition,
+  SQLiteProcessorHandlerContext<Driver>
+>;
 
 export type SQLiteProcessorEachMessageHandler<
   MessageType extends Message = Message,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
 > = SingleRecordedMessageHandlerWithContext<
   MessageType,
   ReadEventMetadataWithGlobalPosition,
-  SQLiteProcessorHandlerContext
+  SQLiteProcessorHandlerContext<Driver>
 >;
 
 export type SQLiteProcessorEachBatchHandler<
   MessageType extends Message = Message,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
 > = BatchRecordedMessageHandlerWithContext<
   MessageType,
   ReadEventMetadataWithGlobalPosition,
-  SQLiteProcessorHandlerContext
+  SQLiteProcessorHandlerContext<Driver>
 >;
 
 export type SQLiteProcessorStartFrom =
   CurrentMessageProcessorPosition | 'CURRENT';
 
-export type SQLiteProcessorConnectionOptions = {
+export type SQLiteProcessorConnectionOptions<
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
+> = {
   connection?: AnySQLiteConnection;
-};
+  pool?: InferPoolFromEventStoreDriver<Driver>;
+} & Partial<InferOptionsFromEventStoreDriver<Driver>>;
 
-type SQLiteProcessorOptionsBase = SQLiteProcessorConnectionOptions &
-  EventStoreSchemaMigrationOptions;
+type SQLiteConnectionOptions<
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
+> = {
+  connectionOptions?: SQLiteProcessorConnectionOptions<Driver>;
+  driver?: Driver;
+} & JSONSerializationOptions;
+
+type SQLiteProcessorOptionsBase<
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
+> = SQLiteConnectionOptions<Driver> & EventStoreSchemaMigrationOptions;
 
 export type SQLiteReactorOptions<
   MessageType extends Message = Message,
   MessagePayloadType extends AnyMessage = MessageType,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
 > = ReactorOptions<
   MessageType,
   ReadEventMetadataWithGlobalPosition,
-  SQLiteProcessorHandlerContext,
+  SQLiteProcessorHandlerContext<Driver>,
   MessagePayloadType
 > &
-  SQLiteProcessorOptionsBase;
+  SQLiteProcessorOptionsBase<Driver>;
 
 export type SQLiteProjectorOptions<
   EventType extends AnyEvent = AnyEvent,
   EventPayloadType extends Event = EventType,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
 > = ProjectorOptions<
   EventType,
   ReadEventMetadataWithGlobalPosition,
-  SQLiteProcessorHandlerContext,
+  SQLiteProcessorHandlerContext<Driver>,
   EventPayloadType
 > &
-  SQLiteProcessorOptionsBase;
+  SQLiteProcessorOptionsBase<Driver>;
 
 export type SQLiteWorkflowProcessorOptions<
   Input extends AnyEvent | AnyCommand,
@@ -118,6 +163,7 @@ export type SQLiteWorkflowProcessorOptions<
   MetaDataType extends AnyRecordedMessageMetadata = AnyRecordedMessageMetadata,
   HandlerContext extends WorkflowProcessorContext = WorkflowProcessorContext,
   StoredMessage extends AnyEvent | AnyCommand = Output,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
 > = WorkflowProcessorOptions<
   Input,
   State,
@@ -126,86 +172,121 @@ export type SQLiteWorkflowProcessorOptions<
   HandlerContext,
   StoredMessage
 > &
-  SQLiteProcessorOptionsBase & {
-    messageStore: SQLiteWorkflowMessageStoreFactory;
-  };
+  SQLiteProcessorOptionsBase<Driver>;
 
-export type SQLiteWorkflowMessageStoreFactory = (
-  connection: AnySQLiteConnection,
-) => WorkflowProcessorContext['connection']['messageStore'];
+const sqliteProcessingScope = <
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
+>(options: {
+  pool: InferPoolFromEventStoreDriver<Driver> | null;
+  connectionOptions: InferDumboOptionsFromEventStoreDriver<Driver> | null;
+  processorId: string;
+  partition: string;
+  migrationOptions?: EventStoreSchemaMigrationOptions['migrationOptions'];
+  driver?: Driver;
+}): MessageProcessingScope<SQLiteProcessorHandlerContext<Driver>> => {
+  const processorConnectionOptions = options.connectionOptions;
 
-const sqliteProcessingScope = (
-  migrationOptions?: EventStoreSchemaMigrationOptions['migrationOptions'],
-): MessageProcessingScope<SQLiteProcessorHandlerContext> => {
+  const processorPool = options.pool;
+
   const processingScope: MessageProcessingScope<
-    SQLiteProcessorHandlerContext
+    SQLiteProcessorHandlerContext<Driver>
   > = async <Result = SingleMessageHandlerResult>(
     handler: (
-      context: SQLiteProcessorHandlerContext,
+      context: SQLiteProcessorHandlerContext<Driver>,
     ) => Result | Promise<Result>,
-    partialContext: Partial<SQLiteProcessorHandlerContext>,
+    partialContext: PartialHandlerContext<
+      SQLiteProcessorHandlerContext<Driver>
+    >,
   ) => {
-    const connection = partialContext?.connection;
+    const session = partialContext?.session;
 
-    if (!connection)
-      // TODO: Map it to dumbo connection correctly
-      throw new EmmettError('Connection is required in context or options');
+    const { pool, connectionOptions } = processorPool
+      ? {
+          pool: processorPool,
+          connectionOptions: processorConnectionOptions ?? undefined,
+        }
+      : { pool: session?.pool, connectionOptions: session?.connectionOptions };
 
-    return connection.withTransaction(
-      async (transaction: SQLiteTransaction) => {
-        return handler({
-          ...partialContext,
-          connection: connection,
-          driverType: connection.driverType as DatabaseDriverType,
-          execute: transaction.execute,
-          migrationOptions,
-          observabilityScope: partialContext?.observabilityScope ?? noopScope,
-        });
-      },
+    if (!pool)
+      throw new EmmettError(
+        `SQLite processor '${options.processorId}' is missing a connection pool. Ensure that you passed connection options through options`,
+      );
+
+    const driver = eventStoreDriverOf<Driver>(
+      options.driver ?? partialContext?.driver,
     );
+
+    return pool.withTransaction(async (transaction: AnyDatabaseTransaction) => {
+      const sqliteTransaction =
+        transaction as InferTransactionFromEventStoreDriver<Driver>;
+      const connection =
+        transaction.connection as InferDumboConnectionFromEventStoreDriver<Driver>;
+
+      return handler({
+        ...partialContext,
+        partition: options.partition,
+        execute: sqliteTransaction.execute,
+        driver,
+        driverType: connection.driverType,
+        session: {
+          ...partialContext?.session,
+          pool,
+          connectionOptions,
+          connection,
+          transaction: sqliteTransaction,
+          messageStore: getSQLiteEventStore({
+            driver,
+            pool: sqliteAmbientConnectionPool({
+              driverType: connection.driverType,
+              connection,
+            }),
+            schema: {
+              autoMigration: 'None',
+              ...options.migrationOptions,
+            },
+          }),
+        },
+        migrationOptions: options.migrationOptions,
+        observabilityScope: partialContext?.observabilityScope ?? noopScope,
+      });
+    });
   };
 
   return processingScope;
 };
 
-const sqliteWorkflowProcessingScope = (
-  createMessageStore: SQLiteWorkflowMessageStoreFactory,
-  migrationOptions?: EventStoreSchemaMigrationOptions['migrationOptions'],
-): MessageProcessingScope<
-  SQLiteProcessorHandlerContext & WorkflowProcessorContext
-> => {
-  const processingScope: MessageProcessingScope<
-    SQLiteProcessorHandlerContext & WorkflowProcessorContext
-  > = async <Result = SingleMessageHandlerResult>(
-    handler: (
-      context: SQLiteProcessorHandlerContext & WorkflowProcessorContext,
-    ) => Result | Promise<Result>,
-    partialContext: Partial<SQLiteProcessorHandlerContext> &
-      Partial<WorkflowProcessorContext>,
-  ) => {
-    const connection = partialContext?.connection;
+const getProcessorPool = <
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
+>(
+  options: SQLiteConnectionOptions<Driver>,
+) => {
+  const poolOptions = options.connectionOptions;
 
-    if (!connection)
-      throw new EmmettError('Connection is required in context or options');
+  if (!poolOptions) return { pool: null, connectionOptions: null };
 
-    return connection.withTransaction(
-      async (transaction: SQLiteTransaction) => {
-        return handler({
-          ...partialContext,
-          connection: {
-            ...connection,
-            messageStore: createMessageStore(transaction.connection),
-          },
-          driverType: connection.driverType as DatabaseDriverType,
-          execute: transaction.execute,
-          migrationOptions,
-          observabilityScope: partialContext?.observabilityScope ?? noopScope,
-        });
-      },
-    );
+  if (poolOptions.pool)
+    return { pool: poolOptions.pool, connectionOptions: null };
+
+  if (poolOptions.connection)
+    return {
+      pool: sqliteAmbientConnectionPool({
+        driverType: poolOptions.connection.driverType,
+        connection: poolOptions.connection,
+      }) as InferPoolFromEventStoreDriver<Driver>,
+      connectionOptions: null,
+    };
+
+  const driver = eventStoreDriverOf<Driver>(options.driver);
+
+  const connectionOptions = {
+    serialization: options.serialization,
+    ...driver.mapToDumboOptions(poolOptions),
+  } as InferDumboOptionsFromEventStoreDriver<Driver>;
+
+  return {
+    pool: dumbo(connectionOptions) as InferPoolFromEventStoreDriver<Driver>,
+    connectionOptions,
   };
-
-  return processingScope;
 };
 
 export const sqliteWorkflowProcessor = <
@@ -249,10 +330,13 @@ export const sqliteWorkflowProcessor = <
     version,
     partition,
     hooks,
-    processingScope: sqliteWorkflowProcessingScope(
-      options.messageStore,
-      options.migrationOptions,
-    ) as unknown as MessageProcessingScope<HandlerContext>,
+    processingScope: sqliteProcessingScope({
+      ...getProcessorPool(options),
+      processorId,
+      partition,
+      migrationOptions: options.migrationOptions,
+      driver: options.driver,
+    }) as unknown as MessageProcessingScope<HandlerContext>,
     checkpoints:
       options.checkpoints === 'DISABLED'
         ? inMemoryCheckpointer<Input | Output, MetaDataType, HandlerContext>()
@@ -267,9 +351,10 @@ export const sqliteWorkflowProcessor = <
 export const sqliteReactor = <
   MessageType extends Message = Message,
   MessagePayloadType extends AnyMessage = MessageType,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
 >(
-  options: SQLiteReactorOptions<MessageType, MessagePayloadType>,
-): SQLiteProcessor<MessageType> => {
+  options: SQLiteReactorOptions<MessageType, MessagePayloadType, Driver>,
+): SQLiteProcessor<MessageType, Driver> => {
   const {
     processorId = options.processorId,
     processorInstanceId = getProcessorInstanceId(processorId),
@@ -285,21 +370,28 @@ export const sqliteReactor = <
     version,
     partition,
     hooks,
-    processingScope: sqliteProcessingScope(options.migrationOptions),
+    processingScope: sqliteProcessingScope<Driver>({
+      ...getProcessorPool<Driver>(options),
+      processorId,
+      partition,
+      migrationOptions: options.migrationOptions,
+      driver: options.driver,
+    }),
 
     checkpoints:
       options.checkpoints === 'DISABLED'
         ? inMemoryCheckpointer<MessageType>()
-        : sqliteCheckpointer<MessageType>(),
+        : sqliteCheckpointer<MessageType, Driver>(),
   });
 };
 
 export const sqliteProjector = <
   EventType extends Event = Event,
   EventPayloadType extends Event = EventType,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
 >(
-  options: SQLiteProjectorOptions<EventType, EventPayloadType>,
-): SQLiteProcessor<EventType> => {
+  options: SQLiteProjectorOptions<EventType, EventPayloadType, Driver>,
+): SQLiteProcessor<EventType, Driver> => {
   const {
     processorId = getProjectorId({
       projectionName: options.projection.name ?? 'unknown',
@@ -309,11 +401,11 @@ export const sqliteProjector = <
     partition = defaultProcessorPartition,
   } = options;
 
-  const hooks: ProcessorHooks<SQLiteProcessorHandlerContext> = {
+  const hooks: ProcessorHooks<SQLiteProcessorHandlerContext<Driver>> = {
     ...(options.hooks ?? {}),
     onInit:
       options.projection.init !== undefined || options.hooks?.onInit
-        ? async (context: SQLiteProcessorHandlerContext) => {
+        ? async (context: SQLiteProcessorHandlerContext<Driver>) => {
             if (options.projection.init)
               await options.projection.init({
                 version: options.projection.version ?? version,
@@ -337,7 +429,7 @@ export const sqliteProjector = <
   const processor = projector<
     EventType,
     ReadEventMetadataWithGlobalPosition,
-    SQLiteProcessorHandlerContext,
+    SQLiteProcessorHandlerContext<Driver>,
     EventPayloadType
   >({
     ...options,
@@ -346,11 +438,17 @@ export const sqliteProjector = <
     version,
     partition,
     hooks,
-    processingScope: sqliteProcessingScope(options.migrationOptions),
+    processingScope: sqliteProcessingScope<Driver>({
+      ...getProcessorPool<Driver>(options),
+      processorId,
+      partition,
+      migrationOptions: options.migrationOptions,
+      driver: options.driver,
+    }),
     checkpoints:
       options.checkpoints === 'DISABLED'
         ? inMemoryCheckpointer<EventType>()
-        : sqliteCheckpointer<EventType>(),
+        : sqliteCheckpointer<EventType, Driver>(),
   });
 
   return processor;

--- a/src/packages/emmett-sqlite/src/eventStore/eventStoreDriver.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/eventStoreDriver.ts
@@ -1,5 +1,12 @@
+import { EmmettError } from '@event-driven-io/emmett';
+import type { AnyPongoDriver } from '@event-driven-io/pongo';
+import type {
+  AnySQLiteConnection,
+  SQLiteDriverType,
+} from '@event-driven-io/dumbo/sqlite';
 import type {
   AnyDumboDatabaseDriver,
+  Dumbo,
   DumboDatabaseDriver,
   ExtractDumboDatabaseDriverOptions,
   ExtractDumboTypeFromDriver,
@@ -13,10 +20,37 @@ export interface EventStoreDriver<
 > {
   driverType: DatabaseDriver['driverType'];
   dumboDriver: DatabaseDriver;
+  pongoDriver?: AnyPongoDriver;
   mapToDumboOptions(
-    driverOptions: DriverOptions,
+    options: DriverOptions,
   ): ExtractDumboDatabaseDriverOptions<DatabaseDriver>;
 }
+
+export const eventStoreDriverOf = <
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
+>(
+  driver: Driver | undefined,
+): Driver => {
+  if (!driver)
+    throw new EmmettError(
+      `The handler context carries no event store driver. Ensure that you passed it to getSQLiteEventStore.`,
+    );
+
+  return driver;
+};
+
+export const pongoDriverOf = (
+  driver: AnySQLiteEventStoreDriver | undefined,
+): AnyPongoDriver => {
+  const pongoDriver = eventStoreDriverOf(driver).pongoDriver;
+
+  if (!pongoDriver)
+    throw new EmmettError(
+      `Pongo projections need a Pongo driver on the event store driver. Ensure that the driver you passed to getSQLiteEventStore defines 'pongoDriver'.`,
+    );
+
+  return pongoDriver;
+};
 
 export type EventStoreDriverOptions<
   Driver extends AnyEventStoreDriver = AnyEventStoreDriver,
@@ -33,7 +67,23 @@ export type AnyEventStoreDriver = EventStoreDriver<
   AnyEventStoreDriverOptions
 >;
 
-export type InferOptionsFromEventStoreDriver<C extends AnyEventStoreDriver> =
+/**
+ * Any driver this package can actually talk to. Constraining on it keeps
+ * `context.session.connection` a SQLite connection, whichever SQLite driver
+ * you picked.
+ */
+export type AnySQLiteEventStoreDriver = Omit<
+  EventStoreDriver<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    DumboDatabaseDriver<AnySQLiteConnection, any>,
+    AnyEventStoreDriverOptions
+  >,
+  'driverType'
+> & { driverType: SQLiteDriverType };
+
+export type InferOptionsFromEventStoreDriver<
+  C extends AnySQLiteEventStoreDriver,
+> =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   C extends EventStoreDriver<any, infer DO> ? DO : never;
 
@@ -43,11 +93,11 @@ export type InferOptionsFromEventStoreDriver<C extends AnyEventStoreDriver> =
  * without one exposes whatever it does have.
  */
 export type InferDumboOptionsFromEventStoreDriver<
-  C extends AnyEventStoreDriver,
+  C extends AnySQLiteEventStoreDriver,
 > = ExtractDumboDatabaseDriverOptions<C['dumboDriver']>;
 
 export type InferDumboConnectionFromEventStoreDriver<
-  Driver extends AnyEventStoreDriver,
+  Driver extends AnySQLiteEventStoreDriver,
 > =
   Driver['dumboDriver'] extends DumboDatabaseDriver<
     infer ConnectionType,
@@ -59,17 +109,24 @@ export type InferDumboConnectionFromEventStoreDriver<
     ? ConnectionType
     : never;
 
-export type InferPoolFromEventStoreDriver<Driver extends AnyEventStoreDriver> =
-  ExtractDumboTypeFromDriver<Driver['dumboDriver']>;
+export type InferPoolFromEventStoreDriver<
+  Driver extends AnySQLiteEventStoreDriver,
+> = ExtractDumboTypeFromDriver<Driver['dumboDriver']>;
 
 export type InferDbClientFromEventStoreDriver<
-  Driver extends AnyEventStoreDriver,
+  Driver extends AnySQLiteEventStoreDriver,
 > = InferDbClientFromConnection<
   InferDumboConnectionFromEventStoreDriver<Driver>
 >;
 
 export type InferTransactionFromEventStoreDriver<
-  Driver extends AnyEventStoreDriver,
+  Driver extends AnySQLiteEventStoreDriver,
 > = InferTransactionFromConnection<
   InferDumboConnectionFromEventStoreDriver<Driver>
 >;
+
+export type PoolOrConnectionOptions<
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
+> =
+  | ({ pool?: undefined } & InferOptionsFromEventStoreDriver<Driver>)
+  | ({ pool: Dumbo } & Partial<InferOptionsFromEventStoreDriver<Driver>>);

--- a/src/packages/emmett-sqlite/src/eventStore/eventStoreDriver.unit.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/eventStoreDriver.unit.spec.ts
@@ -1,0 +1,214 @@
+import type { Dumbo } from '@event-driven-io/dumbo';
+import type { AnySQLiteConnection } from '@event-driven-io/dumbo/sqlite';
+import { pongoDriver as sqlite3PongoDriver } from '@event-driven-io/pongo/sqlite3';
+import type {
+  SQLite3Connection,
+  SQLite3DumboOptions,
+  SQLiteAmbientConnectionPool,
+  SQLiteTransaction,
+  SQLiteTransactionOptions,
+} from '@event-driven-io/dumbo/sqlite3';
+import { assertThrows, assertTrue, EmmettError } from '@event-driven-io/emmett';
+import { describe, it } from 'vitest';
+import type { D1EventStoreDriver } from '../cloudflare';
+import {
+  sqlite3EventStoreDriver,
+  type SQLite3EventStoreDriver,
+} from '../sqlite3';
+import type { SQLiteProcessorHandlerContext } from './consumers/sqliteProcessor';
+import {
+  eventStoreDriverOf,
+  pongoDriverOf,
+  type AnySQLiteEventStoreDriver,
+  type PoolOrConnectionOptions,
+} from './eventStoreDriver';
+import type { SQLiteProjectionHandlerContext } from './projections/sqliteProjection';
+
+type Equals<Left, Right> =
+  (<T>() => T extends Left ? 1 : 2) extends <T>() => T extends Right ? 1 : 2
+    ? true
+    : false;
+
+const assertTypesEqual = <_Assertion extends true>(): void => {};
+
+type ProcessorSession<Driver extends AnySQLiteEventStoreDriver> =
+  SQLiteProcessorHandlerContext<Driver>['session'];
+
+type ProjectionSession<Driver extends AnySQLiteEventStoreDriver> =
+  SQLiteProjectionHandlerContext<Driver>['session'];
+
+type ProcessorConnection<Driver extends AnySQLiteEventStoreDriver> =
+  ProcessorSession<Driver>['connection'];
+
+type ProjectionConnection<Driver extends AnySQLiteEventStoreDriver> =
+  ProjectionSession<Driver>['connection'];
+
+void describe('Handler context session typing', () => {
+  void it('keeps the connection a SQLite one when no driver is given', () => {
+    assertTypesEqual<
+      ProcessorConnection<AnySQLiteEventStoreDriver> extends AnySQLiteConnection
+        ? true
+        : false
+    >();
+    assertTypesEqual<
+      ProjectionConnection<AnySQLiteEventStoreDriver> extends AnySQLiteConnection
+        ? true
+        : false
+    >();
+
+    assertTrue(true);
+  });
+
+  void it('derives the connection from the driver it was given', () => {
+    assertTypesEqual<
+      ProcessorConnection<SQLite3EventStoreDriver> extends SQLite3Connection
+        ? true
+        : false
+    >();
+    assertTypesEqual<
+      ProjectionConnection<SQLite3EventStoreDriver> extends SQLite3Connection
+        ? true
+        : false
+    >();
+
+    assertTrue(true);
+  });
+
+  void it('derives the transaction from the driver it was given', () => {
+    assertTypesEqual<
+      Equals<
+        ProcessorSession<SQLite3EventStoreDriver>['transaction'],
+        SQLiteTransaction<SQLite3Connection, SQLiteTransactionOptions>
+      >
+    >();
+    assertTypesEqual<
+      Equals<
+        ProjectionSession<SQLite3EventStoreDriver>['transaction'],
+        SQLiteTransaction<SQLite3Connection, SQLiteTransactionOptions>
+      >
+    >();
+
+    assertTrue(true);
+  });
+
+  void it('derives the pool from the driver it was given', () => {
+    assertTypesEqual<
+      Equals<
+        ProcessorSession<SQLite3EventStoreDriver>['pool'],
+        SQLiteAmbientConnectionPool<SQLite3Connection>
+      >
+    >();
+    assertTypesEqual<
+      Equals<
+        ProjectionSession<SQLite3EventStoreDriver>['pool'],
+        SQLiteAmbientConnectionPool<SQLite3Connection>
+      >
+    >();
+
+    assertTrue(true);
+  });
+
+  void it('derives the connection options from the driver it was given', () => {
+    assertTypesEqual<
+      Equals<
+        ProcessorSession<SQLite3EventStoreDriver>['connectionOptions'],
+        SQLite3DumboOptions | undefined
+      >
+    >();
+
+    assertTrue(true);
+  });
+
+  void it('names the driver type the driver declares', () => {
+    assertTypesEqual<
+      SQLite3EventStoreDriver['driverType'] extends 'SQLite:sqlite3'
+        ? true
+        : false
+    >();
+
+    assertTrue(true);
+  });
+
+  void it('accepts every driver this package ships', () => {
+    assertTypesEqual<
+      SQLite3EventStoreDriver extends AnySQLiteEventStoreDriver ? true : false
+    >();
+    assertTypesEqual<
+      D1EventStoreDriver extends AnySQLiteEventStoreDriver ? true : false
+    >();
+
+    assertTrue(true);
+  });
+
+  void it('rejects a driver that is not a SQLite one', () => {
+    type NotSQLite = {
+      driverType: 'PostgreSQL:pg';
+      dumboDriver: never;
+      mapToDumboOptions: () => never;
+    };
+
+    assertTypesEqual<
+      NotSQLite extends AnySQLiteEventStoreDriver ? false : true
+    >();
+
+    assertTrue(true);
+  });
+});
+
+void describe('pongoDriverOf', () => {
+  void it('returns the Pongo driver the event store driver names', () => {
+    assertTrue(pongoDriverOf(sqlite3EventStoreDriver) === sqlite3PongoDriver);
+  });
+
+  void it('fails when the event store driver names no Pongo driver', () => {
+    const { pongoDriver: _, ...withoutPongoDriver } = sqlite3EventStoreDriver;
+
+    assertThrows(
+      () => pongoDriverOf(withoutPongoDriver),
+      (error) => error instanceof EmmettError,
+    );
+  });
+});
+
+void describe('eventStoreDriverOf', () => {
+  void it('returns the driver the context was given', () => {
+    assertTrue(
+      eventStoreDriverOf(sqlite3EventStoreDriver) === sqlite3EventStoreDriver,
+    );
+  });
+
+  void it('fails when the context carries no driver', () => {
+    assertThrows(
+      () => eventStoreDriverOf(undefined),
+      (error) => error instanceof EmmettError,
+    );
+  });
+});
+
+void describe('PoolOrConnectionOptions', () => {
+  void it('needs the driver options when no pool is given', () => {
+    assertTypesEqual<
+      {
+        fileName: string;
+      } extends PoolOrConnectionOptions<SQLite3EventStoreDriver>
+        ? true
+        : false
+    >();
+    assertTypesEqual<
+      // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+      {} extends PoolOrConnectionOptions<SQLite3EventStoreDriver> ? false : true
+    >();
+
+    assertTrue(true);
+  });
+
+  void it('makes the driver options optional when a pool is given', () => {
+    assertTypesEqual<
+      { pool: Dumbo } extends PoolOrConnectionOptions<SQLite3EventStoreDriver>
+        ? true
+        : false
+    >();
+
+    assertTrue(true);
+  });
+});

--- a/src/packages/emmett-sqlite/src/eventStore/projections/pongo/pongoProjection.transaction.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/projections/pongo/pongoProjection.transaction.int.spec.ts
@@ -1,0 +1,165 @@
+import {
+  assertDeepEqual,
+  assertEqual,
+  assertFalse,
+  assertIsNull,
+  assertRejects,
+  type Event,
+} from '@event-driven-io/emmett';
+import { pongoClient } from '@event-driven-io/pongo';
+import { pongoDriver as sqlite3PongoDriver } from '@event-driven-io/pongo/sqlite3';
+import { v4 as uuid } from 'uuid';
+import { afterAll, beforeAll, describe, it } from 'vitest';
+import { sqlite3EventStoreDriver } from '../../../sqlite3';
+import { deleteSQLiteDatabaseFiles } from '../../../testing/sqliteTestDatabase';
+import {
+  getSQLiteEventStore,
+  type SQLiteEventStore,
+} from '../../SQLiteEventStore';
+import {
+  pongoProjection,
+  pongoSingleStreamProjection,
+} from './pongoProjections';
+
+const withDeadline = { timeout: 30000 };
+
+type ProductItemAdded = Event<'ProductItemAdded', { quantity: number }>;
+
+type ShoppingCartSummary = { productItemsCount: number };
+
+void describe('Pongo projection sharing the event store transaction', () => {
+  let fileName: string;
+
+  beforeAll(() => {
+    fileName = `./test-pongo-transaction-${uuid()}.db`;
+  });
+
+  afterAll(() => {
+    deleteSQLiteDatabaseFiles(fileName);
+  });
+
+  void it(
+    'rolls the events and the projected document back when a later projection throws',
+    withDeadline,
+    async () => {
+      const collectionName = uniqueCollectionName();
+
+      const migratingStore = storeWith(collectionName, []);
+      try {
+        await migratingStore.appendToStream<ProductItemAdded>(
+          `shopping_cart:${uuid()}`,
+          [{ type: 'ProductItemAdded', data: { quantity: 1 } }],
+        );
+      } finally {
+        await migratingStore.close();
+      }
+
+      const store = storeWith(collectionName, [failingProjection()]);
+      try {
+        const rolledBackStream = `shopping_cart:${uuid()}`;
+        await assertRejects(
+          store.appendToStream<ProductItemAdded>(rolledBackStream, [
+            { type: 'ProductItemAdded', data: { quantity: 3 } },
+          ]),
+        );
+
+        assertIsNull(await summaryIn(collectionName, rolledBackStream));
+
+        const { streamExists, events } =
+          await store.readStream<ProductItemAdded>(rolledBackStream);
+        assertFalse(streamExists);
+        assertEqual(0, events.length);
+      } finally {
+        await store.close();
+      }
+    },
+  );
+
+  void it(
+    'lets a projection handler open its own Pongo transaction',
+    withDeadline,
+    async () => {
+      const collectionName = uniqueCollectionName();
+      const streamName = `shopping_cart:${uuid()}`;
+      const store = storeWith(collectionName, [nestedTransactionProjection()]);
+
+      try {
+        await store.appendToStream<ProductItemAdded>(streamName, [
+          { type: 'ProductItemAdded', data: { quantity: 3 } },
+        ]);
+
+        assertDeepEqual(await summaryIn(collectionName, streamName), {
+          _id: streamName,
+          _version: 1n,
+          productItemsCount: 3,
+        });
+      } finally {
+        await store.close();
+      }
+    },
+  );
+
+  const storeWith = (
+    collectionName: string,
+    alsoProjecting: ReturnType<typeof failingProjection>[],
+  ): SQLiteEventStore =>
+    getSQLiteEventStore({
+      driver: sqlite3EventStoreDriver,
+      fileName,
+      schema: { autoMigration: 'CreateOrUpdate' },
+      projections: [
+        {
+          type: 'inline',
+          projection: shoppingCartProjection(collectionName),
+        },
+        ...alsoProjecting.map((projection) => ({
+          type: 'inline' as const,
+          projection,
+        })),
+      ],
+    });
+
+  const summaryIn = async (collectionName: string, streamName: string) => {
+    const pongo = pongoClient({
+      connectionString: fileName,
+      driver: sqlite3PongoDriver,
+    });
+
+    try {
+      return await pongo
+        .db()
+        .collection<ShoppingCartSummary>(collectionName)
+        .findOne({ _id: streamName });
+    } finally {
+      await pongo.close();
+    }
+  };
+});
+
+const uniqueCollectionName = () =>
+  `shopping_cart_summary_${uuid().replaceAll('-', '_')}`;
+
+const shoppingCartProjection = (collectionName: string) =>
+  pongoSingleStreamProjection<ShoppingCartSummary, ProductItemAdded>({
+    collectionName,
+    canHandle: ['ProductItemAdded'],
+    evolve: (document: ShoppingCartSummary, event: ProductItemAdded) => ({
+      productItemsCount: document.productItemsCount + event.data.quantity,
+    }),
+    initialState: () => ({ productItemsCount: 0 }),
+  });
+
+const failingProjection = () =>
+  pongoProjection<ProductItemAdded>({
+    name: `failing_${uuid().replaceAll('-', '_')}`,
+    canHandle: ['ProductItemAdded'],
+    handle: () => Promise.reject(new Error('projection failed on purpose')),
+  });
+
+const nestedTransactionProjection = () =>
+  pongoProjection<ProductItemAdded>({
+    name: `nested_${uuid().replaceAll('-', '_')}`,
+    canHandle: ['ProductItemAdded'],
+    handle: (_events, { pongo }) =>
+      pongo.db().withTransaction(() => Promise.resolve()),
+  });

--- a/src/packages/emmett-sqlite/src/eventStore/projections/pongo/pongoProjectionSpec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/projections/pongo/pongoProjectionSpec.ts
@@ -1,4 +1,3 @@
-import type { DatabaseDriverType } from '@event-driven-io/dumbo';
 import type { AnySQLiteConnection } from '@event-driven-io/dumbo/sqlite';
 import {
   assertDeepEqual,
@@ -16,6 +15,10 @@ import {
   type WithId,
 } from '@event-driven-io/pongo';
 import type { SQLiteProjectionAssert } from '..';
+import {
+  pongoDriverOf,
+  type AnySQLiteEventStoreDriver,
+} from '../../eventStoreDriver';
 import type { EventStoreDatabaseSchemaOptions } from '../../schema';
 
 export type PongoAssertOptions = {
@@ -28,23 +31,22 @@ const withCollection = async (
   handle: (collection: PongoCollection<PongoDocument>) => Promise<void>,
   options: {
     connection: AnySQLiteConnection;
+    driver: AnySQLiteEventStoreDriver;
     migrationOptions?: EventStoreDatabaseSchemaOptions | undefined;
   } & PongoAssertOptions,
 ) => {
   const {
     connection,
+    driver,
     inDatabase,
     inCollection,
     collectionOptions,
     migrationOptions,
   } = options;
 
-  const driver = (await pongoDriverRegistry.tryResolve(
-    connection.driverType as DatabaseDriverType,
-  ))!;
   const pongo = pongoClient({
     connectionOptions: { connection },
-    driver,
+    driver: pongoDriverOf(driver),
     defaultSchemaName: migrationOptions?.projectionsDatabaseSchemaName,
     migrationTable: migrationOptions?.migrationTable,
   });

--- a/src/packages/emmett-sqlite/src/eventStore/projections/pongo/pongoProjections.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/projections/pongo/pongoProjections.ts
@@ -19,6 +19,7 @@ import {
   type SQLiteProjectionHandlerContext,
 } from '..';
 import type { SQLiteReadEventMetadata } from '../../SQLiteEventStore';
+import { pongoDriverOf } from '../../eventStoreDriver';
 
 export type PongoProjectionHandlerContext = SQLiteProjectionHandlerContext & {
   pongo: PongoClient;
@@ -107,15 +108,12 @@ export const pongoProjection = <
     canHandle,
     eventsOptions,
     handle: async (events, context) => {
-      const { connection } = context;
-      const driver = (await pongoDriverRegistry.tryResolve(
-        context.driverType,
-      ))!;
+      const { connection } = context.session;
       const pongo = pongoClient({
-        driver,
+        driver: pongoDriverOf(context.driver),
         ...pongoSchemaOptions(context),
-        schema: { autoMigration: 'None' },
         connectionOptions: { connection },
+        schema: { autoMigration: 'None' },
       });
       try {
         await handle(events, {
@@ -128,12 +126,9 @@ export const pongoProjection = <
     },
     truncate: truncate
       ? async (context) => {
-          const { connection } = context;
-          const driver = (await pongoDriverRegistry.tryResolve(
-            context.driverType,
-          ))!;
+          const { connection } = context.session;
           const pongo = pongoClient({
-            driver,
+            driver: pongoDriverOf(context.driver),
             ...pongoSchemaOptions(context),
             connectionOptions: { connection },
           });
@@ -149,12 +144,9 @@ export const pongoProjection = <
       : undefined,
     init: init
       ? async (options) => {
-          const { connection } = options.context;
-          const driver = (await pongoDriverRegistry.tryResolve(
-            options.context.driverType,
-          ))!;
+          const { connection } = options.context.session;
           const pongo = pongoClient({
-            driver,
+            driver: pongoDriverOf(options.context.driver),
             ...pongoSchemaOptions(options.context),
             connectionOptions: { connection },
           });
@@ -281,12 +273,9 @@ export const pongoMultiStreamProjection = <
     },
     canHandle,
     truncate: async (context) => {
-      const { connection } = context;
-      const driver = (await pongoDriverRegistry.tryResolve(
-        context.driverType,
-      ))!;
+      const { connection } = context.session;
       const pongo = pongoClient({
-        driver,
+        driver: pongoDriverOf(context.driver),
         ...pongoSchemaOptions(context),
         connectionOptions: { connection },
       });

--- a/src/packages/emmett-sqlite/src/eventStore/projections/pongo/sqlitePongoProjection.schema.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/projections/pongo/sqlitePongoProjection.schema.int.spec.ts
@@ -25,6 +25,7 @@ import { SQLiteProjectionSpec } from '../sqliteProjectionSpec';
 import { pongoClient, type PongoCollection } from '@event-driven-io/pongo';
 import { pongoSingleStreamProjection } from './pongoProjections';
 import { expectPongoDocuments } from './pongoProjectionSpec';
+import { pongoDriverOf } from '../../eventStoreDriver';
 
 const withDeadline = { timeout: 30000 };
 
@@ -405,9 +406,7 @@ void describe('SQLite Pongo projection schema configuration', () => {
     ) => Promise<Result>,
   ): Promise<Result> =>
     pool.withConnection(async (connection) => {
-      const driver = (await pongoDriverRegistry.tryResolve(
-        connection.driverType,
-      ))!;
+      const driver = pongoDriverOf(sqlite3EventStoreDriver);
       const pongo = pongoClient({
         driver,
         connectionOptions: { connection },

--- a/src/packages/emmett-sqlite/src/eventStore/projections/sqliteProjection.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/projections/sqliteProjection.ts
@@ -1,10 +1,14 @@
 import type {
+  AnyConnection,
+  AnyDatabaseTransaction,
   DatabaseDriverType,
+  Dumbo,
   SQL,
   SQLExecutor,
 } from '@event-driven-io/dumbo';
-import type { AnySQLiteConnection } from '@event-driven-io/dumbo/sqlite';
+
 import {
+  noopScope,
   projection,
   type CanHandle,
   type Event,
@@ -16,52 +20,98 @@ import {
   type ProjectionInitOptions,
   type ReadEvent,
 } from '@event-driven-io/emmett';
+import type {
+  AnySQLiteEventStoreDriver,
+  InferDumboConnectionFromEventStoreDriver,
+  InferDumboOptionsFromEventStoreDriver,
+  InferPoolFromEventStoreDriver,
+  InferTransactionFromEventStoreDriver,
+} from '../eventStoreDriver';
 import type { EventStoreSchemaMigrationOptions } from '../schema';
 import type { SQLiteReadEventMetadata } from '../SQLiteEventStore';
 
-export type SQLiteProjectionHandlerContext = ProjectionHandlerContext<
+export type SQLiteProjectionHandlerContext<
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
+> = ProjectionHandlerContext<
   {
     execute: SQLExecutor;
-    connection: AnySQLiteConnection;
     driverType: DatabaseDriverType;
+    driver?: Driver;
   } &
     // TODO: This should be only for Init options
     // Make init options type configurable for projections
-    EventStoreSchemaMigrationOptions
+    EventStoreSchemaMigrationOptions,
+  {
+    connection: InferDumboConnectionFromEventStoreDriver<Driver>;
+    transaction: InferTransactionFromEventStoreDriver<Driver>;
+    pool: InferPoolFromEventStoreDriver<Driver>;
+    connectionOptions?: InferDumboOptionsFromEventStoreDriver<Driver>;
+  }
 >;
+
+export const transactionToSQLiteProjectionHandlerContext = <
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
+>(
+  session: {
+    pool: Dumbo;
+    driver?: Driver;
+    connectionOptions?: InferDumboOptionsFromEventStoreDriver<Driver>;
+  },
+  transaction: AnyDatabaseTransaction,
+): SQLiteProjectionHandlerContext<Driver> =>
+  ({
+    execute: transaction.execute,
+    driverType: session.pool.driverType,
+    driver: session.driver,
+    session: {
+      ...session,
+      connection: transaction.connection as AnyConnection,
+      transaction: transaction,
+    },
+    observabilityScope: noopScope,
+  }) as SQLiteProjectionHandlerContext<Driver>;
 
 export type SQLiteProjectionHandler<
   EventType extends Event = Event,
   EventMetaDataType extends SQLiteReadEventMetadata = SQLiteReadEventMetadata,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
 > = ProjectionHandler<
   EventType,
   EventMetaDataType,
-  SQLiteProjectionHandlerContext
+  SQLiteProjectionHandlerContext<Driver>
 >;
 
 export type SQLiteProjectionDefinition<
   EventType extends Event = Event,
   EventPayloadType extends Event = EventType,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
 > = ProjectionDefinition<
   EventType,
   SQLiteReadEventMetadata,
-  SQLiteProjectionHandlerContext,
+  SQLiteProjectionHandlerContext<Driver>,
   EventPayloadType
 >;
 
-export type SQLiteProjectionHandlerOptions<EventType extends Event = Event> = {
+export type SQLiteProjectionHandlerOptions<
+  EventType extends Event = Event,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
+> = {
   events: ReadEvent<EventType, SQLiteReadEventMetadata>[];
-  projections: SQLiteProjectionDefinition<EventType>[];
-} & SQLiteProjectionHandlerContext;
+  projections: SQLiteProjectionDefinition<EventType, EventType, Driver>[];
+} & SQLiteProjectionHandlerContext<Driver>;
 
-export const handleProjections = async <EventType extends Event = Event>(
-  options: SQLiteProjectionHandlerOptions<EventType>,
+export const handleProjections = async <
+  EventType extends Event = Event,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
+>(
+  options: SQLiteProjectionHandlerOptions<EventType, Driver>,
 ): Promise<void> => {
   const {
     projections: allProjections,
     events,
-    connection,
+    session,
     execute,
+    driver,
     driverType,
   } = options;
 
@@ -73,8 +123,9 @@ export const handleProjections = async <EventType extends Event = Event>(
     if (filteredEvents.length === 0) continue;
 
     await projection.handle(filteredEvents, {
-      connection,
+      session,
       execute,
+      driver,
       driverType,
       migrationOptions: options.migrationOptions,
       observabilityScope: options.observabilityScope,
@@ -85,30 +136,32 @@ export const handleProjections = async <EventType extends Event = Event>(
 export const sqliteProjection = <
   EventType extends Event,
   EventPayloadType extends Event = EventType,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
 >(
-  definition: SQLiteProjectionDefinition<EventType, EventPayloadType>,
-): SQLiteProjectionDefinition<EventType, EventPayloadType> =>
+  definition: SQLiteProjectionDefinition<EventType, EventPayloadType, Driver>,
+): SQLiteProjectionDefinition<EventType, EventPayloadType, Driver> =>
   projection<
     EventType,
     SQLiteReadEventMetadata,
-    SQLiteProjectionHandlerContext,
+    SQLiteProjectionHandlerContext<Driver>,
     EventPayloadType
   >(definition);
 
 export type SQLiteRawBatchSQLProjection<
   EventType extends Event,
   EventPayloadType extends Event = EventType,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
 > = {
   name: string;
   kind?: string;
   version?: number;
   evolve: (
     events: EventType[],
-    context: SQLiteProjectionHandlerContext,
+    context: SQLiteProjectionHandlerContext<Driver>,
   ) => Promise<SQL[]> | SQL[];
   canHandle: CanHandle<EventType>;
   init?: (
-    context: ProjectionInitOptions<SQLiteProjectionHandlerContext>,
+    context: ProjectionInitOptions<SQLiteProjectionHandlerContext<Driver>>,
   ) => void | Promise<void> | SQL | Promise<SQL> | Promise<SQL[]> | SQL[];
   eventsOptions?: {
     schema?: EventStoreReadSchemaOptions<EventType, EventPayloadType>;
@@ -118,10 +171,11 @@ export type SQLiteRawBatchSQLProjection<
 export const sqliteRawBatchSQLProjection = <
   EventType extends Event,
   EventPayloadType extends Event = EventType,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
 >(
-  options: SQLiteRawBatchSQLProjection<EventType, EventPayloadType>,
-): SQLiteProjectionDefinition<EventType, EventPayloadType> =>
-  sqliteProjection<EventType, EventPayloadType>({
+  options: SQLiteRawBatchSQLProjection<EventType, EventPayloadType, Driver>,
+): SQLiteProjectionDefinition<EventType, EventPayloadType, Driver> =>
+  sqliteProjection<EventType, EventPayloadType, Driver>({
     name: options.name,
     kind: options.kind ?? 'emt:projections:sqlite:raw_sql:batch',
     version: options.version,
@@ -150,17 +204,18 @@ export const sqliteRawBatchSQLProjection = <
 export type SQLiteRawSQLProjection<
   EventType extends Event,
   EventPayloadType extends Event = EventType,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
 > = {
   name: string;
   kind?: string;
   version?: number;
   evolve: (
     events: EventType,
-    context: SQLiteProjectionHandlerContext,
+    context: SQLiteProjectionHandlerContext<Driver>,
   ) => Promise<SQL[]> | SQL[] | Promise<SQL> | SQL;
   canHandle: CanHandle<EventType>;
   init?: (
-    context: ProjectionInitOptions<SQLiteProjectionHandlerContext>,
+    context: ProjectionInitOptions<SQLiteProjectionHandlerContext<Driver>>,
   ) => void | Promise<void> | SQL | Promise<SQL> | Promise<SQL[]> | SQL[];
   eventsOptions?: {
     schema?: EventStoreReadSchemaOptions<EventType, EventPayloadType>;
@@ -170,11 +225,12 @@ export type SQLiteRawSQLProjection<
 export const sqliteRawSQLProjection = <
   EventType extends Event,
   EventPayloadType extends Event = EventType,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
 >(
-  options: SQLiteRawSQLProjection<EventType, EventPayloadType>,
-): SQLiteProjectionDefinition<EventType, EventPayloadType> => {
+  options: SQLiteRawSQLProjection<EventType, EventPayloadType, Driver>,
+): SQLiteProjectionDefinition<EventType, EventPayloadType, Driver> => {
   const { evolve, kind, ...rest } = options;
-  return sqliteRawBatchSQLProjection<EventType, EventPayloadType>({
+  return sqliteRawBatchSQLProjection<EventType, EventPayloadType, Driver>({
     kind: kind ?? 'emt:projections:sqlite:raw:_sql:single',
     ...rest,
     evolve: async (events, context) => {

--- a/src/packages/emmett-sqlite/src/eventStore/projections/sqliteProjectionSpec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/projections/sqliteProjectionSpec.ts
@@ -8,7 +8,6 @@ import {
   assertTrue,
   bigIntProcessorCheckpoint,
   isErrorConstructor,
-  noopScope,
   type CombinedReadEventMetadata,
   type Event,
   type JSONSerializationOptions,
@@ -17,7 +16,9 @@ import {
 } from '@event-driven-io/emmett';
 import { v4 as uuid } from 'uuid';
 import type {
-  AnyEventStoreDriver,
+  AnySQLiteEventStoreDriver,
+  InferDumboOptionsFromEventStoreDriver,
+  InferDumboConnectionFromEventStoreDriver,
   InferOptionsFromEventStoreDriver,
 } from '../eventStoreDriver';
 import {
@@ -30,6 +31,7 @@ import {
 } from '../SQLiteEventStore';
 import {
   handleProjections,
+  transactionToSQLiteProjectionHandlerContext,
   type SQLiteProjectionDefinition,
 } from './sqliteProjection';
 
@@ -60,12 +62,13 @@ export type SQLiteProjectionSpec<EventType extends Event> = (
 
 export type SQLiteProjectionAssert = (options: {
   connection: AnySQLiteConnection;
+  driver: AnySQLiteEventStoreDriver;
   migrationOptions?: EventStoreDatabaseSchemaOptions | undefined;
 }) => Promise<void | boolean>;
 
 export type SQLiteProjectionSpecOptions<
   EventType extends Event,
-  Driver extends AnyEventStoreDriver = AnyEventStoreDriver,
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
 > = {
   projection: SQLiteProjectionDefinition<EventType>;
 
@@ -80,22 +83,28 @@ export type SQLiteProjectionSpecOptions<
 export const SQLiteProjectionSpec = {
   for: <
     EventType extends Event,
-    Driver extends AnyEventStoreDriver = AnyEventStoreDriver,
+    Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
   >(
     options: SQLiteProjectionSpecOptions<EventType, Driver>,
   ): SQLiteProjectionSpec<EventType> => {
     {
-      const driverType = options.driver.driverType;
-      const pool =
-        options.pool ??
-        dumbo({
-          serialization: options.serialization,
-          transactionOptions: {
-            allowNestedTransactions: true,
-            mode: 'session_based',
-          },
-          ...options.driver.mapToDumboOptions(options),
-        });
+      const driver = options.driver;
+      const dumboOptions = {
+        serialization: options.serialization,
+        transactionOptions: {
+          allowNestedTransactions: true,
+          mode: 'session_based',
+        },
+        ...options.driver.mapToDumboOptions(options),
+      } as InferDumboOptionsFromEventStoreDriver<Driver>;
+
+      const pool = options.pool ?? dumbo(dumboOptions);
+
+      const session = {
+        pool: pool,
+        driver,
+        connectionOptions: dumboOptions,
+      };
       const projection = options.projection;
       const migrationOptions = {
         ...options.schema,
@@ -114,17 +123,19 @@ export const SQLiteProjectionSpec = {
         await eventStore.schema.migrate();
 
         if (projection.init)
-          await projection.init({
-            registrationType: 'async',
-            status: 'active',
-            context: {
-              execute: connection.execute,
-              connection,
-              driverType,
-              migrationOptions,
-              observabilityScope: noopScope,
-            },
-            version: projection.version ?? 1,
+          await connection.withTransaction(async (transaction) => {
+            await projection.init!({
+              registrationType: 'async',
+              status: 'active',
+              context: {
+                ...transactionToSQLiteProjectionHandlerContext(
+                  session,
+                  transaction,
+                ),
+                migrationOptions,
+              },
+              version: projection.version ?? 1,
+            });
           });
       };
 
@@ -137,7 +148,10 @@ export const SQLiteProjectionSpec = {
             const allEvents: ReadEvent<EventType, SQLiteReadEventMetadata>[] =
               [];
 
-            const run = async (connection: AnySQLiteConnection) => {
+            const run = async (untypedConnection: AnySQLiteConnection) => {
+              // TODO: Fix this cast when the pool plumbing is driver-generic
+              const connection =
+                untypedConnection as InferDumboConnectionFromEventStoreDriver<Driver>;
               let globalPosition = 0n;
               const numberOfTimes = options?.numberOfTimes ?? 1;
 
@@ -168,15 +182,15 @@ export const SQLiteProjectionSpec = {
 
               await initialize(connection);
 
-              await connection.withTransaction(() =>
+              await connection.withTransaction((transaction) =>
                 handleProjections({
                   events: allEvents,
                   projections: [projection],
-                  execute: connection.execute,
-                  connection,
-                  driverType,
+                  ...transactionToSQLiteProjectionHandlerContext(
+                    session,
+                    transaction,
+                  ),
                   migrationOptions,
-                  observabilityScope: noopScope,
                 }),
               );
             };
@@ -191,6 +205,7 @@ export const SQLiteProjectionSpec = {
 
                   const succeeded = await assert({
                     connection,
+                    driver,
                     migrationOptions,
                   });
 

--- a/src/packages/emmett-sqlite/src/eventStore/schema/appendToStream.d1.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/schema/appendToStream.d1.int.spec.ts
@@ -69,7 +69,7 @@ void describe('appendEvent', () => {
     });
     execute = connection.execute;
     pool = d1Pool({ database, connection });
-    await createEventStoreSchema(pool);
+    await createEventStoreSchema({ pool });
   });
 
   afterAll(async () => {

--- a/src/packages/emmett-sqlite/src/eventStore/schema/appendToStream.sqlite3.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/schema/appendToStream.sqlite3.int.spec.ts
@@ -60,7 +60,9 @@ void describe('appendEvent', () => {
       connection,
     });
     execute = connection.execute;
-    await createEventStoreSchema(pool);
+    await createEventStoreSchema({
+      pool,
+    });
   });
 
   afterAll(async () => {

--- a/src/packages/emmett-sqlite/src/eventStore/schema/appendToStream.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/schema/appendToStream.ts
@@ -56,7 +56,10 @@ export const appendToStream = async <MessageType extends Message>(
     context?: ObservabilityContext;
     onBeforeCommit?: BeforeEventStoreCommitHandler<
       SQLiteEventStore,
-      { connection: AnySQLiteConnection }
+      {
+        connection: AnySQLiteConnection;
+        transaction: AnyDatabaseTransaction;
+      }
     >;
   },
 ): Promise<AppendEventResult> => {
@@ -110,7 +113,10 @@ export const appendToStream = async <MessageType extends Message>(
         );
 
         if (options?.onBeforeCommit)
-          await options.onBeforeCommit(messagesToAppend, { connection });
+          await options.onBeforeCommit(messagesToAppend, {
+            connection,
+            transaction,
+          });
 
         // TODO: Refactor this to map or not success from appendToStreamRaw
         return { success: true, result };

--- a/src/packages/emmett-sqlite/src/eventStore/schema/createEventStoreSchema.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/schema/createEventStoreSchema.int.spec.ts
@@ -39,7 +39,9 @@ void describe('createEventStoreSchema', () => {
       },
     });
 
-    await createEventStoreSchema(pool);
+    await createEventStoreSchema({
+      pool,
+    });
   });
 
   afterAll(async () => {
@@ -74,8 +76,11 @@ void describe('createEventStoreSchema with configured database schemas', () => {
   });
 
   void it('creates the event store objects in the schema configured by the user', async () => {
-    await createEventStoreSchema(pool, undefined, {
-      databaseSchemaName: 'events',
+    await createEventStoreSchema({
+      pool,
+      schema: {
+        databaseSchemaName: 'events',
+      },
     });
 
     assertTrue(await configuredTableExists('events', 'emt_streams'));
@@ -90,11 +95,14 @@ void describe('createEventStoreSchema with configured database schemas', () => {
   });
 
   void it('uses the migration table schema and name configured by the user', async () => {
-    await createEventStoreSchema(pool, undefined, {
-      databaseSchemaName: 'store',
-      migrationTable: {
-        schemaName: 'infrastructure',
-        tableName: 'emmett_migrations',
+    await createEventStoreSchema({
+      pool,
+      schema: {
+        databaseSchemaName: 'store',
+        migrationTable: {
+          schemaName: 'infrastructure',
+          tableName: 'emmett_migrations',
+        },
       },
     });
 
@@ -110,7 +118,10 @@ void describe('createEventStoreSchema with configured database schemas', () => {
   void it('records no migrations from before schema support in the schema configured by the user', async () => {
     const schemaOptions = { databaseSchemaName: 'events' };
 
-    await createEventStoreSchema(pool, undefined, schemaOptions);
+    await createEventStoreSchema({
+      pool,
+      schema: schemaOptions,
+    });
 
     assertDeepEqual(
       await migrationNames({
@@ -166,9 +177,9 @@ void describe('createEventStoreSchema with configured database schemas', () => {
     let afterMigrationTableSchemaName: string | undefined;
     let afterProjectionsDatabaseSchemaName: string | undefined;
 
-    await createEventStoreSchema(
+    await createEventStoreSchema({
       pool,
-      {
+      hooks: {
         onBeforeSchemaCreated: (context) => {
           beforeMigrationTableSchemaName =
             context.migrationOptions?.migrationTable?.schemaName;
@@ -182,11 +193,11 @@ void describe('createEventStoreSchema with configured database schemas', () => {
             context.migrationOptions?.projectionsDatabaseSchemaName;
         },
       },
-      {
+      schema: {
         databaseSchemaName: 'events',
         migrationTable: { tableName: 'emmett_migrations' },
       },
-    );
+    });
 
     assertEqual(beforeMigrationTableSchemaName, 'events');
     assertEqual(beforeProjectionsDatabaseSchemaName, 'events');
@@ -274,7 +285,10 @@ void describe('createEventStoreSchema with configured database schemas', () => {
   void it('stores and reads events from the configured schema when the user turns auto migration off', async () => {
     const schemaOptions = { databaseSchemaName: 'events' };
     const streamName = `shopping_cart-${uuid()}`;
-    await createEventStoreSchema(pool, undefined, schemaOptions);
+    await createEventStoreSchema({
+      pool,
+      schema: schemaOptions,
+    });
 
     const eventStore = getSQLiteEventStore({
       driver: sqlite3EventStoreDriver,

--- a/src/packages/emmett-sqlite/src/eventStore/schema/index.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/schema/index.ts
@@ -3,9 +3,14 @@ import {
   type Dumbo,
   type RunSQLMigrationsResult,
 } from '@event-driven-io/dumbo';
-import type { AnySQLiteConnection } from '@event-driven-io/dumbo/sqlite';
-import { noopScope } from '@event-driven-io/emmett';
-import type { SQLiteProjectionHandlerContext } from '../projections';
+import type {
+  AnySQLiteEventStoreDriver,
+  InferDumboOptionsFromEventStoreDriver,
+} from '../eventStoreDriver';
+import {
+  transactionToSQLiteProjectionHandlerContext,
+  type SQLiteProjectionHandlerContext,
+} from '../projections';
 import type { SQLiteEventStoreOptions } from '../SQLiteEventStore';
 import {
   eventStoreDatabaseSchema,
@@ -36,22 +41,28 @@ export type EventStoreSchemaMigrationOptions = {
   migrationOptions?: CreateEventStoreSchemaOptions;
 };
 
-export const createEventStoreSchema = (
-  pool: Dumbo,
-  hooks?: SQLiteEventStoreOptions['hooks'],
-  options?: CreateEventStoreSchemaOptions,
-): Promise<RunSQLMigrationsResult> =>
-  pool.withTransaction<RunSQLMigrationsResult>(async (tx) => {
+export const createEventStoreSchema = <
+  Driver extends AnySQLiteEventStoreDriver = AnySQLiteEventStoreDriver,
+>({
+  hooks,
+  schema: options,
+  ...session
+}: {
+  pool: Dumbo;
+  driver?: Driver;
+  connectionOptions?: InferDumboOptionsFromEventStoreDriver<Driver>;
+  hooks?: SQLiteEventStoreOptions['hooks'];
+  schema?: CreateEventStoreSchemaOptions;
+}): Promise<RunSQLMigrationsResult> =>
+  session.pool.withTransaction<RunSQLMigrationsResult>(async (tx) => {
+    const { pool } = session;
     const databaseSchema = eventStoreDatabaseSchema(options);
-    const schemaContext: SQLiteProjectionHandlerContext = {
-      execute: tx.execute,
-      connection: tx.connection as AnySQLiteConnection,
-      driverType: pool.driverType,
+    const schemaContext: SQLiteProjectionHandlerContext<Driver> = {
+      ...transactionToSQLiteProjectionHandlerContext(session, tx),
       migrationOptions: {
         ...options,
         ...databaseSchema,
       },
-      observabilityScope: noopScope,
     };
 
     if (hooks?.onBeforeSchemaCreated) {

--- a/src/packages/emmett-sqlite/src/eventStore/schema/readLastMessageGlobalPosition.d1.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/schema/readLastMessageGlobalPosition.d1.int.spec.ts
@@ -53,7 +53,7 @@ void describe('readLastMessageGlobalPosition', () => {
       },
     });
     pool = d1Pool({ database, connection });
-    await createEventStoreSchema(pool);
+    await createEventStoreSchema({ pool });
   });
 
   beforeEach(async () => {

--- a/src/packages/emmett-sqlite/src/eventStore/schema/readLastMessageGlobalPosition.sqlite3.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/schema/readLastMessageGlobalPosition.sqlite3.int.spec.ts
@@ -44,7 +44,9 @@ void describe('readLastMessageGlobalPosition', () => {
       singleton: true,
       connection,
     });
-    await createEventStoreSchema(pool);
+    await createEventStoreSchema({
+      pool,
+    });
   });
 
   beforeEach(async () => {

--- a/src/packages/emmett-sqlite/src/eventStore/schema/readStream.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/schema/readStream.int.spec.ts
@@ -58,7 +58,9 @@ void describe('appendEvent', () => {
       singleton: true,
       connection,
     });
-    await createEventStoreSchema(pool);
+    await createEventStoreSchema({
+      pool,
+    });
   });
 
   afterAll(async () => {

--- a/src/packages/emmett-sqlite/src/eventStore/schema/truncateTables.int.spec.ts
+++ b/src/packages/emmett-sqlite/src/eventStore/schema/truncateTables.int.spec.ts
@@ -65,7 +65,7 @@ void describe('truncateTables', () => {
 
   void it('truncates all tables in the default database schema', async () => {
     // Given
-    await createEventStoreSchema(pool);
+    await createEventStoreSchema({ pool });
     await appendTestEvent(uuid());
 
     assertEqual(1, await tableCount(undefined, streamsTable.name));
@@ -83,11 +83,17 @@ void describe('truncateTables', () => {
 
   void it('truncates only the tables in the database schema configured by the user', async () => {
     // Given
-    await createEventStoreSchema(pool, undefined, {
-      databaseSchemaName: 'events',
+    await createEventStoreSchema({
+      pool,
+      schema: {
+        databaseSchemaName: 'events',
+      },
     });
-    await createEventStoreSchema(pool, undefined, {
-      databaseSchemaName: 'other_events',
+    await createEventStoreSchema({
+      pool,
+      schema: {
+        databaseSchemaName: 'other_events',
+      },
     });
 
     await appendTestEvent(uuid(), 'events');
@@ -153,7 +159,7 @@ void describe('truncateTables', () => {
 
   void it('restarts the global position at 1 after truncating', async () => {
     // Given
-    await createEventStoreSchema(pool);
+    await createEventStoreSchema({ pool });
     await appendTestEvent(uuid());
 
     const firstGlobalPosition = await latestGlobalPosition();
@@ -173,11 +179,17 @@ void describe('truncateTables', () => {
 
   void it('restarts the global position at 1 only in the truncated database schema', async () => {
     // Given
-    await createEventStoreSchema(pool, undefined, {
-      databaseSchemaName: 'events',
+    await createEventStoreSchema({
+      pool,
+      schema: {
+        databaseSchemaName: 'events',
+      },
     });
-    await createEventStoreSchema(pool, undefined, {
-      databaseSchemaName: 'other_events',
+    await createEventStoreSchema({
+      pool,
+      schema: {
+        databaseSchemaName: 'other_events',
+      },
     });
 
     await appendTestEvent(uuid(), 'events');

--- a/src/packages/emmett-sqlite/src/sqlite3.ts
+++ b/src/packages/emmett-sqlite/src/sqlite3.ts
@@ -1,24 +1,27 @@
 import type { SQLite3DumboOptions } from '@event-driven-io/dumbo/sqlite3';
 import { sqlite3DumboDriver } from '@event-driven-io/dumbo/sqlite3';
+import { pongoDriver as sqlite3PongoDriver } from '@event-driven-io/pongo/sqlite3';
 import type { SQLiteEventStoreOptions } from './eventStore';
 import type { EventStoreDriver } from './eventStore/eventStoreDriver';
 
-export const sqlite3EventStoreDriver: EventStoreDriver<
-  typeof sqlite3DumboDriver,
-  SQLite3EventStoreDriverOptions
-> = {
+export const sqlite3EventStoreDriver = {
   driverType: sqlite3DumboDriver.driverType,
   dumboDriver: sqlite3DumboDriver,
-  mapToDumboOptions: (driverOptions) =>
+  pongoDriver: sqlite3PongoDriver,
+  mapToDumboOptions: (options) =>
     ({
       driver: sqlite3DumboDriver,
-      fileName: driverOptions.fileName,
-      ...driverOptions.connectionOptions,
+      fileName: options.fileName,
+      ...options.connectionOptions,
       transactionOptions: {
         allowNestedTransactions: true,
+        ...options.connectionOptions?.transactionOptions,
       },
     }) as SQLite3DumboOptions,
-};
+} satisfies EventStoreDriver<
+  typeof sqlite3DumboDriver,
+  SQLite3EventStoreDriverOptions
+>;
 
 export type SQLite3EventStoreDriver = typeof sqlite3EventStoreDriver;
 

--- a/src/packages/emmett-sqlite/src/sqlite3.unit.spec.ts
+++ b/src/packages/emmett-sqlite/src/sqlite3.unit.spec.ts
@@ -1,0 +1,82 @@
+import type { SQLite3DumboOptions } from '@event-driven-io/dumbo/sqlite3';
+import { sqlite3DumboDriver } from '@event-driven-io/dumbo/sqlite3';
+import { assertEqual } from '@event-driven-io/emmett';
+import { pongoDriver as sqlite3PongoDriver } from '@event-driven-io/pongo/sqlite3';
+import { describe, it } from 'vitest';
+import {
+  sqlite3EventStoreDriver,
+  type SQLite3EventStoreDriverOptions,
+} from './sqlite3';
+
+const fileName = ':memory:';
+
+/**
+ * `SQLite3DumboOptions` has no `driver` key of its own, so the mapped options
+ * declare it only through the cast inside {@link sqlite3EventStoreDriver}.
+ * Reading it back needs the same widening.
+ */
+const driverOf = (options: SQLite3DumboOptions): unknown =>
+  (options as { driver?: unknown }).driver;
+
+void describe('sqlite3EventStoreDriver', () => {
+  void it('names the same driver type as the dumbo driver it wraps', () => {
+    assertEqual(
+      sqlite3DumboDriver.driverType,
+      sqlite3EventStoreDriver.driverType,
+    );
+    assertEqual(sqlite3DumboDriver, sqlite3EventStoreDriver.dumboDriver);
+  });
+
+  void it('carries the Pongo driver its projections need', () => {
+    assertEqual<unknown>(
+      sqlite3PongoDriver,
+      sqlite3EventStoreDriver.pongoDriver,
+    );
+  });
+
+  void it('carries the driver when given a file name alone', () => {
+    const options = sqlite3EventStoreDriver.mapToDumboOptions({ fileName });
+
+    assertEqual(sqlite3DumboDriver, driverOf(options));
+    assertEqual(fileName, options.fileName);
+  });
+
+  void it('carries the driver for every supported option shape', () => {
+    const shapes: SQLite3EventStoreDriverOptions[] = [
+      { fileName },
+      { fileName, connectionOptions: undefined },
+      {
+        fileName,
+        connectionOptions: {
+          transactionOptions: { allowNestedTransactions: false },
+        },
+      },
+    ];
+
+    for (const shape of shapes) {
+      const options = sqlite3EventStoreDriver.mapToDumboOptions(shape);
+
+      assertEqual(sqlite3DumboDriver, driverOf(options));
+      assertEqual(fileName, options.fileName);
+    }
+  });
+
+  void it('allows nested transactions unless the caller says otherwise', () => {
+    assertEqual(
+      true,
+      sqlite3EventStoreDriver.mapToDumboOptions({ fileName }).transactionOptions
+        ?.allowNestedTransactions,
+    );
+  });
+
+  void it('keeps the transaction options the caller set explicitly', () => {
+    const { transactionOptions } = sqlite3EventStoreDriver.mapToDumboOptions({
+      fileName,
+      connectionOptions: {
+        transactionOptions: { allowNestedTransactions: false },
+      },
+    });
+
+    assertEqual(false, transactionOptions?.allowNestedTransactions);
+  });
+});

--- a/src/packages/emmett-sqlite/src/testing/dumboDriverIsolation.ts
+++ b/src/packages/emmett-sqlite/src/testing/dumboDriverIsolation.ts
@@ -1,0 +1,37 @@
+import { dumboDatabaseDriverRegistry } from '@event-driven-io/dumbo';
+
+/**
+ * A connection string no driver can claim. The global registry resolves a
+ * driver either from an explicit `driverType` or by parsing the connection
+ * string; an unparseable one leaves it with nothing to match. A `dumbo()` call
+ * that still succeeds on these options was therefore handed its driver.
+ */
+export const unresolvableConnectionString = 'driver-must-come-from-options';
+
+type MutableRegistry = {
+  tryGet: (typeof dumboDatabaseDriverRegistry)['tryGet'];
+  tryResolve: (typeof dumboDatabaseDriverRegistry)['tryResolve'];
+};
+
+/**
+ * Makes the global dumbo driver registry resolve nothing, and returns the
+ * function that puts it back.
+ *
+ * The registry exposes no `clear`, and `dumbo()` reads it through the imported
+ * module binding rather than through `globalThis`, so replacing the global slot
+ * goes unnoticed. Overriding the lookup on the shared object is the only
+ * observable way to empty it. That makes this global for the duration of the
+ * override, so it belongs in a spec file of its own.
+ */
+export const clearRegisteredDumboDrivers = (): (() => void) => {
+  const registry = dumboDatabaseDriverRegistry as MutableRegistry;
+  const { tryGet, tryResolve } = registry;
+
+  registry.tryGet = () => null;
+  registry.tryResolve = () => Promise.resolve(null);
+
+  return () => {
+    registry.tryGet = tryGet;
+    registry.tryResolve = tryResolve;
+  };
+};

--- a/src/packages/emmett-sqlite/src/testing/dumboDriverIsolation.unit.spec.ts
+++ b/src/packages/emmett-sqlite/src/testing/dumboDriverIsolation.unit.spec.ts
@@ -1,0 +1,43 @@
+import { dumbo, dumboDatabaseDriverRegistry } from '@event-driven-io/dumbo';
+import '@event-driven-io/dumbo/sqlite3';
+import {
+  assertEqual,
+  assertIsNotNull,
+  assertThrows,
+  assertTrue,
+} from '@event-driven-io/emmett';
+import { afterEach, beforeEach, describe, it } from 'vitest';
+import { clearRegisteredDumboDrivers } from './dumboDriverIsolation';
+
+const connectionString = 'file::memory:';
+
+void describe('clearRegisteredDumboDrivers', () => {
+  let restore: () => void;
+
+  beforeEach(() => {
+    restore = clearRegisteredDumboDrivers();
+  });
+
+  afterEach(() => {
+    restore();
+  });
+
+  void it('leaves the driver registry unable to resolve anything', () => {
+    assertEqual(null, dumboDatabaseDriverRegistry.tryGet({ connectionString }));
+
+    // eslint-disable-next-line no-restricted-syntax
+    const error = assertThrows<Error>(() => dumbo({ connectionString }));
+
+    assertTrue(error.message.includes('No plugin found for driver type'));
+  });
+
+  void it('resolves drivers again once restored', async () => {
+    restore();
+
+    assertIsNotNull(dumboDatabaseDriverRegistry.tryGet({ connectionString }));
+
+    // eslint-disable-next-line no-restricted-syntax
+    const pool = dumbo({ connectionString });
+    await pool.close();
+  });
+});

--- a/src/packages/emmett-tests/src/processors/postgreSQLProcessorLock.int.spec.ts
+++ b/src/packages/emmett-tests/src/processors/postgreSQLProcessorLock.int.spec.ts
@@ -26,7 +26,7 @@ beforeAll(async () => {
     driver: pgDumboDriver,
     transactionOptions: { allowNestedTransactions: true },
   });
-  await createEventStoreSchema({ connectionString }, pool);
+  await createEventStoreSchema({ pool });
 }, 120000);
 
 afterAll(async () => {

--- a/src/packages/emmett/src/consumers/consumers.ts
+++ b/src/packages/emmett/src/consumers/consumers.ts
@@ -19,7 +19,8 @@ import type {
   AnyEvent,
   AnyReadEventMetadata,
   Message,
-  MessageHandlerContext,
+  AnyMessageHandlerContext,
+  PartialHandlerContext,
   RecordedMessage,
 } from '../typing';
 import { asyncAwaiter, type AsyncAwaiter } from '../utils';
@@ -111,9 +112,9 @@ export type MessageConsumer<
  * wrapped in `pool.withConnection`.
  */
 export type MessageConsumerScope<
-  HandlerContext extends MessageHandlerContext | undefined = undefined,
+  HandlerContext extends AnyMessageHandlerContext = AnyMessageHandlerContext,
 > = <Result>(
-  handler: (context: Partial<HandlerContext>) => Promise<Result>,
+  handler: (context: PartialHandlerContext<HandlerContext>) => Promise<Result>,
 ) => Promise<Result>;
 
 export const DefaultConsumerBatchSize = 100;
@@ -131,7 +132,7 @@ export type MessageConsumerSetup<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ConsumerMessageType extends Message = any,
   MessageMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
-  HandlerContext extends MessageHandlerContext | undefined = undefined,
+  HandlerContext extends AnyMessageHandlerContext = AnyMessageHandlerContext,
   ReactorFactory extends AnyMessageProcessorFactory<ConsumerMessageType> =
     never,
   ProjectorFactory extends AnyMessageProcessorFactory<ConsumerMessageType> =
@@ -187,7 +188,7 @@ export const consumer = <
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ConsumerMessageType extends Message = any,
   MessageMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
-  HandlerContext extends MessageHandlerContext | undefined = undefined,
+  HandlerContext extends AnyMessageHandlerContext = AnyMessageHandlerContext,
   ReactorFactory extends AnyMessageProcessorFactory<ConsumerMessageType> =
     never,
   ProjectorFactory extends AnyMessageProcessorFactory<ConsumerMessageType> =

--- a/src/packages/emmett/src/consumers/consumers.unit.spec.ts
+++ b/src/packages/emmett/src/consumers/consumers.unit.spec.ts
@@ -22,6 +22,7 @@ import type {
   Command,
   Event,
   Message,
+  AnyMessageHandlerContext,
   MessageHandlerContext,
   RecordedMessage,
 } from '../typing';
@@ -176,7 +177,7 @@ const testProcessorFactory: TestProcessorFactory = ({ processor }) => processor;
 const testConsumer = <
   ConsumerMessageType extends Message = AnyMessage,
   MessageMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
-  HandlerContext extends MessageHandlerContext | undefined = undefined,
+  HandlerContext extends AnyMessageHandlerContext = AnyMessageHandlerContext,
 >(
   options: Omit<
     MessageConsumerSetup<

--- a/src/packages/emmett/src/eventStore/projections/inMemory/inMemoryProjection.ts
+++ b/src/packages/emmett/src/eventStore/projections/inMemory/inMemoryProjection.ts
@@ -59,6 +59,7 @@ export const handleInMemoryProjections = async <
       projection.handle(filteredEvents, {
         eventStore,
         database,
+        session: {},
         observabilityScope,
       }),
     );

--- a/src/packages/emmett/src/processors/inMemoryProcessors.ts
+++ b/src/packages/emmett/src/processors/inMemoryProcessors.ts
@@ -176,7 +176,11 @@ const inMemoryProcessingScope = (options: {
         `InMemory processor '${options.processorId}' is missing database. Ensure that you passed it through options`,
       );
 
-    return handler({ ...partialContext, database });
+    return handler({
+      ...partialContext,
+      database,
+      session: partialContext?.session ?? {},
+    });
   };
 
   return processingScope;

--- a/src/packages/emmett/src/processors/processorStartPositions.ts
+++ b/src/packages/emmett/src/processors/processorStartPositions.ts
@@ -2,7 +2,8 @@ import type {
   AnyMessage,
   AnyReadEventMetadata,
   Message,
-  MessageHandlerContext,
+  AnyMessageHandlerContext,
+  PartialHandlerContext,
   RecordedMessage,
 } from '../typing';
 import type { MaybePromise } from '../utils';
@@ -80,14 +81,14 @@ export const ProcessorStartPositions = (): ProcessorStartPositions => {
 export type ResolveConsumerStartPositionsOptions<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ConsumerMessageType extends Message = any,
-  HandlerContext extends MessageHandlerContext | undefined = undefined,
+  HandlerContext extends AnyMessageHandlerContext = AnyMessageHandlerContext,
 > = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   processors: Array<MessageProcessor<ConsumerMessageType, any, HandlerContext>>;
   readLastMessageCheckpoint: (
-    context: Partial<HandlerContext>,
+    context: PartialHandlerContext<HandlerContext>,
   ) => MaybePromise<ProcessorCheckpoint | null>;
-  handlerContext: Partial<HandlerContext>;
+  handlerContext: PartialHandlerContext<HandlerContext>;
   /**
    * Wraps only the processors' own start calls. The checkpoint read stays
    * outside it,
@@ -95,7 +96,9 @@ export type ResolveConsumerStartPositionsOptions<
    * pooled connection) that reading the checkpoint would wait on forever.
    */
   scope?: <Result>(
-    handler: (context: Partial<HandlerContext>) => Promise<Result>,
+    handler: (
+      context: PartialHandlerContext<HandlerContext>,
+    ) => Promise<Result>,
   ) => Promise<Result>;
 };
 
@@ -103,7 +106,7 @@ export const ConsumerStartPositions = {
   resolve: async <
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ConsumerMessageType extends Message = any,
-    HandlerContext extends MessageHandlerContext | undefined = undefined,
+    HandlerContext extends AnyMessageHandlerContext = AnyMessageHandlerContext,
   >({
     processors,
     handlerContext: handlerOptions,
@@ -117,8 +120,11 @@ export const ConsumerStartPositions = {
 
     const inScope =
       scope ??
-      ((handler: (context: Partial<HandlerContext>) => Promise<void>) =>
-        handler(handlerOptions));
+      ((
+        handler: (
+          context: PartialHandlerContext<HandlerContext>,
+        ) => Promise<void>,
+      ) => handler(handlerOptions));
 
     await inScope((context) =>
       Promise.all(

--- a/src/packages/emmett/src/processors/processors.observability.unit.spec.ts
+++ b/src/packages/emmett/src/processors/processors.observability.unit.spec.ts
@@ -214,11 +214,14 @@ describe('processors observability wiring', () => {
       reactor<
         AnyMessage,
         AnyRecordedMessageMetadata,
-        MessageHandlerContext<{ connection: { messageStore: EventStore } }>
+        MessageHandlerContext<
+          Record<never, never>,
+          { messageStore: EventStore }
+        >
       >({
         processorId: 'test',
         eachMessage: async (_message, context) => {
-          await context.connection.messageStore.appendToStream(streamName, [
+          await context.session.messageStore.appendToStream(streamName, [
             { type: 'OrderConfirmed', kind: 'Event', data: {} },
           ]);
         },
@@ -226,7 +229,7 @@ describe('processors observability wiring', () => {
       }),
     )
       .when(async (reactor) => {
-        await reactor.start({ connection: { messageStore: eventStore } });
+        await reactor.start({ session: { messageStore: eventStore } });
         await reactor.handle(
           [
             makeMessage('OrderPlaced', {
@@ -234,9 +237,9 @@ describe('processors observability wiring', () => {
               correlationId: 'flow-1',
             }),
           ],
-          { connection: { messageStore: eventStore } },
+          { session: { messageStore: eventStore } },
         );
-        await reactor.close({ connection: { messageStore: eventStore } });
+        await reactor.close({ session: { messageStore: eventStore } });
 
         const { events } = await eventStore.readStream(streamName);
         metadata = events[0]?.metadata;

--- a/src/packages/emmett/src/processors/processors.ts
+++ b/src/packages/emmett/src/processors/processors.ts
@@ -29,7 +29,9 @@ import {
   type DefaultRecord,
   type Event,
   type Message,
+  type AnyMessageHandlerContext,
   type MessageHandlerContext,
+  type PartialHandlerContext,
   type RecordedMessage,
   type SingleMessageHandlerResult,
   type SingleRecordedMessageHandlerWithContext,
@@ -146,17 +148,19 @@ const raceWithTimeout = (
 export type MessageProcessor<
   MessageType extends AnyMessage = AnyMessage,
   MessageMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
-  HandlerContext extends MessageHandlerContext | undefined = undefined,
+  HandlerContext extends AnyMessageHandlerContext = AnyMessageHandlerContext,
 > = {
   id: string;
   instanceId: string;
   type: string;
   canHandle?: string[];
-  init: (options?: Partial<HandlerContext>) => Promise<void>;
+  init: (options?: PartialHandlerContext<HandlerContext>) => Promise<void>;
   start: (
-    options?: Partial<HandlerContext>,
+    options?: PartialHandlerContext<HandlerContext>,
   ) => Promise<CurrentMessageProcessorPosition | undefined>;
-  close: (closeOptions?: Partial<HandlerContext>) => Promise<void>;
+  close: (
+    closeOptions?: PartialHandlerContext<HandlerContext>,
+  ) => Promise<void>;
   isActive: boolean;
   /**
    * Resolves once the processor has stored a checkpoint at or past the given
@@ -171,7 +175,7 @@ export type MessageProcessor<
   handle: BatchRecordedMessageHandlerWithContext<
     MessageType,
     MessageMetadataType,
-    Partial<HandlerContext>
+    PartialHandlerContext<HandlerContext>
   >;
 };
 
@@ -286,14 +290,14 @@ export const MessageProcessor = {
 };
 
 export type MessageProcessingScope<
-  HandlerContext extends MessageHandlerContext | undefined = undefined,
+  HandlerContext extends AnyMessageHandlerContext = AnyMessageHandlerContext,
 > = <Result = SingleMessageHandlerResult>(
   handler: (context: HandlerContext) => Result | Promise<Result>,
-  partialContext: WithObservabilityScope<Partial<HandlerContext>>,
+  partialContext: WithObservabilityScope<PartialHandlerContext<HandlerContext>>,
 ) => Result | Promise<Result>;
 
 export type ProcessorHooks<
-  HandlerContext extends MessageHandlerContext = MessageHandlerContext,
+  HandlerContext extends AnyMessageHandlerContext = AnyMessageHandlerContext,
 > = {
   onInit?: OnReactorInitHook<HandlerContext>;
   onStart?: OnReactorStartHook<HandlerContext>;
@@ -303,7 +307,7 @@ export type ProcessorHooks<
 export type BaseMessageProcessorOptions<
   MessageType extends AnyMessage = AnyMessage,
   MessageMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
-  HandlerContext extends MessageHandlerContext = MessageHandlerContext,
+  HandlerContext extends AnyMessageHandlerContext = AnyMessageHandlerContext,
 > = {
   type?: string;
   processorId: string;
@@ -327,7 +331,7 @@ export type BaseMessageProcessorOptions<
 export type HandlerOptions<
   MessageType extends AnyMessage = AnyMessage,
   MessageMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
-  HandlerContext extends MessageHandlerContext = MessageHandlerContext,
+  HandlerContext extends AnyMessageHandlerContext = AnyMessageHandlerContext,
 > =
   | {
       eachMessage: SingleRecordedMessageHandlerWithContext<
@@ -347,21 +351,21 @@ export type HandlerOptions<
     };
 
 export type OnReactorInitHook<
-  HandlerContext extends MessageHandlerContext = MessageHandlerContext,
+  HandlerContext extends AnyMessageHandlerContext = AnyMessageHandlerContext,
 > = (context: HandlerContext) => Promise<void>;
 
 export type OnReactorStartHook<
-  HandlerContext extends MessageHandlerContext = MessageHandlerContext,
+  HandlerContext extends AnyMessageHandlerContext = AnyMessageHandlerContext,
 > = (context: HandlerContext) => Promise<void>;
 
 export type OnReactorCloseHook<
-  HandlerContext extends MessageHandlerContext = MessageHandlerContext,
+  HandlerContext extends AnyMessageHandlerContext = AnyMessageHandlerContext,
 > = (context: HandlerContext) => Promise<void>;
 
 export type ReactorOptions<
   MessageType extends AnyMessage = AnyMessage,
   MessageMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
-  HandlerContext extends MessageHandlerContext = MessageHandlerContext,
+  HandlerContext extends AnyMessageHandlerContext = AnyMessageHandlerContext,
   MessagePayloadType extends AnyMessage = MessageType,
 > = BaseMessageProcessorOptions<
   MessageType,
@@ -379,7 +383,7 @@ export type ReactorOptions<
 export type ProjectorOptions<
   EventType extends AnyEvent = AnyEvent,
   MessageMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
-  HandlerContext extends MessageHandlerContext = MessageHandlerContext,
+  HandlerContext extends AnyMessageHandlerContext = AnyMessageHandlerContext,
   EventPayloadType extends Event = EventType,
 > = Omit<
   BaseMessageProcessorOptions<EventType, MessageMetadataType, HandlerContext>,
@@ -395,13 +399,13 @@ export type ProjectorOptions<
 };
 
 export const defaultProcessingMessageProcessingScope = <
-  HandlerContext = never,
+  HandlerContext extends AnyMessageHandlerContext = AnyMessageHandlerContext,
   Result = SingleMessageHandlerResult,
 >(
   handler: (
     context: WithObservabilityScope<HandlerContext>,
   ) => Result | Promise<Result>,
-  partialContext: WithObservabilityScope<Partial<HandlerContext>>,
+  partialContext: WithObservabilityScope<PartialHandlerContext<HandlerContext>>,
 ) =>
   handler({
     ...partialContext,
@@ -422,6 +426,17 @@ const isAppendingMessageStore = (
   typeof (store as AppendingMessageStore | undefined)?.appendToStream ===
   'function';
 
+const appendsThroughItsSession = (
+  context: unknown,
+): context is MessageHandlerContext<
+  Record<never, never>,
+  { messageStore: AppendingMessageStore }
+> =>
+  isAppendingMessageStore(
+    (context as { session?: { messageStore?: unknown } } | undefined)?.session
+      ?.messageStore,
+  );
+
 /**
  * Binds the message store handed to the handler to the scope of the message
  * being handled, so what a handler appends continues the triggering message's
@@ -432,14 +447,11 @@ const withScopedMessageStore = <HandlerContext>(
   context: HandlerContext,
   scope: ObservabilityScope,
 ): HandlerContext => {
-  const connection = (
-    context as { connection?: { messageStore?: unknown } } | undefined
-  )?.connection;
+  if (!appendsThroughItsSession(context)) return context;
 
-  if (!connection || !isAppendingMessageStore(connection.messageStore))
-    return context;
+  const { session } = context;
 
-  const messageStore = new Proxy(connection.messageStore, {
+  const messageStore = new Proxy(session.messageStore, {
     get: (target, property, receiver): unknown => {
       if (property !== 'appendToStream')
         return Reflect.get(target, property, receiver);
@@ -461,7 +473,7 @@ const withScopedMessageStore = <HandlerContext>(
 
   return {
     ...context,
-    connection: { ...connection, messageStore },
+    session: { ...session, messageStore },
   };
 };
 
@@ -509,7 +521,7 @@ const acquireProcessorLock = async <HandlerContext extends DefaultRecord>(
 export const reactor = <
   MessageType extends Message = AnyMessage,
   MessageMetadataType extends AnyReadEventMetadata = AnyReadEventMetadata,
-  HandlerContext extends MessageHandlerContext = MessageHandlerContext,
+  HandlerContext extends AnyMessageHandlerContext = AnyMessageHandlerContext,
   MessagePayloadType extends Message = MessageType,
 >(
   options: ReactorOptions<
@@ -658,7 +670,7 @@ export const reactor = <
   };
 
   const init = async (
-    initOptions: WithObservabilityScope<Partial<HandlerContext>>,
+    initOptions: WithObservabilityScope<PartialHandlerContext<HandlerContext>>,
   ): Promise<void> => {
     if (isInitiated) return;
 
@@ -674,7 +686,7 @@ export const reactor = <
   };
 
   const close = async (
-    closeOptions: WithObservabilityScope<Partial<HandlerContext>>,
+    closeOptions: WithObservabilityScope<PartialHandlerContext<HandlerContext>>,
   ): Promise<void> => {
     // TODO: Align when active is set to false
     // if (!isActive) return;
@@ -708,7 +720,9 @@ export const reactor = <
     canHandle,
     init: async (partialOptions) => {
       partialOptions ??= {};
-      const options: WithObservabilityScope<Partial<HandlerContext>> = {
+      const options: WithObservabilityScope<
+        PartialHandlerContext<HandlerContext>
+      > = {
         ...partialOptions,
         // TODO: Consider adding explicit init scope
         observabilityScope:
@@ -720,11 +734,13 @@ export const reactor = <
       await init(options);
     },
     start: async (
-      partialOptions?: Partial<HandlerContext>,
+      partialOptions?: PartialHandlerContext<HandlerContext>,
     ): Promise<CurrentMessageProcessorPosition | undefined> => {
       partialOptions ??= {};
 
-      const startOptions: WithObservabilityScope<Partial<HandlerContext>> = {
+      const startOptions: WithObservabilityScope<
+        PartialHandlerContext<HandlerContext>
+      > = {
         ...partialOptions,
         // TODO: Consider adding explicit start scope
         observabilityScope:
@@ -847,7 +863,9 @@ export const reactor = <
     },
     close: async (partialOptions) => {
       partialOptions ??= {};
-      const options: WithObservabilityScope<Partial<HandlerContext>> = {
+      const options: WithObservabilityScope<
+        PartialHandlerContext<HandlerContext>
+      > = {
         ...partialOptions,
         // TODO: Consider adding explicit close scope
         observabilityScope:
@@ -863,7 +881,7 @@ export const reactor = <
     whenProcessed,
     handle: async (
       messages: RecordedMessage<MessageType, MessageMetadataType>[],
-      partialContext: Partial<HandlerContext>,
+      partialContext: PartialHandlerContext<HandlerContext>,
     ): Promise<BatchMessageHandlerResult> => {
       if (!isActive) return Promise.resolve();
 
@@ -997,7 +1015,7 @@ export const projector = <
   EventType extends Event = Event,
   EventMetaDataType extends AnyRecordedMessageMetadata =
     AnyRecordedMessageMetadata,
-  HandlerContext extends MessageHandlerContext = MessageHandlerContext,
+  HandlerContext extends AnyMessageHandlerContext = AnyMessageHandlerContext,
   EventPayloadType extends Event = EventType,
 >(
   options: ProjectorOptions<

--- a/src/packages/emmett/src/projections/index.ts
+++ b/src/packages/emmett/src/projections/index.ts
@@ -11,6 +11,7 @@ import type {
   CanHandle,
   DefaultRecord,
   Event,
+  HandlerContextRoot,
   MessageHandlerContext,
 } from '../typing';
 import { arrayUtils } from '../utils';
@@ -18,8 +19,9 @@ import { arrayUtils } from '../utils';
 export type ProjectionHandlingType = 'inline' | 'async';
 
 export type ProjectionHandlerContext<
-  HandlerContext extends DefaultRecord = DefaultRecord,
-> = MessageHandlerContext<HandlerContext>;
+  HandlerContext extends HandlerContextRoot = Record<never, never>,
+  Session extends DefaultRecord = DefaultRecord,
+> = MessageHandlerContext<HandlerContext, Session>;
 
 export type ProjectionHandler<
   EventType extends Event = AnyEvent,

--- a/src/packages/emmett/src/typing/messageHandling.ts
+++ b/src/packages/emmett/src/typing/messageHandling.ts
@@ -1,6 +1,9 @@
 import type { DefaultRecord } from '.';
 import type { EmmettError } from '../errors';
-import type { WithObservabilityScope } from '../observability';
+import type {
+  ObservabilityScope,
+  WithObservabilityScope,
+} from '../observability';
 import type {
   AnyMessage,
   AnyRecordedMessage,
@@ -9,9 +12,37 @@ import type {
   RecordedMessage,
 } from './message';
 
+/**
+ * What a context carries on its own. The session and the observability scope
+ * are added by `MessageHandlerContext`, so a root may not declare either.
+ */
+export type HandlerContextRoot = DefaultRecord & {
+  session?: never;
+  observabilityScope?: never;
+};
+
+/**
+ * What your handler gets for the message it is handling. Whatever it was
+ * handed to talk to the outside lives under `context.session`: a SQL store
+ * puts the connection, the transaction you are inside, the pool and the driver
+ * options there, a document store puts its client there. A processor that
+ * names no session gets one it knows nothing about.
+ */
 export type MessageHandlerContext<
-  HandlerContext extends DefaultRecord = DefaultRecord,
-> = WithObservabilityScope<HandlerContext>;
+  HandlerContext extends HandlerContextRoot = Record<never, never>,
+  Session extends DefaultRecord = DefaultRecord,
+> = WithObservabilityScope<HandlerContext & { session: Session }>;
+
+export type AnyMessageHandlerContext = {
+  session: DefaultRecord;
+  observabilityScope: ObservabilityScope;
+};
+
+export type PartialHandlerContext<Ctx extends AnyMessageHandlerContext> =
+  Partial<Omit<Ctx, 'session' | 'observabilityScope'>> & {
+    session?: Partial<Ctx['session']>;
+    observabilityScope?: ObservabilityScope;
+  };
 
 export type SingleRawMessageHandlerWithoutContext<
   MessageType extends Message = AnyMessage,

--- a/src/packages/emmett/src/workflows/workflowProcessor.ts
+++ b/src/packages/emmett/src/workflows/workflowProcessor.ts
@@ -13,8 +13,8 @@ import type {
   AnyReadEventMetadata,
   AnyRecordedMessageMetadata,
   CanHandle,
-  Event,
   MessageHandlerContext,
+  Event,
   MessageTypeOf,
   RecordedMessage,
 } from '../typing';
@@ -55,11 +55,15 @@ export type WorkflowOptions<
   };
 };
 
-export type WorkflowProcessorContext = MessageHandlerContext<{
-  connection: {
-    messageStore: EventStore;
-  };
-}>;
+/** Append what your workflow produces through `context.session.messageStore`. */
+export type MessageStoreSession = {
+  messageStore: EventStore;
+};
+
+export type WorkflowProcessorContext = MessageHandlerContext<
+  Record<never, never>,
+  MessageStoreSession
+>;
 
 export type WorkflowOutputHandlerResult<Input extends AnyEvent | AnyCommand> =
   | Promise<Input | Input[] | EmmettError | [] | void>
@@ -238,7 +242,7 @@ export const workflowProcessor = <
 
       if (isInput || inputs.includes(messageType)) {
         const result = await handle(
-          context.connection.messageStore,
+          context.session.messageStore,
           message as RecordedMessage<Input, MetaDataType>,
           {
             observability: withOperationScope(context.observabilityScope),
@@ -309,7 +313,7 @@ export const workflowProcessor = <
           },
         }));
 
-        await context.connection.messageStore.appendToStream(
+        await context.session.messageStore.appendToStream(
           streamName,
           inputTaggedMessages as unknown as Event[],
           appendOptionsFromHandledOutput(

--- a/src/packages/emmett/src/workflows/workflowProcessor.unit.spec.ts
+++ b/src/packages/emmett/src/workflows/workflowProcessor.unit.spec.ts
@@ -166,12 +166,12 @@ void describe('Workflow Processor', () => {
       });
 
       await processor.start({
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       // When
       await processor.handle([message], {
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       // Then
@@ -213,11 +213,11 @@ void describe('Workflow Processor', () => {
       });
 
       await processor.start({
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       await processor.handle([externalMessage], {
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       // Then: process the prefixed input: simulates what the consumer delivers
@@ -240,7 +240,7 @@ void describe('Workflow Processor', () => {
       } as unknown as RecordedMessage<InitiateGroupCheckout>;
 
       await processor.handle([prefixedMessage], {
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       // Then
@@ -276,12 +276,12 @@ void describe('Workflow Processor', () => {
       });
 
       await processor.start({
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       // When
       await processor.handle([message], {
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       // Then - no workflow stream should be created
@@ -312,7 +312,7 @@ void describe('Workflow Processor', () => {
 
       // When
       await processor.start({
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       // Then
@@ -335,12 +335,12 @@ void describe('Workflow Processor', () => {
       });
 
       await processor.start({
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       // When
       await processor.close({
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       // Then
@@ -354,12 +354,12 @@ void describe('Workflow Processor', () => {
 
       // When
       await processor.start({
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
       assertEqual(processor.isActive, true);
 
       await processor.close({
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       // Then
@@ -382,7 +382,7 @@ void describe('Workflow Processor', () => {
       });
 
       await processor.start({
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
       assertEqual(processor.isActive, true);
 
@@ -401,7 +401,7 @@ void describe('Workflow Processor', () => {
       const processor = workflowProcessor(workflowOptions);
 
       await processor.start({
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
       assertEqual(processor.isActive, true);
 
@@ -424,12 +424,12 @@ void describe('Workflow Processor', () => {
       } as unknown as InitiateGroupCheckout);
 
       await processor.start({
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       // When
       await processor.handle([unknownMessage], {
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
       // Then - reactor filtered the message before eachMessage; no assertion needed beyond no crash
     });
@@ -459,12 +459,12 @@ void describe('Workflow Processor', () => {
       } as unknown as InitiateGroupCheckout);
 
       await processor.start({
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       // When
       await processor.handle([nonMatchingMessage, matchingMessage], {
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       // Then - only the matching message should be processed
@@ -537,11 +537,11 @@ void describe('Workflow Processor', () => {
         streamName,
       );
 
-      await processor.start({ connection: { messageStore: eventStore } });
+      await processor.start({ session: { messageStore: eventStore } });
       // TODO: Fix this when combined message metadata doesn't return `now` and other metadata
 
       await processor.handle([outputMessage], {
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       // Then
@@ -617,11 +617,11 @@ void describe('Workflow Processor', () => {
         },
       } as unknown as RecordedMessage<GroupCheckoutInput>;
 
-      await processor.start({ connection: { messageStore: eventStore } });
+      await processor.start({ session: { messageStore: eventStore } });
       // TODO: Fix this when combined message metadata doesn't return `now` and other metadata
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
       await processor.handle([inputMessage as any], {
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       // Router must not have been called: metadata.input===true routes to handler
@@ -668,11 +668,11 @@ void describe('Workflow Processor', () => {
         streamName,
       );
 
-      await processor.start({ connection: { messageStore: eventStore } });
+      await processor.start({ session: { messageStore: eventStore } });
       // TODO: Fix this when combined message metadata doesn't return `now` and other metadata
 
       await processor.handle([outputMessage], {
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       // Then - the response is appended to the workflow stream
@@ -727,9 +727,9 @@ void describe('Workflow Processor', () => {
         },
       } as unknown as RecordedMessage<GroupCheckoutInput>;
 
-      await processor.start({ connection: { messageStore: eventStore } });
+      await processor.start({ session: { messageStore: eventStore } });
       await processor.handle([outputMessage], {
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       const { events } = await eventStore.readStream(streamName);
@@ -766,11 +766,11 @@ void describe('Workflow Processor', () => {
         streamName,
       );
 
-      await processor.start({ connection: { messageStore: eventStore } });
+      await processor.start({ session: { messageStore: eventStore } });
       // TODO: Fix this when combined message metadata doesn't return `now` and other metadata
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
       await processor.handle([outputMessage as any], {
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       // Stream must not have been created
@@ -802,11 +802,11 @@ void describe('Workflow Processor', () => {
         streamName,
       );
 
-      await processor.start({ connection: { messageStore: eventStore } });
+      await processor.start({ session: { messageStore: eventStore } });
       // TODO: Fix this when combined message metadata doesn't return `now` and other metadata
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
       const result = await processor.handle([outputMessage as any], {
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       assertMatches(result, { type: 'STOP' });
@@ -871,7 +871,7 @@ void describe('Workflow Processor', () => {
         },
       ] as unknown as Event[]);
 
-      await processor.start({ connection: { messageStore: eventStore } });
+      await processor.start({ session: { messageStore: eventStore } });
 
       // Step 1: output handler intercepts CheckOut and appends GuestCheckedOut to the stream
       const checkOutOutput = recordedOutput<CheckOut>(
@@ -879,7 +879,7 @@ void describe('Workflow Processor', () => {
         streamName,
       );
       await processor.handle([checkOutOutput], {
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       let { events } = await eventStore.readStream(streamName);
@@ -891,7 +891,7 @@ void describe('Workflow Processor', () => {
         [
           appendedGuestCheckedOut as unknown as RecordedMessage<GroupCheckoutInput>,
         ],
-        { connection: { messageStore: eventStore } },
+        { session: { messageStore: eventStore } },
       );
 
       ({ events } = await eventStore.readStream(streamName));
@@ -906,7 +906,7 @@ void describe('Workflow Processor', () => {
         [
           prefixedGuestCheckedOut as unknown as RecordedMessage<GroupCheckoutInput>,
         ],
-        { connection: { messageStore: eventStore } },
+        { session: { messageStore: eventStore } },
       );
 
       // Then
@@ -948,11 +948,11 @@ void describe('Workflow Processor', () => {
         wrongStream,
       );
 
-      await processor.start({ connection: { messageStore: eventStore } });
+      await processor.start({ session: { messageStore: eventStore } });
       // TODO: Fix this when combined message metadata doesn't return `now` and other metadata
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
       await processor.handle([outputMessage as any], {
-        connection: { messageStore: eventStore },
+        session: { messageStore: eventStore },
       });
 
       // Response must land on the workflow stream, not the wrong stream


### PR DESCRIPTION
This aligns the connection setup and passes through the message handler context.

**BREAKING:** Now, all event stores have a "session" property. For PostgreSQL and SQLite, that means if you used `connection`, you should now use the `session` name. Also MongoDB and ESDB clients were nested underneath.

Reusing the pool changed for SQL-based stores to create their own pool when the explicit setup was done. For PostgreSQL, this is fine, as Dumbo is caching pools based on the connection string internally. For SQLite, that may require adding caching, but maybe not.